### PR TITLE
[codex] Adiciona wrapper protegido para o cron do Sandcastle

### DIFF
--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -112,8 +112,10 @@ Mostra quais issues seriam enviadas ao agente sem executar sandbox, sem criar br
   .env.example             ← modelo de configuração
   Dockerfile               ← imagem usada pelo sandbox
   execucao-sandcastle.ts   ← integração com Sandcastle/Codex
-  github-gh.ts             ← leitura e edição de issues via gh
-  main.ts                  ← entrada principal do cron
+  run.ts                   ← entrada principal acionada por `pnpm sandcastle:run`
+  runner.ts                ← orquestra fila, validações e execução dos adaptadores
+  github/
+    issue.ts               ← leitura e edição de issues e labels via gh
   prompts/
     agente.md              ← prompt base do agente
   rodar-cron-com-lock.sh   ← wrapper com lock, timeout e validações

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -1,6 +1,6 @@
 # Orquestração do Sandcastle
 
-> Como o Hermes orquestra o Sandcastle para implementar issues e revisões do FDP.
+> Estado atual do fluxo automatizado do Sandcastle no FDP.
 
 ---
 
@@ -9,19 +9,28 @@
 | Entidade       | Função                                                                                             |
 | -------------- | -------------------------------------------------------------------------------------------------- |
 | **Vinícius**   | Dono do produto. Revisa PRs direto no GitHub.                                                      |
-| **Hermes**     | Orquestrador. Prepara ambiente, dispara o cron, monitora resultado e reporta ao Vinícius.          |
+| **Hermes**     | Papel ainda em definição. O workflow oficial do Hermes será documentado no futuro.                 |
 | **Sandcastle** | Executor do agente. Sobe sandbox Docker, cria branch isolada e roda o Codex com prompt controlado. |
 | **Codex**      | Coding agent que implementa código, cria commits e atualiza o branch da issue.                     |
 | **GitHub**     | Repo, issues, PRs e labels. Fonte da verdade.                                                      |
 
 ---
 
-## Fluxo Real no Repositório
+## Escopo Deste Documento
 
-Hoje o fluxo automatizado usa a pasta `.sandcastle/` e os scripts do `package.json`.
+- Este documento descreve apenas o fluxo atual do Sandcastle.
+- O papel do Hermes no processo ainda não está fechado e não deve ser inferido a partir deste arquivo.
+- Sempre que houver conflito entre este documento e a implementação em `.sandcastle/`, a implementação atual prevalece até a documentação ser atualizada.
+
+---
+
+## Fluxo Atual no Repositório
+
+Hoje o fluxo automatizado usa a pasta `.sandcastle/`, os scripts do `package.json` e um cron externo executado a cada **5 minutos**.
 
 ### Seleção de issues
 
+- A cada 5 minutos, o cron dispara uma nova rodada do Sandcastle.
 - O cron busca issues abertas com a label `sandcastle:run`.
 - Antes da execução, adiciona `sandcastle:running` e remove `sandcastle:run`.
 - Em cada rodada, processa no máximo **3 issues**, priorizando as mais antigas.
@@ -117,22 +126,21 @@ Mostra quais issues seriam enviadas ao agente sem executar sandbox, sem criar br
 ```mermaid
 sequenceDiagram
     participant V as Vinícius
-    participant H as Hermes
     participant GH as GitHub
+    participant X as Cron Externo
     participant S as Sandcastle
     participant C as Codex
 
     V->>GH: Aplica label sandcastle:run na issue
-    H->>H: Roda pnpm sandcastle:cron:lock
-    H->>GH: Lista issues abertas com sandcastle:run
-    H->>GH: Remove sandcastle:run e adiciona sandcastle:running
-    H->>S: Executa issue em sandbox Docker
+    X->>S: A cada 5 min roda pnpm sandcastle:cron:lock
+    S->>GH: Lista issues abertas com sandcastle:run
+    S->>GH: Remove sandcastle:run e adiciona sandcastle:running
+    S->>S: Prepara sandbox Docker e contexto
     S->>C: Entrega prompt + contexto da issue
     Note over C: Lê AGENTS.md<br/>Lê ARQUITETURA.md<br/>Implementa<br/>Commita no branch da issue
     C->>GH: Push dos commits e atualização do branch
-    S->>H: Retorna branch, commits e log
-    H->>GH: Remove label sandcastle:running
-    H->>V: Reporta resultado da execução
+    S->>GH: Remove label sandcastle:running
+    S->>X: Retorna branch, commits e log
 ```
 
 ---
