### PR TITLE
feat: expandir dry run do sandcastle

### DIFF
--- a/.sandcastle/processadores/issue.test.ts
+++ b/.sandcastle/processadores/issue.test.ts
@@ -47,9 +47,9 @@ function mockIssueEmEsperaComSubsecao() {
 }
 
 async function importarReavaliacao() {
-  const { reavaliarIssuesEmEspera } = await import('./issue');
+  const { listarDryRunIssuesEmEspera, reavaliarIssuesEmEspera } = await import('./reavaliacao-issue');
 
-  return reavaliarIssuesEmEspera;
+  return { listarDryRunIssuesEmEspera, reavaliarIssuesEmEspera };
 }
 
 function esperarIssueEmEspera() {
@@ -75,8 +75,8 @@ describe('reavaliacao de issues em espera', () => {
       state: 'CLOSED',
     }));
 
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
 
     expect(removerLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:waiting');
     expect(adicionarLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:run');
@@ -91,8 +91,8 @@ describe('reavaliacao de issues ainda bloqueadas', () => {
       state: numero === 50 ? 'OPEN' : 'CLOSED',
     }));
 
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
 
     esperarIssueEmEspera();
   });
@@ -112,9 +112,9 @@ describe('reavaliacao com bloqueador nao legivel', () => {
       };
     });
 
-    const reavaliar = await importarReavaliacao();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
     expect(() => {
-      reavaliar();
+      reavaliarIssuesEmEspera();
     }).not.toThrow();
     esperarIssueEmEspera();
   });
