### PR TITLE
feat: permitir override de modelo e esforço do Codex por ambiente

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,5 +1,9 @@
 GITHUB_TOKEN=
 SANDCASTLE_AGENT=codex
+# Override opcional do modelo do Codex (padrao: gpt-5.4)
+SANDCASTLE_CODEX_MODEL=
+# Override opcional do esforço de raciocínio: low | medium | high | xhigh (padrao: low)
+SANDCASTLE_CODEX_EFFORT=
 # Opcional quando o Codex estiver autenticado com ChatGPT via `codex login`
 OPENAI_API_KEY=
 # Obrigatoria quando SANDCASTLE_AGENT=pi

--- a/.sandcastle/configuracao-agente.test.ts
+++ b/.sandcastle/configuracao-agente.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  lerConfiguracaoAgente,
+  MODELO_CODEX_PADRAO,
+  ESFORCO_CODEX_PADRAO,
+  ESFORCOS_CODEX_SUPORTADOS,
+} from './configuracao-agente';
+
+describe('agente padrao', () => {
+  it('retorna codex quando SANDCASTLE_AGENT nao esta definido', () => {
+    const config = lerConfiguracaoAgente({});
+
+    expect(config.agente).toBe('codex');
+  });
+
+  it('lanca erro para agente invalido', () => {
+    expect(() => lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'invalido' })).toThrow(
+      /Valor invalido para SANDCASTLE_AGENT/,
+    );
+  });
+});
+
+describe('modelo do Codex', () => {
+  it('usa modelo padrao quando override nao esta definido', () => {
+    const config = lerConfiguracaoAgente({});
+
+    expect(config.agente).toBe('codex');
+    if (config.agente === 'codex') {
+      expect(config.modelo).toBe(MODELO_CODEX_PADRAO);
+    }
+  });
+
+  it('usa override quando SANDCASTLE_CODEX_MODEL esta definido', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_CODEX_MODEL: 'gpt-4o' });
+
+    expect(config.agente).toBe('codex');
+    if (config.agente === 'codex') {
+      expect(config.modelo).toBe('gpt-4o');
+    }
+  });
+
+  it('ignora override quando agente e pi', () => {
+    const config = lerConfiguracaoAgente({
+      SANDCASTLE_AGENT: 'pi',
+      SANDCASTLE_CODEX_MODEL: 'gpt-4o',
+    });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
+      expect(config.modelo).not.toBe('gpt-4o');
+    }
+  });
+});
+
+describe('esforco do Codex', () => {
+  it('usa esforco padrao quando override nao esta definido', () => {
+    const config = lerConfiguracaoAgente({});
+
+    expect(config.agente).toBe('codex');
+    if (config.agente === 'codex') {
+      expect(config.esforco).toBe(ESFORCO_CODEX_PADRAO);
+    }
+  });
+
+  it.each(ESFORCOS_CODEX_SUPORTADOS)('aceita esforco valido: %s', (esforco) => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_CODEX_EFFORT: esforco });
+
+    expect(config.agente).toBe('codex');
+    if (config.agente === 'codex') {
+      expect(config.esforco).toBe(esforco);
+    }
+  });
+
+  it('lanca erro para esforco invalido', () => {
+    expect(() => lerConfiguracaoAgente({ SANDCASTLE_CODEX_EFFORT: 'extreme' })).toThrow(
+      /Valor invalido para SANDCASTLE_CODEX_EFFORT/,
+    );
+  });
+
+  it('aceita esforco em maiusculas (case-insensitive)', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_CODEX_EFFORT: 'HIGH' });
+
+    expect(config.agente).toBe('codex');
+    if (config.agente === 'codex') {
+      expect(config.esforco).toBe('high');
+    }
+  });
+});

--- a/.sandcastle/configuracao-agente.ts
+++ b/.sandcastle/configuracao-agente.ts
@@ -1,10 +1,14 @@
 export const AGENTES_SUPORTADOS = ['codex', 'pi'] as const;
+export const ESFORCOS_CODEX_SUPORTADOS = ['low', 'medium', 'high', 'xhigh'] as const;
 export const ESFORCO_CODEX_PADRAO = 'low';
 export const MODELO_CODEX_PADRAO = 'gpt-5.4';
 export const MODELO_PI_PADRAO = 'opencode-go';
 const NOME_VARIAVEL_AGENTE = 'SANDCASTLE_AGENT';
+const NOME_VARIAVEL_MODELO_CODEX = 'SANDCASTLE_CODEX_MODEL';
+const NOME_VARIAVEL_ESFORCO_CODEX = 'SANDCASTLE_CODEX_EFFORT';
 
 export type AgenteSandcastle = (typeof AGENTES_SUPORTADOS)[number];
+export type EsforcoCodex = (typeof ESFORCOS_CODEX_SUPORTADOS)[number];
 
 interface ConfiguracaoBaseAgente {
   agente: AgenteSandcastle;
@@ -13,7 +17,7 @@ interface ConfiguracaoBaseAgente {
 
 export interface ConfiguracaoCodex extends ConfiguracaoBaseAgente {
   agente: 'codex';
-  esforco: typeof ESFORCO_CODEX_PADRAO;
+  esforco: EsforcoCodex;
 }
 
 export interface ConfiguracaoPi extends ConfiguracaoBaseAgente {
@@ -34,9 +38,31 @@ export function lerConfiguracaoAgente(env = process.env): ConfiguracaoAgente {
 
   return {
     agente,
-    modelo: MODELO_CODEX_PADRAO,
-    esforco: ESFORCO_CODEX_PADRAO,
+    modelo: lerModeloCodex(env),
+    esforco: lerEsforcoCodex(env),
   };
+}
+
+function lerModeloCodex(env: NodeJS.ProcessEnv): string {
+  const valor = env[NOME_VARIAVEL_MODELO_CODEX]?.trim();
+
+  return valor || MODELO_CODEX_PADRAO;
+}
+
+function lerEsforcoCodex(env: NodeJS.ProcessEnv): EsforcoCodex {
+  const valor = env[NOME_VARIAVEL_ESFORCO_CODEX]?.trim().toLowerCase();
+
+  if (!valor) {
+    return ESFORCO_CODEX_PADRAO;
+  }
+
+  if (ESFORCOS_CODEX_SUPORTADOS.includes(valor as EsforcoCodex)) {
+    return valor as EsforcoCodex;
+  }
+
+  throw new Error(
+    `Valor invalido para ${NOME_VARIAVEL_ESFORCO_CODEX}: ${valor}. Valores suportados: ${ESFORCOS_CODEX_SUPORTADOS.join(', ')}.`,
+  );
 }
 
 function lerAgente(env: NodeJS.ProcessEnv): AgenteSandcastle {


### PR DESCRIPTION
Closes #38

## O que mudou

- `SANDCASTLE_CODEX_MODEL` sobrescreve o modelo do Codex (padrão: `gpt-5.4`)
- `SANDCASTLE_CODEX_EFFORT` sobrescreve o esforço de raciocínio (padrão: `low`). Valores suportados: `low`, `medium`, `high`, `xhigh`
- Validação explícita: valor inválido lança erro antes do processamento da fila
- Sem overrides → comportamento idêntico ao atual
- Documentação atualizada em `.env.example`
- 12 testes unitários para a nova configuração