@@ -158,6 +166,6 @@ sequenceDiagram
 
 ## Próximos Passos
 
-1. Separar este documento em runbook operacional e decisões históricas, se a complexidade crescer.
+1. Definir futuramente o papel do Hermes no processo e documentá-lo sem misturar com o fluxo atual do Sandcastle.
 2. Documentar a política de criação de PR pelo agente quando esse fluxo estiver estável.
 3. Adicionar cleanup explícito de branches e estratégia de retry, se isso virar necessidade real.

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -1,90 +1,113 @@
-# Orquestração do Pi CLI
+# Orquestração do Sandcastle
 
-> Como o Hermes orquestra o Pi CLI para implementar issues e revisões do FDP.
+> Como o Hermes orquestra o Sandcastle para implementar issues e revisões do FDP.
 
 ---
 
 ## Visão Geral
 
-| Entidade | Função |
-|----------|--------|
-| **Vinícius** | Dono do produto. Revisa PRs direto no GitHub. |
-| **Hermes** | Orquestrador. Prepara workspace, dispara Pi, monitora progresso, reporta ao Vinícius. |
-| **Pi CLI** | Coding agent. Implementa código, abre PRs, aplica revisões. Autônomo. |
-| **GitHub** | Repo, issues, PRs, CI. Fonte da verdade. |
+| Entidade       | Função                                                                                             |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| **Vinícius**   | Dono do produto. Revisa PRs direto no GitHub.                                                      |
+| **Hermes**     | Orquestrador. Prepara ambiente, dispara o cron, monitora resultado e reporta ao Vinícius.          |
+| **Sandcastle** | Executor do agente. Sobe sandbox Docker, cria branch isolada e roda o Codex com prompt controlado. |
+| **Codex**      | Coding agent que implementa código, cria commits e atualiza o branch da issue.                     |
+| **GitHub**     | Repo, issues, PRs e labels. Fonte da verdade.                                                      |
 
 ---
 
-## Comandos do Pi
+## Fluxo Real no Repositório
 
-O Pi está instalado via nvm e configurado com **kimi2.5**.
+Hoje o fluxo automatizado usa a pasta `.sandcastle/` e os scripts do `package.json`.
 
-### 1. Implementar Issue
+### Seleção de issues
 
-**Método preferido (prompt inline):**
+- O cron busca issues abertas com a label `sandcastle:run`.
+- Antes da execução, adiciona `sandcastle:running` e remove `sandcastle:run`.
+- Em cada rodada, processa no máximo **3 issues**, priorizando as mais antigas.
 
-```bash
-cd <worktree>
-export PATH="/home/agente/.nvm/versions/node/v24.15.0/bin:$PATH"
-pi --print --no-session "Leia AGENTS.md, ARQUITETURA.md, e execute 'gh issue view <id>'. Depois implemente a issue #<id>. Commit e abra PR."
-```
+### Branch de execução
 
-**Método alternativo (skill — use apenas se já testou e funcionou):**
+- Cada issue roda em um branch isolado no formato `sandcastle-issue-<id>`.
+- O branch é criado pelo próprio Sandcastle via `branchStrategy`.
 
-```bash
-cd <worktree>
-export PATH="/home/agente/.nvm/versions/node/v24.15.0/bin:$PATH"
-pi --print --no-session --skill .pi/skills/fdp-issue "/skill:fdp-issue <id>"
-```
+### Prompt do agente
 
