### PR TITLE
fix: silenciar logs do cron sandcastle

### DIFF
--- a/.sandcastle/rodar-cron-com-lock.sh
+++ b/.sandcastle/rodar-cron-com-lock.sh
@@ -37,8 +37,15 @@ garantir_arvore_limpa() {
 }
 
 atualizar_branch_base() {
-  git fetch origin "${BRANCH_BASE}"
-  git pull --ff-only origin "${BRANCH_BASE}"
+  local referencia_local referencia_remota
+
+  git fetch --quiet origin "${BRANCH_BASE}"
+  referencia_local="$(git rev-parse "${BRANCH_BASE}")"
+  referencia_remota="$(git rev-parse "origin/${BRANCH_BASE}")"
+
+  if [[ "${referencia_local}" != "${referencia_remota}" ]]; then
+    git pull --ff-only origin "${BRANCH_BASE}"
+  fi
 }
 
 adquirir_lock() {

--- a/.sandcastle/runner.ts
+++ b/.sandcastle/runner.ts
@@ -51,7 +51,7 @@ export async function executarRunner(opcoes: OpcoesRunner): Promise<void> {
   const fila = await montarFila(opcoes.adaptadores, opcoes.limite ?? LIMITE_ITENS_POR_RODADA);
 
   if (fila.length === 0) {
-    console.log('Nenhum item elegivel para o Sandcastle.');
+    console.log('OK');
     return;
   }
 
@@ -93,7 +93,6 @@ async function processarEntrada(entrada: EntradaFila, dryRun: boolean): Promise<
   }
 
   if (dryRun) {
-    console.log(entrada.adaptador.formatarDryRun(item, contexto));
     return;
   }
 


### PR DESCRIPTION
## Resumo
- silencia o `git fetch` no cron com `--quiet`
- só executa `git pull --ff-only` quando `origin/main` está à frente da `main` local
- faz o runner imprimir apenas `OK` quando a fila está vazia e silencia o `--dry-run` para itens elegíveis

Closes #45