### PR TITLE
fix: ajustar preflight do sandcastle por modo e agente

### DIFF
--- a/.sandcastle/execucao-sandcastle.ts
+++ b/.sandcastle/execucao-sandcastle.ts
@@ -115,6 +115,12 @@ function montarHooksSandbox(): {
 }
 
 function montarMountsDocker(): { hostPath: string; sandboxPath: string; readonly?: boolean }[] {
+  const configuracao = lerConfiguracaoAgente();
+
+  if (configuracao.agente !== 'codex') {
+    return [];
+  }
+
   if (process.env.OPENAI_API_KEY || !existsSync(CAMINHO_AUTH_CODEX)) {
     return [];
   }

--- a/.sandcastle/runner.test.ts
+++ b/.sandcastle/runner.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const validarGhDisponivel = vi.fn();
+const validarAutenticacaoCodex = vi.fn();
+const validarAutenticacaoPi = vi.fn();
+const validarDocker = vi.fn();
+
+vi.mock('./github', () => ({
+  validarGhDisponivel,
+}));
+
+vi.mock('./execucao-sandcastle', () => ({
+  validarAutenticacaoCodex,
+  validarAutenticacaoPi,
+  validarDocker,
+  formatarResultadoAgente: vi.fn(),
+  rodarAgenteSandcastle: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  delete process.env.SANDCASTLE_AGENT;
+});
+
+describe('dry run do runner', () => {
+  it('no dry run valida GitHub e Docker sem exigir autenticacao do agente', async () => {
+    const { executarRunner } = await import('./runner');
+
+    await executarRunner({ adaptadores: [], dryRun: true });
+
+    expect(validarGhDisponivel).toHaveBeenCalledOnce();
+    expect(validarDocker).toHaveBeenCalledOnce();
+    expect(validarAutenticacaoCodex).not.toHaveBeenCalled();
+    expect(validarAutenticacaoPi).not.toHaveBeenCalled();
+  });
+});
+
+describe('execucao real com codex', () => {
+  it('na execucao real valida autenticacao apenas do agente codex ativo', async () => {
+    const { executarRunner } = await import('./runner');
+
+    await executarRunner({ adaptadores: [], dryRun: false });
+
+    expect(validarGhDisponivel).toHaveBeenCalledOnce();
+    expect(validarDocker).toHaveBeenCalledOnce();
+    expect(validarAutenticacaoCodex).toHaveBeenCalledOnce();
+    expect(validarAutenticacaoPi).not.toHaveBeenCalled();
+  });
+});
+
+describe('execucao real com pi', () => {
+  it('na execucao real valida autenticacao apenas do agente pi ativo', async () => {
+    process.env.SANDCASTLE_AGENT = 'pi';
+    const { executarRunner } = await import('./runner');
+
+    await executarRunner({ adaptadores: [], dryRun: false });
+
+    expect(validarGhDisponivel).toHaveBeenCalledOnce();
+    expect(validarDocker).toHaveBeenCalledOnce();
+    expect(validarAutenticacaoPi).toHaveBeenCalledOnce();
+    expect(validarAutenticacaoCodex).not.toHaveBeenCalled();
+  });
+});

--- a/.sandcastle/runner.ts
+++ b/.sandcastle/runner.ts
@@ -28,8 +28,12 @@ interface EntradaFila {
 export function prepararAmbiente(): void {
   carregarEnvLocal();
   validarGhDisponivel();
-  validarAutenticacaoAgente();
   validarDocker();
+}
+
+export function prepararExecucaoReal(): void {
+  prepararAmbiente();
+  validarAutenticacaoAgente();
 }
 
 export function lerArquivo(caminho: URL): string {
@@ -48,7 +52,11 @@ export async function executarEntrada(executar: () => Promise<void>, mensagemErr
 }
 
 export async function executarRunner(opcoes: OpcoesRunner): Promise<void> {
-  prepararAmbiente();
+  if (opcoes.dryRun) {
+    prepararAmbiente();
+  } else {
+    prepararExecucaoReal();
+  }
 
   const fila = await montarFila(opcoes.adaptadores, opcoes.limite ?? LIMITE_ITENS_POR_RODADA);
 

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -108,6 +108,7 @@ pnpm sandcastle:cron -- --dry-run
 ```
 
 Mostra quais issues seriam enviadas ao agente sem executar sandbox, sem criar branch e sem alterar labels.
+Nesse modo, o preflight continua validando `gh`, Docker e a imagem `sandcastle:fdp-online`, mas nao exige autenticacao do agente ativo.
 
 ---
 


### PR DESCRIPTION
## Resumo
- separa o preflight entre dry run e execucao real no runner
- no dry run valida GitHub, Docker e imagem sem exigir autenticacao do agente
- em execucao real valida apenas a autenticacao do agente ativo e evita montar auth do Codex quando o agente ativo e Pi

## Validacao
- `pnpm test -- .sandcastle/configuracao-agente.test.ts .sandcastle/runner.test.ts`
- `pnpm typecheck`

Closes #40