### PR TITLE
feat: permitir execução do Pi com modelo e esforço configuráveis

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -10,3 +10,5 @@ OPENAI_API_KEY=
 OPENCODE_API_KEY=
 # Opcional: modelo passado para `pi --model`. Use `pi --list-models` para alternativas.
 SANDCASTLE_PI_MODEL=opencode-go/mimo-v2-pro
+# Override opcional do nivel de thinking do Pi: off | minimal | low | medium | high | xhigh (padrao: medium)
+SANDCASTLE_PI_EFFORT=

--- a/.sandcastle/configuracao-agente.test.ts
+++ b/.sandcastle/configuracao-agente.test.ts
@@ -4,6 +4,9 @@ import {
   MODELO_CODEX_PADRAO,
   ESFORCO_CODEX_PADRAO,
   ESFORCOS_CODEX_SUPORTADOS,
+  MODELO_PI_PADRAO,
+  ESFORCO_PI_PADRAO,
+  ESFORCOS_PI_SUPORTADOS,
 } from './configuracao-agente';
 
 describe('agente padrao', () => {
@@ -82,6 +85,67 @@ describe('esforco do Codex', () => {
 
     expect(config.agente).toBe('codex');
     if (config.agente === 'codex') {
+      expect(config.esforco).toBe('high');
+    }
+  });
+});
+
+describe('modelo do Pi', () => {
+  it('usa modelo padrao quando override nao esta definido', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi' });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
+      expect(config.modelo).toBe(MODELO_PI_PADRAO);
+    }
+  });
+
+  it('usa override quando SANDCASTLE_PI_MODEL esta definido', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi', SANDCASTLE_PI_MODEL: 'outro-modelo' });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
+      expect(config.modelo).toBe('outro-modelo');
+    }
+  });
+
+  it('lanca erro quando modelo e explicitamente vazio', () => {
+    expect(() => lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi', SANDCASTLE_PI_MODEL: '   ' })).toThrow(
+      /Valor invalido para SANDCASTLE_PI_MODEL/,
+    );
+  });
+});
+
+describe('esforco do Pi', () => {
+  it('usa esforco padrao quando override nao esta definido', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi' });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
+      expect(config.esforco).toBe(ESFORCO_PI_PADRAO);
+    }
+  });
+
+  it.each(ESFORCOS_PI_SUPORTADOS)('aceita esforco valido: %s', (esforco) => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi', SANDCASTLE_PI_EFFORT: esforco });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
+      expect(config.esforco).toBe(esforco);
+    }
+  });
+
+  it('lanca erro para esforco invalido', () => {
+    expect(() => lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi', SANDCASTLE_PI_EFFORT: 'extreme' })).toThrow(
+      /Valor invalido para SANDCASTLE_PI_EFFORT/,
+    );
+  });
+
+  it('aceita esforco em maiusculas (case-insensitive)', () => {
+    const config = lerConfiguracaoAgente({ SANDCASTLE_AGENT: 'pi', SANDCASTLE_PI_EFFORT: 'HIGH' });
+
+    expect(config.agente).toBe('pi');
+    if (config.agente === 'pi') {
       expect(config.esforco).toBe('high');
     }
   });

--- a/.sandcastle/configuracao-agente.ts
+++ b/.sandcastle/configuracao-agente.ts
@@ -1,15 +1,19 @@
 export const AGENTES_SUPORTADOS = ['codex', 'pi'] as const;
 export const ESFORCOS_CODEX_SUPORTADOS = ['low', 'medium', 'high', 'xhigh'] as const;
+export const ESFORCOS_PI_SUPORTADOS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
 export const ESFORCO_CODEX_PADRAO = 'low';
+export const ESFORCO_PI_PADRAO = 'medium';
 export const MODELO_CODEX_PADRAO = 'gpt-5.4';
 export const MODELO_PI_PADRAO = 'opencode-go/mimo-v2-pro';
 const NOME_VARIAVEL_AGENTE = 'SANDCASTLE_AGENT';
 const NOME_VARIAVEL_MODELO_CODEX = 'SANDCASTLE_CODEX_MODEL';
 const NOME_VARIAVEL_ESFORCO_CODEX = 'SANDCASTLE_CODEX_EFFORT';
 const NOME_VARIAVEL_MODELO_PI = 'SANDCASTLE_PI_MODEL';
+const NOME_VARIAVEL_ESFORCO_PI = 'SANDCASTLE_PI_EFFORT';
 
 export type AgenteSandcastle = (typeof AGENTES_SUPORTADOS)[number];
 export type EsforcoCodex = (typeof ESFORCOS_CODEX_SUPORTADOS)[number];
