### PR TITLE
feat: distinguir issue aguardando dependencia no sandcastle

### DIFF
--- a/.sandcastle/github/issue.ts
+++ b/.sandcastle/github/issue.ts
@@ -3,6 +3,7 @@ import { executarGh, executarGhJson, executarGhSemErro, type ResultadoGh } from 
 export const LABEL_EXECUCAO_SANDCASTLE = 'sandcastle:run';
 export const LABEL_EXECUTANDO_SANDCASTLE = 'sandcastle:running';
 export const LABEL_BLOQUEIO_SANDCASTLE = 'sandcastle:blocked';
+export const LABEL_ESPERA_SANDCASTLE = 'sandcastle:waiting';
 
 export interface IssueGitHub {
   number: number;

--- a/.sandcastle/prompts/agente.md
+++ b/.sandcastle/prompts/agente.md
@@ -6,9 +6,20 @@ Passo 1. Leia AGENTS.md e ARQUITETURA.md.
 Passo 2. Leia a issue e os comentários abaixo.
 Passo 3. Decida se a issue é executável agora.
 
-Você deve bloquear a issue, e não tentar salvar o ambiente, se encontrar qualquer bloqueio operacional ou de escopo.
+Você deve distinguir issue aguardando dependências de bloqueio manual.
+Se a implementação depender de outra issue aberta, trate como espera, não como bloqueio manual.
+Você deve bloquear a issue, e não tentar salvar o ambiente, se encontrar qualquer outro bloqueio operacional ou de escopo.
 Exemplos de bloqueio operacional: falta de dependências, `node_modules` ausente, versão errada de Node, browser ou biblioteca nativa ausente no Playwright, problema de autenticação, problema de push, problema de SSH, problema de Docker, problema de permissão, ou qualquer setup faltando no runner.
-Exemplos de bloqueio de escopo: issue ambígua, grande demais, depender de decisão humana, conflitar com a arquitetura, depender de outra issue ou PR, ou não ter critério claro de validação.
+Exemplos de bloqueio de escopo: issue ambígua, grande demais, depender de decisão humana, conflitar com a arquitetura, depender de outra PR, ou não ter critério claro de validação.
+
+Se houver dependência de outra issue aberta em qualquer passo:
+
+1. Adicione a label `sandcastle:waiting`.
+2. Garanta que a label `{{label_execucao}}` não esteja mais presente.
+3. Não adicione `sandcastle:blocked` apenas por estar aguardando outra issue.
+4. Comente objetivamente quais issues ainda bloqueiam este trabalho e por que ele entrou em espera.
+5. Escreva exatamente `<promise>COMPLETE</promise>` na resposta final.
+6. Pare. Não implemente workaround paralelo nem altere o corpo da issue para escrever ou atualizar `## Blocked by`.
 
 Se houver bloqueio em qualquer passo:
 

--- a/.sandcastle/prompts/agente.test.ts
+++ b/.sandcastle/prompts/agente.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const CAMINHO_PROMPT = new URL('./agente.md', import.meta.url);
+
+describe('prompt do agente de issue', () => {
+  it('instrui usar waiting para dependencia de outra issue aberta', () => {
+    const prompt = readFileSync(CAMINHO_PROMPT, 'utf8');
+
+    expect(prompt).toContain('Adicione a label `sandcastle:waiting`.');
+    expect(prompt).toContain('Garanta que a label `{{label_execucao}}` não esteja mais presente.');
+    expect(prompt).toContain('Não adicione `sandcastle:blocked` apenas por estar aguardando outra issue.');
+    expect(prompt).toContain('Não implemente workaround paralelo nem altere o corpo da issue');
+  });
+});

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -35,6 +35,15 @@ Hoje o fluxo automatizado usa a pasta `.sandcastle/`, os scripts do `package.jso
 - Antes da execução, adiciona `sandcastle:running` e remove `sandcastle:run`.
 - Em cada rodada, processa no máximo **3 issues**, priorizando as mais antigas.
 
+### Estados operacionais de issue
+
+- `sandcastle:run`: issue pronta para entrar na fila do agente.
+- `sandcastle:running`: issue atualmente em execução pelo cron.
+- `sandcastle:waiting`: issue temporariamente fora da fila porque depende de outra issue aberta.
+- `sandcastle:blocked`: issue bloqueada por problema operacional ou bloqueio manual de escopo.
+
+Quando o agente identificar dependência de outra issue aberta, ele deve usar `sandcastle:waiting`, remover `sandcastle:run` e comentar objetivamente quais bloqueadores seguem abertos e por que a issue entrou em espera. Esse protocolo não implica escrever ou atualizar `## Blocked by` no corpo da issue.
+
 ### Branch de execução
 
 - Cada issue roda em um branch isolado no formato `sandcastle-issue-<id>`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -11,3 +11,9 @@ As skills usam cinco papéis canônicos de triagem. Este arquivo mapeia esses pa
 | `wontfix`         | `wontfix`           | Não será executada                                 |
 
 Quando uma skill mencionar um papel de triagem, use o label correspondente desta tabela.
+
+Estados operacionais do Sandcastle fora da triagem canônica:
+
+- `sandcastle:running`: item atualmente em execução.
+- `sandcastle:waiting`: item aguardando dependência de outra issue aberta; deve sair da fila do agente sem virar bloqueio manual.
+- `sandcastle:blocked`: item bloqueado por ambiente ou por bloqueio manual de escopo.


### PR DESCRIPTION
## Resumo
- distingue no prompt do Sandcastle o estado de espera por outra issue aberta do bloqueio manual
- documenta o novo estado operacional `sandcastle:waiting` sem escrever `## Blocked by`
- adiciona teste para garantir a instrucao do prompt

Closes #49