@@ -123,8 +123,8 @@ describe('reavaliacao com bloqueador nao legivel', () => {
 describe('reavaliacao com blocked by ausente ou valido', () => {
   it('bloqueia manualmente quando a secao blocked by esta ausente', async () => {
     mockIssueEmEspera('## What to build\n\ntexto');
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     esperarBloqueioManual(51, 'secao `## Blocked by` ausente');
     expect(comentarIssue.mock.invocationCallOrder[0]).toBeLessThan(adicionarLabelIssue.mock.invocationCallOrder[0]);
   });
@@ -132,16 +132,16 @@ describe('reavaliacao com blocked by ausente ou valido', () => {
   it('mantem em espera quando blocked by e valido e bloqueador ainda aberto', async () => {
     mockIssueEmEspera('## Blocked by\n\n- #10');
     lerIssue.mockReturnValue({ number: 10, state: 'OPEN' });
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     esperarIssueEmEspera();
   });
 
   it('reativa a issue quando blocked by valido usa referencia sem bullet', async () => {
     mockIssueEmEspera('## Blocked by\n\n#10');
     lerIssue.mockReturnValue({ number: 10, state: 'CLOSED' });
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     expect(removerLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:waiting');
     expect(adicionarLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:run');
   });
@@ -153,8 +153,8 @@ describe('reavaliacao com dependencia inexistente ou erro operacional', () => {
     lerIssue.mockImplementation(() => {
       throw new Error('Falha ao executar gh issue view 10 --json ...: HTTP 404 Not Found');
     });
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     esperarBloqueioManual(51, 'referencia #10 que nao pode ser lida como issue');
   });
 
@@ -163,9 +163,9 @@ describe('reavaliacao com dependencia inexistente ou erro operacional', () => {
     lerIssue.mockImplementation(() => {
       throw new Error('Falha ao executar gh issue view 10 --json ...: rate limit exceeded');
     });
-    const reavaliar = await importarReavaliacao();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
     expect(() => {
-      reavaliar();
+      reavaliarIssuesEmEspera();
     }).not.toThrow();
     esperarIssueEmEspera();
   });
@@ -179,8 +179,8 @@ describe('reavaliacao com subsecoes apos blocked by', () => {
       state: numero === 50 ? 'CLOSED' : 'OPEN',
     }));
 
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
 
     expect(removerLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:waiting');
     expect(adicionarLabelIssue).toHaveBeenCalledWith(51, 'sandcastle:run');

--- a/.sandcastle/processadores/issue.ts
+++ b/.sandcastle/processadores/issue.ts
@@ -11,7 +11,7 @@ import {
   type IssueGitHub,
 } from '../github';
 import { lerArquivo } from '../runner';
-import { reavaliarIssuesEmEspera } from './reavaliacao-issue';
+import { listarDryRunIssuesEmEspera, reavaliarIssuesEmEspera } from './reavaliacao-issue';
 import type { AdaptadorProcessamento, ItemFila } from './tipos';
 
 const LIMITE_COMENTARIOS_CONTEXTO = 5;
@@ -24,6 +24,7 @@ interface ContextoIssue {
 export const adaptadorIssue: AdaptadorProcessamento<IssueGitHub, ContextoIssue> = {
   tipo: 'issue',
   prepararRodada: reavaliarIssuesEmEspera,
+  formatarDryRunPreparacao: listarDryRunIssuesEmEspera,
   listarElegiveis,
   carregarItem: lerIssue,
   avaliarElegibilidade,

--- a/.sandcastle/processadores/reavaliacao-issue.test.ts
+++ b/.sandcastle/processadores/reavaliacao-issue.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const issueEhPullRequest = vi.fn();
+const lerIssue = vi.fn();
+const listarIssuesEmEspera = vi.fn();
+
+vi.mock('../github', () => ({
+  LABEL_BLOQUEIO_SANDCASTLE: 'sandcastle:blocked',
+  LABEL_EXECUCAO_SANDCASTLE: 'sandcastle:run',
+  LABEL_ESPERA_SANDCASTLE: 'sandcastle:waiting',
+  adicionarLabelIssue: vi.fn(),
+  comentarIssue: vi.fn(),
+  issueEhPullRequest,
+  lerIssue,
+  listarIssuesEmEspera,
+  removerLabelIssue: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  issueEhPullRequest.mockReturnValue(false);
+});
+
+function mockIssueEmEspera(body: string) {
+  listarIssuesEmEspera.mockReturnValue([{ number: 51, body }]);
+}
+
+function esperarDryRunIssueEmEspera(linhas: string[]) {
+  return [linhas.join('\n')];
+}
+
+it('mostra no dry run a reativacao esperada sem alterar labels', async () => {
+  mockIssueEmEspera('## Blocked by\n\n- #10');
+  lerIssue.mockReturnValue({ number: 10, state: 'CLOSED' });
+  const { listarDryRunIssuesEmEspera } = await import('./reavaliacao-issue');
+
+  expect(listarDryRunIssuesEmEspera()).toEqual(
+    esperarDryRunIssueEmEspera([
+      'DRY RUN: issue #51 em sandcastle:waiting.',
+      'Resultado: voltaria para sandcastle:run.',
+      'Motivo: todos os bloqueadores estao fechados.',
+    ]),
+  );
+});
+
+it('mostra no dry run quando a issue continua aguardando', async () => {
+  mockIssueEmEspera('## Blocked by\n\n- #10');
+  lerIssue.mockReturnValue({ number: 10, state: 'OPEN' });
+  const { listarDryRunIssuesEmEspera } = await import('./reavaliacao-issue');
+
+  expect(listarDryRunIssuesEmEspera()).toEqual(
+    esperarDryRunIssueEmEspera([
+      'DRY RUN: issue #51 em sandcastle:waiting.',
+      'Resultado: continuaria em sandcastle:waiting.',
+      'Motivo: ainda existe bloqueador aberto ou temporariamente indisponivel.',
+    ]),
+  );
+});
+
+it('mostra no dry run quando a issue viraria bloqueio manual', async () => {
+  mockIssueEmEspera('## What to build\n\ntexto');
+  const { listarDryRunIssuesEmEspera } = await import('./reavaliacao-issue');
+
+  expect(listarDryRunIssuesEmEspera()).toEqual(
+    esperarDryRunIssueEmEspera([
+      'DRY RUN: issue #51 em sandcastle:waiting.',
+      'Resultado: viraria sandcastle:blocked.',
+      'Motivo: secao `## Blocked by` ausente.',
+    ]),
+  );
+});

--- a/.sandcastle/processadores/reavaliacao-issue.ts
+++ b/.sandcastle/processadores/reavaliacao-issue.ts
@@ -14,10 +14,10 @@ import { analisarBlockedBy } from './bloqueios-issue';
 
 export function reavaliarIssuesEmEspera(): void {
   for (const issue of listarIssuesEmEspera()) {
-    const motivoBloqueio = avaliarBlockedByInvalido(issue);
+    const resultado = avaliarIssueEmEspera(issue);
 
-    if (motivoBloqueio) {
-      const comentario = montarComentarioBloqueioBlockedBy(motivoBloqueio);
+    if (resultado.status === 'bloquear') {
+      const comentario = montarComentarioBloqueioBlockedBy(resultado.motivo);
       comentarIssue(issue.number, comentario);
       adicionarLabelIssue(issue.number, LABEL_BLOQUEIO_SANDCASTLE);
       removerLabelIssue(issue.number, LABEL_ESPERA_SANDCASTLE);
@@ -25,11 +25,54 @@ export function reavaliarIssuesEmEspera(): void {
       continue;
     }
 
-    if (todosBloqueadoresFechados(issue.body)) {
+    if (resultado.status === 'reativar') {
       removerLabelIssue(issue.number, LABEL_ESPERA_SANDCASTLE);
       adicionarLabelIssue(issue.number, LABEL_EXECUCAO_SANDCASTLE);
     }
   }
+}
+
+export function listarDryRunIssuesEmEspera(): string[] {
+  return listarIssuesEmEspera().map((issue) => formatarDryRunIssueEmEspera(issue, avaliarIssueEmEspera(issue)));
+}
+
+function formatarDryRunIssueEmEspera(issue: IssueGitHub, resultado: ResultadoReavaliacaoIssueEmEspera): string {
+  const cabecalho = `DRY RUN: issue #${String(issue.number)} em ${LABEL_ESPERA_SANDCASTLE}.`;
+
+  if (resultado.status === 'reativar') {
+    return [
+      cabecalho,
+      `Resultado: voltaria para ${LABEL_EXECUCAO_SANDCASTLE}.`,
+      'Motivo: todos os bloqueadores estao fechados.',
+    ].join('\n');
+  }
+
+  if (resultado.status === 'bloquear') {
+    return [cabecalho, `Resultado: viraria ${LABEL_BLOQUEIO_SANDCASTLE}.`, `Motivo: ${resultado.motivo}.`].join('\n');
+  }
+
+  return [cabecalho, `Resultado: continuaria em ${LABEL_ESPERA_SANDCASTLE}.`, `Motivo: ${resultado.motivo}.`].join(
+    '\n',
+  );
+}
+
+type ResultadoReavaliacaoIssueEmEspera =
+  | { status: 'reativar' }
+  | { status: 'manter'; motivo: string }
+  | { status: 'bloquear'; motivo: string };
+
+function avaliarIssueEmEspera(issue: IssueGitHub): ResultadoReavaliacaoIssueEmEspera {
+  const motivoBloqueio = avaliarBlockedByInvalido(issue);
+
+  if (motivoBloqueio) {
+    return { status: 'bloquear', motivo: motivoBloqueio };
+  }
+
+  if (todosBloqueadoresFechados(issue.body)) {
+    return { status: 'reativar' };
+  }
+
+  return { status: 'manter', motivo: 'ainda existe bloqueador aberto ou temporariamente indisponivel' };
 }
 
 function todosBloqueadoresFechados(corpo: string): boolean {

--- a/.sandcastle/processadores/tipos.ts
+++ b/.sandcastle/processadores/tipos.ts
@@ -7,6 +7,7 @@ export interface ItemFila {
 export interface AdaptadorProcessamento<TItem, TContexto> {
   tipo: ItemFila['tipo'];
   prepararRodada?(): Promise<void> | void;
+  formatarDryRunPreparacao?(): Promise<string[]> | string[];
   listarElegiveis(): Promise<ItemFila[]> | ItemFila[];
   carregarItem(numero: number): Promise<TItem> | TItem;
   avaliarElegibilidade(item: TItem): string | null;

--- a/.sandcastle/runner.test.ts
+++ b/.sandcastle/runner.test.ts
@@ -23,17 +23,66 @@ beforeEach(() => {
   delete process.env.SANDCASTLE_AGENT;
 });
 
-describe('dry run do runner', () => {
-  it('no dry run valida GitHub e Docker sem exigir autenticacao do agente', async () => {
-    const { executarRunner } = await import('./runner');
+function criarAdaptadorBase() {
+  return {
+    tipo: 'issue' as const,
+    listarElegiveis: () => [],
+    carregarItem: vi.fn(),
+    avaliarElegibilidade: vi.fn(),
+    coletarContexto: vi.fn(),
+    formatarDryRun: vi.fn(),
+    fazerLock: vi.fn(),
+    desfazerLock: vi.fn(),
+    montarPrompt: vi.fn(),
+    obterBranch: vi.fn(),
+  };
+}
 
-    await executarRunner({ adaptadores: [], dryRun: true });
+async function executarDryRunComLog(adaptador: ReturnType<typeof criarAdaptadorBase>) {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const { executarRunner } = await import('./runner');
 
-    expect(validarGhDisponivel).toHaveBeenCalledOnce();
-    expect(validarDocker).toHaveBeenCalledOnce();
-    expect(validarAutenticacaoCodex).not.toHaveBeenCalled();
-    expect(validarAutenticacaoPi).not.toHaveBeenCalled();
+  await executarRunner({ dryRun: true, adaptadores: [adaptador] });
+
+  return logSpy;
+}
+
+it('no dry run valida GitHub e Docker sem exigir autenticacao do agente', async () => {
+  const { executarRunner } = await import('./runner');
+
+  await executarRunner({ adaptadores: [], dryRun: true });
+
+  expect(validarGhDisponivel).toHaveBeenCalledOnce();
+  expect(validarDocker).toHaveBeenCalledOnce();
+  expect(validarAutenticacaoCodex).not.toHaveBeenCalled();
+  expect(validarAutenticacaoPi).not.toHaveBeenCalled();
+});
+
+it('no dry run imprime a simulacao da preparacao sem executar mutacoes reais', async () => {
+  const adaptador = criarAdaptadorBase();
+  adaptador.prepararRodada = vi.fn(() => {
+    throw new Error('nao deveria rodar no dry run');
   });
+  adaptador.formatarDryRunPreparacao = () => ['DRY RUN: waiting #10 continuaria em espera.'];
+
+  const logSpy = await executarDryRunComLog(adaptador);
+
+  expect(logSpy).toHaveBeenCalledWith('DRY RUN: waiting #10 continuaria em espera.');
+  logSpy.mockRestore();
+});
+
+it('no dry run imprime o destino da entrada elegivel', async () => {
+  const adaptador = criarAdaptadorBase();
+  adaptador.listarElegiveis = () => [{ tipo: 'issue', numero: 7, criadoEm: '2026-05-02T00:00:00Z' }];
+  adaptador.carregarItem = () => ({ number: 7 });
+  adaptador.avaliarElegibilidade = () => null;
+  adaptador.coletarContexto = () => ({ comentarios: [] });
+  adaptador.formatarDryRun = () => 'DRY RUN: issue #7 seria enviada ao agente.';
+
+  const logSpy = await executarDryRunComLog(adaptador);
+
+  expect(logSpy).toHaveBeenCalledWith('DRY RUN: issue #7 seria enviada ao agente.');
+  logSpy.mockRestore();
 });
 
 describe('execucao real com codex', () => {
@@ -69,7 +118,7 @@ describe('preparacao da rodada', () => {
     const { executarRunner } = await import('./runner');
 
     await executarRunner({
-      dryRun: true,
+      dryRun: false,
       adaptadores: [
         {
           tipo: 'issue',

--- a/.sandcastle/runner.ts
+++ b/.sandcastle/runner.ts
@@ -58,7 +58,11 @@ export async function executarRunner(opcoes: OpcoesRunner): Promise<void> {
     prepararExecucaoReal();
   }
 
-  await prepararRodada(opcoes.adaptadores);
+  if (opcoes.dryRun) {
+    await imprimirDryRunPreparacao(opcoes.adaptadores);
+  } else {
+    await prepararRodada(opcoes.adaptadores);
+  }
   const fila = await montarFila(opcoes.adaptadores, opcoes.limite ?? LIMITE_ITENS_POR_RODADA);
 
   if (fila.length === 0) {
@@ -76,6 +80,16 @@ export async function executarRunner(opcoes: OpcoesRunner): Promise<void> {
 
 async function prepararRodada(adaptadores: AdaptadorGenerico[]): Promise<void> {
   await Promise.all(adaptadores.map((adaptador) => Promise.resolve(adaptador.prepararRodada?.())));
+}
+
+async function imprimirDryRunPreparacao(adaptadores: AdaptadorGenerico[]): Promise<void> {
+  const blocos = await Promise.all(
+    adaptadores.map((adaptador) => Promise.resolve(adaptador.formatarDryRunPreparacao?.() ?? [])),
+  );
+
+  for (const bloco of blocos.flat()) {
+    console.log(bloco);
+  }
 }
 
 async function montarFila(adaptadores: AdaptadorGenerico[], limite: number): Promise<EntradaFila[]> {
@@ -108,6 +122,7 @@ async function processarEntrada(entrada: EntradaFila, dryRun: boolean): Promise<
   }
 
   if (dryRun) {
+    console.log(entrada.adaptador.formatarDryRun(item, contexto));
     return;
   }
 

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -135,6 +135,8 @@ pnpm sandcastle:cron -- --dry-run
 
 Mostra quais issues seriam enviadas ao agente sem executar sandbox, sem criar branch e sem alterar labels.
 
+O `dry-run` tambem simula a reavaliacao de issues em `sandcastle:waiting`: mostra quais voltariam para `sandcastle:run`, quais continuariam aguardando e quais virariam `sandcastle:blocked`, sempre sem comentar, sem trocar labels e sem criar efeitos colaterais no GitHub.
+
 Nesse modo, o preflight valida `gh`, Docker e a imagem `sandcastle:fdp-online`, mas **não** valida a autenticação do agente ativo. Isso permite inspecionar a fila mesmo sem credenciais do Codex ou do Pi configuradas.
 
 ---


### PR DESCRIPTION
Closes #53

## Resumo
- simula a reavaliacao de issues em `sandcastle:waiting` no `--dry-run`
- reutiliza as mesmas regras da reavaliacao real sem efeitos colaterais
- documenta a observabilidade nova e cobre o fluxo com testes
