### PR TITLE
fix: corrige modelo padrão do Pi no cron

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -4,3 +4,5 @@ SANDCASTLE_AGENT=codex
 OPENAI_API_KEY=
 # Obrigatoria quando SANDCASTLE_AGENT=pi
 OPENCODE_API_KEY=
+# Opcional: modelo passado para `pi --model`. Use `pi --list-models` para alternativas.
+SANDCASTLE_PI_MODEL=opencode-go/mimo-v2-pro

--- a/.sandcastle/configuracao-agente.ts
+++ b/.sandcastle/configuracao-agente.ts
@@ -1,8 +1,9 @@
 export const AGENTES_SUPORTADOS = ['codex', 'pi'] as const;
 export const ESFORCO_CODEX_PADRAO = 'low';
 export const MODELO_CODEX_PADRAO = 'gpt-5.4';
-export const MODELO_PI_PADRAO = 'opencode-go';
+export const MODELO_PI_PADRAO = 'opencode-go/mimo-v2-pro';
 const NOME_VARIAVEL_AGENTE = 'SANDCASTLE_AGENT';
+const NOME_VARIAVEL_MODELO_PI = 'SANDCASTLE_PI_MODEL';
 
 export type AgenteSandcastle = (typeof AGENTES_SUPORTADOS)[number];
 
@@ -28,7 +29,7 @@ export function lerConfiguracaoAgente(env = process.env): ConfiguracaoAgente {
   if (agente === 'pi') {
     return {
       agente,
-      modelo: MODELO_PI_PADRAO,
+      modelo: lerModeloPi(env),
     };
   }
 
@@ -37,6 +38,10 @@ export function lerConfiguracaoAgente(env = process.env): ConfiguracaoAgente {
     modelo: MODELO_CODEX_PADRAO,
     esforco: ESFORCO_CODEX_PADRAO,
   };
+}
+
+function lerModeloPi(env: NodeJS.ProcessEnv): string {
+  return env[NOME_VARIAVEL_MODELO_PI]?.trim() || MODELO_PI_PADRAO;
 }
 
 function lerAgente(env: NodeJS.ProcessEnv): AgenteSandcastle {

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -79,6 +79,7 @@ Variáveis suportadas no cron:
 - `SANDCASTLE_AGENT`: agente global da rodada. Valores suportados: `codex` e `pi`. Padrão: `codex`
 - `OPENAI_API_KEY`: opcional para `codex` quando `codex login` já foi feito no host
 - `OPENCODE_API_KEY`: obrigatória para `pi`
+- `SANDCASTLE_PI_MODEL`: opcional para `pi`; padrão `opencode-go/mimo-v2-pro`. Deve ser um modelo válido do `pi --list-models`.
 
 ### 3. Rodar o cron com lock e branch protegida
 


### PR DESCRIPTION
## Resumo
- troca o modelo padrão do Pi de `opencode-go` para `opencode-go/mimo-v2-pro`
- permite override via `SANDCASTLE_PI_MODEL`
- documenta a variável no `.env.example` e na orquestração

## Validação
- `pnpm typecheck`
- `pnpm test`