### PR TITLE
fix: avoid overlapping Sandcastle env keys

### DIFF
--- a/.sandcastle/env-sandcastle.ts
+++ b/.sandcastle/env-sandcastle.ts
@@ -1,0 +1,13 @@
+export function montarEnvAgente(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  return {
+    ...(env.OPENAI_API_KEY ? { OPENAI_API_KEY: env.OPENAI_API_KEY } : {}),
+    ...(env.OPENCODE_API_KEY ? { OPENCODE_API_KEY: env.OPENCODE_API_KEY } : {}),
+  };
+}
+
+export function montarEnvSandbox(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  return {
+    ...(env.GITHUB_TOKEN ? { GH_TOKEN: env.GITHUB_TOKEN } : {}),
+    ...(env.GITHUB_TOKEN ? { GITHUB_TOKEN: env.GITHUB_TOKEN } : {}),
+  };
+}

--- a/.sandcastle/execucao-sandcastle.ts
+++ b/.sandcastle/execucao-sandcastle.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { codex, pi, run, type AgentProvider, type RunResult } from '@ai-hero/sandcastle';
 import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
 import { lerConfiguracaoAgente } from './configuracao-agente';
+import { montarEnvAgente, montarEnvSandbox } from './env-sandcastle';
 
 const NOME_IMAGEM_SANDCASTLE = 'sandcastle:fdp-online';
 const CAMINHO_AUTH_CODEX = `${homedir()}/.codex/auth.json`;
@@ -80,21 +81,6 @@ function montarAgente(configuracao: ReturnType<typeof lerConfiguracaoAgente>): A
 
 function montarNomeExecucao(branch: string): string {
   return `sandcastle-${branch}-${String(Date.now())}`;
-}
-
-function montarEnvAgente(): Record<string, string> {
-  return {
-    ...(process.env.OPENAI_API_KEY ? { OPENAI_API_KEY: process.env.OPENAI_API_KEY } : {}),
-    ...(process.env.OPENCODE_API_KEY ? { OPENCODE_API_KEY: process.env.OPENCODE_API_KEY } : {}),
-  };
-}
-
-function montarEnvSandbox(): Record<string, string> {
-  return {
-    ...(process.env.GITHUB_TOKEN ? { GH_TOKEN: process.env.GITHUB_TOKEN } : {}),
-    ...(process.env.GITHUB_TOKEN ? { GITHUB_TOKEN: process.env.GITHUB_TOKEN } : {}),
-    ...(process.env.OPENCODE_API_KEY ? { OPENCODE_API_KEY: process.env.OPENCODE_API_KEY } : {}),
-  };
 }
 
 function montarHooksSandbox(): {


### PR DESCRIPTION
## Resumo
- separa a montagem de env do agente e do sandbox
- remove OPENCODE_API_KEY do env do sandbox para evitar conflito com o provider do agente

## Validação
- pnpm exec tsc --noEmit -p .sandcastle/tsconfig.json
- pre-push: pnpm typecheck && pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized environment variable configuration for improved code structure and maintainability. Core functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->