+export type EsforcoPi = (typeof ESFORCOS_PI_SUPORTADOS)[number];
 
 interface ConfiguracaoBaseAgente {
   agente: AgenteSandcastle;
@@ -23,6 +27,7 @@ export interface ConfiguracaoCodex extends ConfiguracaoBaseAgente {
 
 export interface ConfiguracaoPi extends ConfiguracaoBaseAgente {
   agente: 'pi';
+  esforco: EsforcoPi;
 }
 
 export type ConfiguracaoAgente = ConfiguracaoCodex | ConfiguracaoPi;
@@ -34,6 +39,7 @@ export function lerConfiguracaoAgente(env = process.env): ConfiguracaoAgente {
     return {
       agente,
       modelo: lerModeloPi(env),
+      esforco: lerEsforcoPi(env),
     };
   }
 
@@ -67,7 +73,35 @@ function lerEsforcoCodex(env: NodeJS.ProcessEnv): EsforcoCodex {
 }
 
 function lerModeloPi(env: NodeJS.ProcessEnv): string {
-  return env[NOME_VARIAVEL_MODELO_PI]?.trim() || MODELO_PI_PADRAO;
+  const valor = env[NOME_VARIAVEL_MODELO_PI];
+
+  if (valor === undefined) {
+    return MODELO_PI_PADRAO;
+  }
+
+  const trimado = valor.trim();
+
+  if (!trimado) {
+    throw new Error(`Valor invalido para ${NOME_VARIAVEL_MODELO_PI}: modelo nao pode ser vazio.`);
+  }
+
+  return trimado;
+}
+
+function lerEsforcoPi(env: NodeJS.ProcessEnv): EsforcoPi {
+  const valor = env[NOME_VARIAVEL_ESFORCO_PI]?.trim().toLowerCase();
+
+  if (!valor) {
+    return ESFORCO_PI_PADRAO;
+  }
+
+  if (ESFORCOS_PI_SUPORTADOS.includes(valor as EsforcoPi)) {
+    return valor as EsforcoPi;
+  }
+
+  throw new Error(
+    `Valor invalido para ${NOME_VARIAVEL_ESFORCO_PI}: ${valor}. Valores suportados: ${ESFORCOS_PI_SUPORTADOS.join(', ')}.`,
+  );
 }
 
 function lerAgente(env: NodeJS.ProcessEnv): AgenteSandcastle {

--- a/.sandcastle/execucao-sandcastle.ts
+++ b/.sandcastle/execucao-sandcastle.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { codex, pi, run, type AgentProvider, type RunResult } from '@ai-hero/sandcastle';
 import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
-import { lerConfiguracaoAgente } from './configuracao-agente';
+import { lerConfiguracaoAgente, type EsforcoPi } from './configuracao-agente';
 import { montarEnvAgente, montarEnvSandbox } from './env-sandcastle';
 
 const NOME_IMAGEM_SANDCASTLE = 'sandcastle:fdp-online';
@@ -73,10 +73,31 @@ async function rodarAgente(prompt: string, branch: string): Promise<RunResult> {
 
 function montarAgente(configuracao: ReturnType<typeof lerConfiguracaoAgente>): AgentProvider {
   if (configuracao.agente === 'pi') {
-    return pi(configuracao.modelo, { env: montarEnvAgente() });
+    return montarAgentePi(configuracao.modelo, configuracao.esforco, montarEnvAgente());
   }
 
   return codex(configuracao.modelo, { effort: configuracao.esforco, env: montarEnvAgente() });
+}
+
+function montarAgentePi(modelo: string, esforco: EsforcoPi, env: Record<string, string>): AgentProvider {
+  const base = pi(modelo, { env });
+
+  return {
+    ...base,
+    buildPrintCommand(options) {
+      const resultado = base.buildPrintCommand(options);
+
+      return {
+        ...resultado,
+        command: `${resultado.command} --thinking ${esforco}`,
+      };
+    },
+    buildInteractiveArgs(options) {
+      const args = base.buildInteractiveArgs?.(options) ?? ['pi', '--model', modelo];
+
+      return [...args, '--thinking', esforco];
+    },
+  };
 }
 
 function montarNomeExecucao(branch: string): string {


### PR DESCRIPTION
## Resumo

- Adiciona `SANDCASTLE_PI_EFFORT` para configurar o nível de thinking do Pi via ambiente (padrão: `medium`, valores: `off | minimal | low | medium | high | xhigh`)
- Validação explícita: valor inválido lança erro antes do processamento da fila
- `SANDCASTLE_PI_MODEL` agora falha com mensagem clara quando configurado como string vazia, evitando modelo obrigatório vazio
- O provider `pi` do Sandcastle é estendido para injetar `--thinking <esforco>` nos comandos de execução
- Documentação atualizada em `.env.example"
- 7 novos testes unitários para a configuração do Pi

## Validação

- `pnpm test` — 30 testes passando
- `pnpm typecheck` — sem erros
- `pnpm lint` — sem erros

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable thinking effort level for Pi agent via the `SANDCASTLE_PI_EFFORT` environment variable with options: `off`, `minimal`, `low`, `medium` (default), `high`, and `xhigh`.

* **Tests**
  * Expanded test coverage for Pi agent configuration, model validation, and effort level handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->