-> **Atenção:** Skills grandes (>3KB, >50 linhas) podem travar silenciosamente. Se travar após 3-5 min com log vazio, use o método de prompt inline.
-
-O Pi:
-1. Lê `AGENTS.md` (automático, está no diretório).
-2. Busca a issue no GitHub.
-3. Implementa seguindo arquitetura e regras.
-4. Roda testes.
-5. Commita e abre PR via `gh pr create`.
-
-### 2. Revisar PR
-
-```bash
-cd <worktree-original-ou-novo>
-export PATH="/home/agente/.nvm/versions/node/v24.15.0/bin:$PATH"
-pi --print --no-session "Leia os comentários do PR #<pr-id> no GitHub. Aplique as revisões necessárias e push um novo commit no mesmo PR."
-```
+- O prompt base fica em `.sandcastle/prompts/agente.md`.
+- O cron injeta no prompt:
+  - contexto da issue
+  - labels atuais
+  - até 5 comentários recentes
 
 ---
 
-## Gerenciamento de Workspace (Hermes)
+## Comandos
 
-```
-.pi/
-  worktrees/
-    issue-5/         ← worktree isolado para issue #5
-  logs/
-    issue-5.log      ← stdout do Pi
-  pids/
-    issue-5.pid      ← PID do processo Pi
-```
-
-### Script de Orquestração (Hermes)
+### 1. Build da imagem Docker
 
 ```bash
-# 1. Criar branch e worktree
-BRANCH="feat/issue-$ISSUE_ID"
-git checkout -b "$BRANCH"
-git worktree add .pi/worktrees/issue-$ISSUE_ID "$BRANCH"
+pnpm sandcastle:build
+```
 
-# 2. Disparar Pi em background
-cd .pi/worktrees/issue-$ISSUE_ID
-pi -p --skill .pi/skills/fdp-issue "/skill:fdp-issue $ISSUE_ID" \
-   > ../../logs/issue-$ISSUE_ID.log 2>&1 &
-echo $! > ../../pids/issue-$ISSUE_ID.pid
+Cria a imagem `sandcastle:fdp-online`, exigida antes de qualquer execução do cron.
 
-# 3. Monitorar
-# Hermes verifica periodicamente se o PID ainda existe.
-# Quando o processo morre, extrai o resultado do log.
+### 2. Rodar o cron diretamente
+
+```bash
+pnpm sandcastle:cron
+```
+
+Esse comando:
+
+1. Carrega `.sandcastle/.env`, se existir.
+2. Valida `gh auth status`.
+3. Valida autenticação do Codex (`OPENAI_API_KEY` ou `~/.codex/auth.json`).
+4. Valida Docker e a imagem `sandcastle:fdp-online`.
+5. Busca issues candidatas no GitHub e executa o agente.
+
+### 3. Rodar o cron com lock e branch protegida
+
+```bash
+pnpm sandcastle:cron:lock
+```
+
+Esse wrapper:
+
+1. Exige branch atual `main` por padrão.
+2. Exige árvore git limpa.
+3. Faz `git fetch` + `git pull --ff-only` da branch base.
+4. Executa o cron com `flock`.
+5. Aplica timeout de `30m`.
+
+Variáveis suportadas:
+
+- `SANDCASTLE_LOCK`: caminho do arquivo de lock. Padrão: `/tmp/fdp-sandcastle.lock`
+- `SANDCASTLE_TIMEOUT`: timeout total da execução. Padrão: `30m`
+- `SANDCASTLE_BRANCH_BASE`: branch obrigatória para iniciar o cron. Padrão: `main`
+
+### 4. Rodar em dry run
+
+```bash
+pnpm sandcastle:cron -- --dry-run
+```
+
+Mostra quais issues seriam enviadas ao agente sem executar sandbox, sem criar branch e sem alterar labels.
+
+---
+
+## Estrutura Atual
+
+```text
+.sandcastle/
+  .env                     ← variáveis locais do cron
+  .env.example             ← modelo de configuração
+  Dockerfile               ← imagem usada pelo sandbox
+  execucao-sandcastle.ts   ← integração com Sandcastle/Codex
+  github-gh.ts             ← leitura e edição de issues via gh
+  main.ts                  ← entrada principal do cron
+  prompts/
+    agente.md              ← prompt base do agente
+  rodar-cron-com-lock.sh   ← wrapper com lock, timeout e validações
 ```
 
 ---
