### PR TITLE
fix: consolidar precedencia entre labels do Sandcastle

### DIFF
--- a/.sandcastle/github/index.ts
+++ b/.sandcastle/github/index.ts
@@ -1,5 +1,6 @@
 export { validarGhDisponivel } from './base';
 export {
+  type EstadoOperacionalIssue,
   LABEL_BLOQUEIO_SANDCASTLE,
   LABEL_EXECUCAO_SANDCASTLE,
   LABEL_EXECUTANDO_SANDCASTLE,
@@ -14,6 +15,8 @@ export {
   lerIssue,
   listarIssuesCandidatas,
   listarIssuesEmEspera,
+  obterEstadoOperacionalIssue,
+  possuiLabelIssue,
   removerLabelIssue,
   type ComentarioGitHub,
   type IssueGitHub,

--- a/.sandcastle/github/issue.test.ts
+++ b/.sandcastle/github/issue.test.ts
@@ -1,5 +1,16 @@
-import { expect, it } from 'vitest';
-import { atualizarSecaoBlockedBy } from './issue';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const { executarGh, executarGhJson, executarGhSemErro } = vi.hoisted(() => ({
+  executarGh: vi.fn(),
+  executarGhJson: vi.fn(),
+  executarGhSemErro: vi.fn(),
+}));
+
+vi.mock('./base', () => ({
+  executarGh,
+  executarGhJson,
+  executarGhSemErro,
+}));
 
 const CORPO_BASE = [
   '## What to build',
@@ -77,20 +88,75 @@ const CORPO_ESPERADO_COM_SUBTITULO_PRESERVADO = [
   'Nao remover este trecho.',
 ].join('\n');
 
+async function importarModuloIssue() {
+  return import('./issue');
+}
+
 it('cria a secao no fim do corpo quando ela nao existe', () => {
-  expect(atualizarSecaoBlockedBy(CORPO_BASE, [49, 52])).toBe(CORPO_ESPERADO_COM_NOVA_SECAO);
+  return importarModuloIssue().then(({ atualizarSecaoBlockedBy }) => {
+    expect(atualizarSecaoBlockedBy(CORPO_BASE, [49, 52])).toBe(CORPO_ESPERADO_COM_NOVA_SECAO);
+  });
 });
 
 it('atualiza a secao existente sem duplicar o titulo', () => {
-  expect(atualizarSecaoBlockedBy(CORPO_COM_BLOCKED_BY, [52])).toBe(CORPO_ESPERADO_COM_SECAO_ATUALIZADA);
+  return importarModuloIssue().then(({ atualizarSecaoBlockedBy }) => {
+    expect(atualizarSecaoBlockedBy(CORPO_COM_BLOCKED_BY, [52])).toBe(CORPO_ESPERADO_COM_SECAO_ATUALIZADA);
+  });
 });
 
 it('preserva o restante do corpo ao encontrar subtitulos markdown apos a secao', () => {
-  expect(atualizarSecaoBlockedBy(CORPO_COM_SUBTITULO_APOS_BLOCKED_BY, [52])).toBe(
-    CORPO_ESPERADO_COM_SUBTITULO_PRESERVADO,
-  );
+  return importarModuloIssue().then(({ atualizarSecaoBlockedBy }) => {
+    expect(atualizarSecaoBlockedBy(CORPO_COM_SUBTITULO_APOS_BLOCKED_BY, [52])).toBe(
+      CORPO_ESPERADO_COM_SUBTITULO_PRESERVADO,
+    );
+  });
 });
 
 it('normaliza dependencias repetidas e ordena as referencias', () => {
-  expect(atualizarSecaoBlockedBy('', [52, 49, 52])).toBe(['## Blocked by', '', '- #49', '- #52'].join('\n'));
+  return importarModuloIssue().then(({ atualizarSecaoBlockedBy }) => {
+    expect(atualizarSecaoBlockedBy('', [52, 49, 52])).toBe(['## Blocked by', '', '- #49', '- #52'].join('\n'));
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it('prioriza blocked sobre running, waiting e run', () => {
+  return importarModuloIssue().then(({ obterEstadoOperacionalIssue }) => {
+    expect(
+      obterEstadoOperacionalIssue({
+        labels: [
+          { name: 'sandcastle:run' },
+          { name: 'sandcastle:waiting' },
+          { name: 'sandcastle:running' },
+          { name: 'sandcastle:blocked' },
+        ],
+      }),
+    ).toBe('blocked');
+  });
+});
+
+it('lista como candidatas apenas issues efetivamente em run', () => {
+  executarGhJson.mockReturnValue([
+    { number: 1, labels: [{ name: 'sandcastle:run' }] },
+    { number: 2, labels: [{ name: 'sandcastle:run' }, { name: 'sandcastle:waiting' }] },
+    { number: 3, labels: [{ name: 'sandcastle:run' }, { name: 'sandcastle:blocked' }] },
+  ]);
+
+  return importarModuloIssue().then(({ listarIssuesCandidatas }) => {
+    expect(listarIssuesCandidatas()).toEqual([{ number: 1, labels: [{ name: 'sandcastle:run' }] }]);
+  });
+});
+
+it('lista como waiting apenas issues sem conflito com blocked ou running', () => {
+  executarGhJson.mockReturnValue([
+    { number: 1, labels: [{ name: 'sandcastle:waiting' }] },
+    { number: 2, labels: [{ name: 'sandcastle:waiting' }, { name: 'sandcastle:running' }] },
+    { number: 3, labels: [{ name: 'sandcastle:waiting' }, { name: 'sandcastle:blocked' }] },
+  ]);
+
+  return importarModuloIssue().then(({ listarIssuesEmEspera }) => {
+    expect(listarIssuesEmEspera()).toEqual([{ number: 1, labels: [{ name: 'sandcastle:waiting' }] }]);
+  });
 });

--- a/.sandcastle/github/issue.ts
+++ b/.sandcastle/github/issue.ts
@@ -5,6 +5,12 @@ export const LABEL_EXECUTANDO_SANDCASTLE = 'sandcastle:running';
 export const LABEL_BLOQUEIO_SANDCASTLE = 'sandcastle:blocked';
 export const LABEL_ESPERA_SANDCASTLE = 'sandcastle:waiting';
 const TITULO_SECAO_BLOCKED_BY = '## Blocked by';
+const LABELS_ESTADO_PRIORIZADOS = [
+  LABEL_BLOQUEIO_SANDCASTLE,
+  LABEL_EXECUTANDO_SANDCASTLE,
+  LABEL_ESPERA_SANDCASTLE,
+  LABEL_EXECUCAO_SANDCASTLE,
+] as const;
 
 export interface IssueGitHub {
   number: number;
@@ -24,8 +30,10 @@ export interface ComentarioGitHub {
   author: { login: string };
 }
 
+export type EstadoOperacionalIssue = 'blocked' | 'running' | 'waiting' | 'run' | 'neutro';
+
 export function listarIssuesCandidatas(limite = 100): IssueGitHub[] {
-  return executarGhJson([
+  const issues = executarGhJson([
     'issue',
     'list',
     '--state',
@@ -37,10 +45,12 @@ export function listarIssuesCandidatas(limite = 100): IssueGitHub[] {
     '--json',
     'number,title,body,state,createdAt,updatedAt,labels',
   ]) as IssueGitHub[];
+
+  return issues.filter((issue) => obterEstadoOperacionalIssue(issue) === 'run');
 }
 
 export function listarIssuesEmEspera(limite = 100): IssueGitHub[] {
-  return executarGhJson([
+  const issues = executarGhJson([
     'issue',
     'list',
     '--state',
@@ -52,6 +62,8 @@ export function listarIssuesEmEspera(limite = 100): IssueGitHub[] {
     '--json',
     'number,title,body,state,createdAt,updatedAt,labels',
   ]) as IssueGitHub[];
+
+  return issues.filter((issue) => obterEstadoOperacionalIssue(issue) === 'waiting');
 }
 
 export function lerIssue(numero: number): IssueGitHub {
@@ -149,10 +161,31 @@ export function comentarIssue(numero: number, comentario: string): void {
   executarGh(['issue', 'comment', String(numero), '--body', comentario]);
 }
 
+export function obterEstadoOperacionalIssue(issue: Pick<IssueGitHub, 'labels'>): EstadoOperacionalIssue {
+  const label = LABELS_ESTADO_PRIORIZADOS.find((item) => possuiLabelIssue(issue, item));
+
+  switch (label) {
+    case LABEL_BLOQUEIO_SANDCASTLE:
+      return 'blocked';
+    case LABEL_EXECUTANDO_SANDCASTLE:
+      return 'running';
+    case LABEL_ESPERA_SANDCASTLE:
+      return 'waiting';
+    case LABEL_EXECUCAO_SANDCASTLE:
+      return 'run';
+    default:
+      return 'neutro';
+  }
+}
+
 export function issueEhPullRequest(numero: number): boolean {
   const resultado = executarGhSemErro(['pr', 'view', String(numero), '--json', 'number']);
 
   return resultado.status === 0;
+}
+
+export function possuiLabelIssue(issue: Pick<IssueGitHub, 'labels'>, label: string): boolean {
+  return issue.labels.some((item) => item.name === label);
 }
 
 function erroLabelAusente(resultado: ResultadoGh): boolean {

--- a/.sandcastle/processadores/issue-estado.test.ts
+++ b/.sandcastle/processadores/issue-estado.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const lerComentariosIssue = vi.fn();
+const listarIssuesCandidatas = vi.fn();
+const obterEstadoOperacionalIssue = vi.fn();
+
+vi.mock('../github', () => ({
+  LABEL_BLOQUEIO_SANDCASTLE: 'sandcastle:blocked',
+  LABEL_EXECUCAO_SANDCASTLE: 'sandcastle:run',
+  LABEL_EXECUTANDO_SANDCASTLE: 'sandcastle:running',
+  LABEL_ESPERA_SANDCASTLE: 'sandcastle:waiting',
+  adicionarLabelIssue: vi.fn(),
+  lerComentariosIssue,
+  lerIssue: vi.fn(),
+  listarIssuesCandidatas,
+  obterEstadoOperacionalIssue,
+  removerLabelIssue: vi.fn(),
+}));
+
+vi.mock('../runner', () => ({
+  lerArquivo: vi.fn(() => 'prompt-base'),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  obterEstadoOperacionalIssue.mockImplementation((issue: { labels?: { name: string }[] }) => {
+    const labels = issue.labels?.map((label) => label.name) ?? [];
+
+    if (labels.includes('sandcastle:blocked')) {
+      return 'blocked';
+    }
+
+    if (labels.includes('sandcastle:running')) {
+      return 'running';
+    }
+
+    if (labels.includes('sandcastle:waiting')) {
+      return 'waiting';
+    }
+
+    if (labels.includes('sandcastle:run')) {
+      return 'run';
+    }
+
+    return 'neutro';
+  });
+});
+
+describe('elegibilidade de issues', () => {
+  it('recusa item waiting mesmo se o runner tentar carregá-lo com run junto', async () => {
+    const { adaptadorIssue } = await import('./issue');
+
+    expect(
+      adaptadorIssue.avaliarElegibilidade({
+        number: 54,
+        state: 'OPEN',
+        labels: [{ name: 'sandcastle:run' }, { name: 'sandcastle:waiting' }],
+      }),
+    ).toContain('sandcastle:waiting');
+  });
+});

--- a/.sandcastle/processadores/issue.test.ts
+++ b/.sandcastle/processadores/issue.test.ts
@@ -125,16 +125,16 @@ describe('reavaliacao de issues ainda bloqueadas', () => {
 
   it('nao altera issue em espera que tambem esteja em execucao', async () => {
     mockIssueEmEspera('## Blocked by\n\n- #10', ['sandcastle:waiting', 'sandcastle:running']);
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     esperarIssueEmEspera();
   });
 
   it('nao reativa issue em espera quando ela tambem esta bloqueada manualmente', async () => {
     mockIssueEmEspera('## Blocked by\n\n- #10', ['sandcastle:waiting', 'sandcastle:blocked']);
     lerIssue.mockReturnValue({ number: 10, state: 'CLOSED' });
-    const reavaliar = await importarReavaliacao();
-    reavaliar();
+    const { reavaliarIssuesEmEspera } = await importarReavaliacao();
+    reavaliarIssuesEmEspera();
     esperarIssueEmEspera();
   });
 });

--- a/.sandcastle/processadores/issue.test.ts
+++ b/.sandcastle/processadores/issue.test.ts
@@ -7,6 +7,7 @@ const lerComentariosIssue = vi.fn();
 const lerIssue = vi.fn();
 const listarIssuesEmEspera = vi.fn();
 const listarIssuesCandidatas = vi.fn();
+const obterEstadoOperacionalIssue = vi.fn();
 const removerLabelIssue = vi.fn();
 
 vi.mock('../github', () => ({
@@ -21,6 +22,7 @@ vi.mock('../github', () => ({
   lerIssue,
   listarIssuesEmEspera,
   listarIssuesCandidatas,
+  obterEstadoOperacionalIssue,
   removerLabelIssue,
 }));
 
@@ -31,13 +33,37 @@ vi.mock('../runner', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   issueEhPullRequest.mockReturnValue(false);
+  obterEstadoOperacionalIssue.mockImplementation(calcularEstadoOperacional);
 });
 
-function mockIssueEmEspera(body = '## Blocked by\n\n- #50\n- #49\n') {
+function calcularEstadoOperacional(issue: { labels?: { name: string }[] }) {
+  const labels = issue.labels?.map((label) => label.name) ?? [];
+
+  if (labels.includes('sandcastle:blocked')) {
+    return 'blocked';
+  }
+
+  if (labels.includes('sandcastle:running')) {
+    return 'running';
+  }
+
+  if (labels.includes('sandcastle:waiting')) {
+    return 'waiting';
+  }
+
+  if (labels.includes('sandcastle:run')) {
+    return 'run';
+  }
+
+  return 'neutro';
+}
+
+function mockIssueEmEspera(body = '## Blocked by\n\n- #50\n- #49\n', labels = ['sandcastle:waiting']) {
   listarIssuesEmEspera.mockReturnValue([
     {
       number: 51,
       body,
+      labels: labels.map((name) => ({ name })),
     },
   ]);
 }
@@ -94,6 +120,21 @@ describe('reavaliacao de issues ainda bloqueadas', () => {
     const reavaliar = await importarReavaliacao();
     reavaliar();
 
+    esperarIssueEmEspera();
+  });
+
+  it('nao altera issue em espera que tambem esteja em execucao', async () => {
+    mockIssueEmEspera('## Blocked by\n\n- #10', ['sandcastle:waiting', 'sandcastle:running']);
+    const reavaliar = await importarReavaliacao();
+    reavaliar();
+    esperarIssueEmEspera();
+  });
+
+  it('nao reativa issue em espera quando ela tambem esta bloqueada manualmente', async () => {
+    mockIssueEmEspera('## Blocked by\n\n- #10', ['sandcastle:waiting', 'sandcastle:blocked']);
+    lerIssue.mockReturnValue({ number: 10, state: 'CLOSED' });
+    const reavaliar = await importarReavaliacao();
+    reavaliar();
     esperarIssueEmEspera();
   });
 });

--- a/.sandcastle/processadores/issue.ts
+++ b/.sandcastle/processadores/issue.ts
@@ -1,11 +1,14 @@
 import {
+  type EstadoOperacionalIssue,
   LABEL_BLOQUEIO_SANDCASTLE,
   LABEL_EXECUCAO_SANDCASTLE,
   LABEL_EXECUTANDO_SANDCASTLE,
+  LABEL_ESPERA_SANDCASTLE,
   adicionarLabelIssue,
   lerComentariosIssue,
   lerIssue,
   listarIssuesCandidatas,
+  obterEstadoOperacionalIssue,
   removerLabelIssue,
   type ComentarioGitHub,
   type IssueGitHub,
@@ -50,16 +53,11 @@ function avaliarElegibilidade(issue: IssueGitHub): string | null {
     return `Issue #${String(issue.number)} nao esta aberta. Estado atual: ${issue.state}.`;
   }
 
-  if (possuiLabel(issue, LABEL_EXECUTANDO_SANDCASTLE)) {
-    return `Issue #${String(issue.number)} ja esta em execucao com a label ${LABEL_EXECUTANDO_SANDCASTLE}.`;
-  }
+  const estadoOperacional = obterEstadoOperacionalIssue(issue);
+  const motivoEstado = descreverEstadoNaoExecutavel(issue.number, estadoOperacional);
 
-  if (possuiLabel(issue, LABEL_BLOQUEIO_SANDCASTLE)) {
-    return `Issue #${String(issue.number)} esta bloqueada com a label ${LABEL_BLOQUEIO_SANDCASTLE}.`;
-  }
-
-  if (!possuiLabel(issue, LABEL_EXECUCAO_SANDCASTLE)) {
-    return `Issue #${String(issue.number)} nao esta liberada. Adicione a label ${LABEL_EXECUCAO_SANDCASTLE}.`;
+  if (motivoEstado) {
+    return motivoEstado;
   }
 
   return null;
@@ -130,6 +128,17 @@ function formatarLabels(issue: IssueGitHub): string {
   return issue.labels.map((label) => label.name).join(', ') || 'nenhuma';
 }
 
-function possuiLabel(issue: IssueGitHub, label: string): boolean {
-  return issue.labels.some((item) => item.name === label);
+function descreverEstadoNaoExecutavel(numero: number, estado: EstadoOperacionalIssue): string | null {
+  switch (estado) {
+    case 'running':
+      return `Issue #${String(numero)} ja esta em execucao com a label ${LABEL_EXECUTANDO_SANDCASTLE}.`;
+    case 'blocked':
+      return `Issue #${String(numero)} esta bloqueada com a label ${LABEL_BLOQUEIO_SANDCASTLE}.`;
+    case 'waiting':
+      return `Issue #${String(numero)} esta aguardando dependencias com a label ${LABEL_ESPERA_SANDCASTLE}.`;
+    case 'neutro':
+      return `Issue #${String(numero)} nao esta liberada. Adicione a label ${LABEL_EXECUCAO_SANDCASTLE}.`;
+    default:
+      return null;
+  }
 }

--- a/.sandcastle/processadores/reavaliacao-issue.ts
+++ b/.sandcastle/processadores/reavaliacao-issue.ts
@@ -7,6 +7,7 @@ import {
   issueEhPullRequest,
   lerIssue,
   listarIssuesEmEspera,
+  obterEstadoOperacionalIssue,
   removerLabelIssue,
   type IssueGitHub,
 } from '../github';
@@ -14,6 +15,10 @@ import { analisarBlockedBy } from './bloqueios-issue';
 
 export function reavaliarIssuesEmEspera(): void {
   for (const issue of listarIssuesEmEspera()) {
+    if (obterEstadoOperacionalIssue(issue) !== 'waiting') {
+      continue;
+    }
+
     const motivoBloqueio = avaliarBlockedByInvalido(issue);
 
     if (motivoBloqueio) {

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -44,6 +44,13 @@ Hoje o fluxo automatizado usa a pasta `.sandcastle/`, os scripts do `package.jso
 - `sandcastle:waiting`: issue temporariamente fora da fila porque depende de outra issue aberta.
 - `sandcastle:blocked`: issue bloqueada por problema operacional ou bloqueio manual de escopo.
 
+Precedência operacional entre labels conflitantes:
+
+- `sandcastle:blocked` prevalece sobre qualquer reativação automática.
+- `sandcastle:running` prevalece sobre `sandcastle:waiting`; a reavaliação de espera não altera issues já em execução.
+- `sandcastle:waiting` prevalece sobre `sandcastle:run`; uma issue aguardando dependências não entra na fila executável.
+- O cron e o processador de issue aplicam a mesma precedência ao reavaliar waiting, montar a fila e adquirir lock.
+
 Quando o agente identificar dependência de outra issue aberta, ele deve usar `sandcastle:waiting`, remover `sandcastle:run`, registrar os bloqueadores no campo canônico `## Blocked by` e comentar objetivamente quais bloqueadores seguem abertos e por que a issue entrou em espera.
 
 Antes de montar a fila executável, o cron também reavalia issues em `sandcastle:waiting` como fail-safe. Se a seção `## Blocked by` estiver ausente, duplicada, vazia, ilegível, apontando para PR ou incompatível com o fluxo automático, a issue sai de `sandcastle:waiting`, entra em `sandcastle:blocked` e recebe um comentário curto com o motivo e a correção esperada.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -17,3 +17,7 @@ Estados operacionais do Sandcastle fora da triagem canônica:
 - `sandcastle:running`: item atualmente em execução.
 - `sandcastle:waiting`: item aguardando dependência de outra issue aberta; deve sair da fila do agente sem virar bloqueio manual.
 - `sandcastle:blocked`: item bloqueado por ambiente ou por bloqueio manual de escopo.
+
+Quando esses labels aparecem juntos por transição incompleta ou corrida, a precedência operacional é:
+
+- `sandcastle:blocked` > `sandcastle:running` > `sandcastle:waiting` > `sandcastle:run`


### PR DESCRIPTION
## Resumo

- centraliza a precedencia entre `sandcastle:blocked`, `sandcastle:running`, `sandcastle:waiting` e `sandcastle:run`
- impede que a reavaliacao de waiting altere issues em execucao ou bloqueadas\n- documenta a precedencia operacional e cobre os conflitos com testes

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an operational state model for issues based on label prioritization, with `blocked` status taking precedence over other states when multiple labels are present.
  * Improved issue filtering logic to ensure only eligible issues are selected for execution or queued as waiting.

* **Documentation**
  * Added documentation clarifying Sandcastle label precedence and operational status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->