### PR TITLE
feat: preparar imagem do sandcastle para suportar pi

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -21,11 +21,11 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && rm -rf /var/lib/apt/lists/*
 
 RUN usermod -d /home/agent -m -l agent node
-RUN npm install -g @openai/codex
+RUN npm install -g @openai/codex @mariozechner/pi-coding-agent
 RUN npm install -g playwright@1.59.1
 RUN playwright install --with-deps chromium
 RUN corepack enable
-RUN mkdir -p /home/agent/.codex && chown -R 1000:1000 /home/agent/.codex
+RUN mkdir -p /home/agent/.codex /home/agent/.pi/agent && chown -R 1000:1000 /home/agent/.codex /home/agent/.pi
 RUN mkdir -p /home/agent/.pnpm-store /home/agent/.local/share/pnpm \
   && chown -R 1000:1000 /home/agent/.pnpm-store /home/agent/.local
 RUN mkdir -p /ms-playwright && chown -R 1000:1000 /ms-playwright

--- a/.sandcastle/execucao-sandcastle.ts
+++ b/.sandcastle/execucao-sandcastle.ts
@@ -74,6 +74,7 @@ function montarEnvSandbox(): Record<string, string> {
   return {
     ...(process.env.GITHUB_TOKEN ? { GH_TOKEN: process.env.GITHUB_TOKEN } : {}),
     ...(process.env.GITHUB_TOKEN ? { GITHUB_TOKEN: process.env.GITHUB_TOKEN } : {}),
+    ...(process.env.OPENCODE_API_KEY ? { OPENCODE_API_KEY: process.env.OPENCODE_API_KEY } : {}),
   };
 }
 


### PR DESCRIPTION
Closes #36

## Resumo
- instala o Pi na imagem `sandcastle:fdp-online` sem alterar o nome da imagem nem o comando de build
- prepara o diretório `/home/agent/.pi/agent` no sandbox
- adiciona `OPENCODE_API_KEY` à allowlist mínima de segredos exposta ao sandbox

## Validação
- `pnpm typecheck`
- `pnpm lint`
- `pnpm sandcastle:build`
- `docker run ... which codex && which pi`
- `docker run ... pi -p --model opencode-go/qwen3.6-plus ...` → `hello world`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build environment configuration with additional development tools and dependencies.
  * Enhanced sandbox environment setup with support for additional authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->