@@ -95,82 +118,46 @@ echo $! > ../../pids/issue-$ISSUE_ID.pid
 sequenceDiagram
     participant V as Vinícius
     participant H as Hermes
-    participant Pi as Pi CLI
     participant GH as GitHub
+    participant S as Sandcastle
+    participant C as Codex
 
-    V->>H: "Vamos implementar issue #5"
-    H->>H: Cria worktree + branch
-    H->>Pi: pi -p --skill .pi/skills/fdp-issue "/skill:fdp-issue 5"
-    Note over Pi: Lê AGENTS.md<br/>Busca issue #5<br/>Implementa<br/>Roda testes<br/>Abre PR
-    Pi->>GH: Push + PR criado
-    H->>V: "PR #12 aberto para issue #5"
-    V->>GH: Revisa e comenta
-    V->>H: "Revisão feita no PR #12"
-    H->>H: Cria worktree da revisão
-    H->>Pi: pi -p --skill .pi/skills/fdp-revisao "/skill:fdp-revisao 12"
-    Note over Pi: Lê comentário<br/>Ajusta código<br/>Push novo commit
-    Pi->>GH: Novo commit no PR #12
-    H->>V: "Ajustes aplicados no PR #12"
+    V->>GH: Aplica label sandcastle:run na issue
+    H->>H: Roda pnpm sandcastle:cron:lock
+    H->>GH: Lista issues abertas com sandcastle:run
+    H->>GH: Remove sandcastle:run e adiciona sandcastle:running
+    H->>S: Executa issue em sandbox Docker
+    S->>C: Entrega prompt + contexto da issue
+    Note over C: Lê AGENTS.md<br/>Lê ARQUITETURA.md<br/>Implementa<br/>Commita no branch da issue
+    C->>GH: Push dos commits e atualização do branch
+    S->>H: Retorna branch, commits e log
+    H->>GH: Remove label sandcastle:running
+    H->>V: Reporta resultado da execução
 ```
 
 ---
 
-## Skills do Pi
+## Pré-requisitos
 
-As skills ficam em `.pi/skills/` dentro do repo:
-
-```
-.pi/skills/
-  fdp-issue/
-    SKILL.md        ← Instruções para implementar issues
-  fdp-revisao/
-    SKILL.md        ← Instruções para aplicar revisões
-```
+- `gh` instalado e autenticado.
+- `codex login` feito, ou `OPENAI_API_KEY` definido em `.sandcastle/.env`.
+- Docker funcional.
+- Imagem `sandcastle:fdp-online` criada com `pnpm sandcastle:build`.
 
 ---
 
-## Aprendizados Práticos (atualizado em 2026-04-24)
+## Notas Operacionais
 
-### 1. Skills grandes travam silenciosamente
-
-**Descoberto na issue #2:** A skill `fdp-issue` (5.189 bytes / 106 linhas) travou o Pi em todas as tentativas com `--skill` + `/skill:`, mesmo usando corretamente ambos. O processo existia mas nunca produzia output (log em 0 bytes).
-
-**Solução:** Prompt inline com instruções completas no lugar de carregar a skill.
-
-**Regra:**
-- Skills pequenas (< 3KB): pode usar `--skill` + `/skill:`
-- Skills grandes (> 3KB): use prompt inline direto
-
-### 2. Foreground é mais confiável que background neste ambiente
-
-Execuções em background (`&`, `nohup`, `terminal(background=true)`) frequentemente perdem o PATH do nvm ou falham no redirecionamento de logs. O modo foreground com `timeout=300` ou `timeout=600` é o mais confiável.
-
-**Sempre use:**
-```bash
-export PATH="/home/agente/.nvm/versions/node/v24.15.0/bin:$PATH"
-cd .pi/worktrees/issue-N
-pi --print --no-session "prompt completo aqui"
-```
-
-### 3. Sempre verifique se o worktree tem os arquivos
-
-Depois de `git worktree add`, confirme que `src/`, `tests/`, `package.json` existem no filesystem. O `git ls-tree` pode mostrar arquivos que o worktree não tem se houve erro na criação.
-
----
-
-## Notas
-
-- O Pi **não sabe que o Hermes existe**. Ele recebe um prompt e executa.
-- O Hermes **não acompanha em tempo real**. Só verifica logs/PIDs quando perguntado.
-- Vinícius **revisa PRs direto no GitHub**, sem intermediário.
-- Se o Pi travar ou der erro, o log em `.pi/logs/` é a fonte de debug.
-- **Skills grandes (>3KB) devem ser usadas como prompt inline**, não via `--skill`.
+- O cron escreve o resultado no stdout e pode retornar `logFilePath` ao final da execução.
+- O sandbox injeta `GH_TOKEN` e `GITHUB_TOKEN` se `GITHUB_TOKEN` estiver presente no ambiente host.
+- Dependências são instaladas no sandbox com `pnpm install --frozen-lockfile --prefer-offline`.
+- Se `~/.docker/config.json` usar `credsStore: "desktop.exe"` em WSL/Linux, a execução é bloqueada preventivamente.
+- Se não houver issues com `sandcastle:run`, o cron encerra sem erro.
 
 ---
 
 ## Próximos Passos
 
-1. ~~Criar `AGENTS.md` na raiz do projeto.~~ ✅ Feito.
-2. ~~Criar skills `fdp-issue` e `fdp-revisao`.~~ ✅ Feitas.
-3. ~~Testar fluxo end-to-end com uma issue simples.~~ ✅ Issue #1 (Fase 0) implementada e revisada.
-4. Evoluir o `ORQUESTRACAO.md` conforme novos aprendizados (ex: redirecionamento de logs, worktree cleanup, timeouts).
+1. Separar este documento em runbook operacional e decisões históricas, se a complexidade crescer.
+2. Documentar a política de criação de PR pelo agente quando esse fluxo estiver estável.
+3. Adicionar cleanup explícito de branches e estratégia de retry, se isso virar necessidade real.


### PR DESCRIPTION
## O que mudou
Adiciona um wrapper para executar o cron do Sandcastle com proteções operacionais básicas e atualiza a documentação para refletir esse fluxo.

## Mudanças principais
- adiciona `.sandcastle/rodar-cron-com-lock.sh`
- expõe o script via `pnpm sandcastle:cron:lock`
- atualiza `ORQUESTRACAO.md` para descrever o fluxo real baseado em `.sandcastle/`

## Por que mudou
Rodar o cron diretamente deixa algumas responsabilidades soltas no operador. O wrapper centraliza validações mínimas antes da execução:
- branch base esperada
- árvore git limpa
- atualização da branch base com `git pull --ff-only`
- lock com `flock`
- timeout total da execução

A documentação foi ajustada no mesmo PR para não deixar drift entre comportamento real e runbook.

## Impacto
O fluxo operacional passa a ter um ponto de entrada mais seguro:
- `pnpm sandcastle:cron` continua existindo para execução direta
- `pnpm sandcastle:cron:lock` vira o comando recomendado para uso operacional

## Validação
- `pnpm exec prettier --check ORQUESTRACAO.md`
- `pnpm typecheck`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated orchestration workflow documentation to reflect new automated system procedures.
  * Added operational guidelines, new available commands, and updated infrastructure requirements.
  * Refined configuration structure and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->