### PR TITLE
feat: expor agente e modelo no resultado do Sandcastle

### DIFF
--- a/.sandcastle/execucao-sandcastle.test.ts
+++ b/.sandcastle/execucao-sandcastle.test.ts
@@ -1,0 +1,28 @@
+import type { RunResult } from '@ai-hero/sandcastle';
+import { describe, expect, it, vi } from 'vitest';
+import { formatarResultadoAgente } from './execucao-sandcastle';
+
+describe('formatarResultadoAgente', () => {
+  it('inclui agente e modelo de forma concisa no resultado do item', () => {
+    vi.stubEnv('SANDCASTLE_AGENT', 'pi');
+    vi.stubEnv('SANDCASTLE_PI_MODEL', 'modelo-auditoria');
+
+    const resultado = {
+      branch: 'sandcastle-issue-41',
+      commits: [{ hash: 'abc123' }],
+      logFilePath: '/tmp/sandcastle.log',
+    } as RunResult;
+
+    expect(formatarResultadoAgente('issue', 41, resultado)).toBe(
+      [
+        'issue #41 processado pelo Sandcastle.',
+        'Executor: agente=pi modelo=modelo-auditoria',
+        'Branch: sandcastle-issue-41',
+        'Commits: 1',
+        'Log: /tmp/sandcastle.log',
+      ].join('\n'),
+    );
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/.sandcastle/execucao-sandcastle.ts
+++ b/.sandcastle/execucao-sandcastle.ts
@@ -40,8 +40,11 @@ export async function rodarAgenteSandcastle(prompt: string, branch: string): Pro
 }
 
 export function formatarResultadoAgente(prefixo: string, numero: number, resultado: RunResult): string {
+  const configuracao = lerConfiguracaoAgente();
+
   return [
     `${prefixo} #${String(numero)} processado pelo Sandcastle.`,
+    `Executor: agente=${configuracao.agente} modelo=${configuracao.modelo}`,
     `Branch: ${resultado.branch}`,
     `Commits: ${String(resultado.commits.length)}`,
     resultado.logFilePath ? `Log: ${resultado.logFilePath}` : null,


### PR DESCRIPTION
## Resumo
Inclui no resultado de cada item processado pelo Sandcastle a identificacao concisa de agente e modelo usados na execucao.

## Validacao
- `pnpm test .sandcastle/configuracao-agente.test.ts .sandcastle/execucao-sandcastle.test.ts`
- `pnpm typecheck`
- hooks de `pre-push` (`pnpm typecheck` e `pnpm test`)

Closes #41