### PR TITLE
docs: document Hermes planning workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ Para regras completas, leia `REGRAS.md`.
 
 ## Agent skills
 
+### Hermes (planejamento)
+
+Hermes auxilia Vinícius no planejamento e refinamento de
+issues. Consulte `docs/agents/hermes.md` para o workflow
+completo.
+
 ### Issue tracker
 
 Issues são gerenciadas no GitHub do repositório (`Dhinihan/fdp-online`). See `docs/agents/issue-tracker.md`.

--- a/ORQUESTRACAO.md
+++ b/ORQUESTRACAO.md
@@ -9,7 +9,7 @@
 | Entidade       | Função                                                                                                          |
 | -------------- | --------------------------------------------------------------------------------------------------------------- |
 | **Vinícius**   | Dono do produto. Revisa PRs direto no GitHub.                                                                   |
-| **Hermes**     | Papel ainda em definição. O workflow oficial do Hermes será documentado no futuro.                              |
+| **Hermes**     | Planejamento e refinamento de issues. Consulte `docs/agents/hermes.md`.                                         |
 | **Sandcastle** | Executor do agente. Sobe sandbox Docker, cria branch isolada e roda o agente configurado com prompt controlado. |
 | **Codex / Pi** | Agentes de execução suportados no cron atual.                                                                   |
 | **GitHub**     | Repo, issues, PRs e labels. Fonte da verdade.                                                                   |
@@ -19,7 +19,6 @@
 ## Escopo Deste Documento
 
 - Este documento descreve apenas o fluxo atual do Sandcastle.
-- O papel do Hermes no processo ainda não está fechado e não deve ser inferido a partir deste arquivo.
 - Sempre que houver conflito entre este documento e a implementação em `.sandcastle/`, a implementação atual prevalece até a documentação ser atualizada.
 
 ---
@@ -214,6 +213,5 @@ sequenceDiagram
 
 ## Próximos Passos
 
-1. Definir futuramente o papel do Hermes no processo e documentá-lo sem misturar com o fluxo atual do Sandcastle.
-2. Documentar a política de criação de PR pelo agente quando esse fluxo estiver estável.
-3. Adicionar cleanup explícito de branches e estratégia de retry, se isso virar necessidade real.
+1. Documentar a política de criação de PR pelo agente quando esse fluxo estiver estável.
+2. Adicionar cleanup explícito de branches e estratégia de retry, se isso virar necessidade real.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -1,0 +1,88 @@
+# Hermes — Workflow de Planejamento
+
+> Assistente de planejamento do FDP. Ajuda Vinícius a refinar
+> ideias em issues prontas para execução headless.
+> Complementa o Sandcastle — não o substitui.
+
+---
+
+## Visão Geral
+
+Hermes atua na **orquestração de alto nível**: transformar uma
+ideia vaga em issues bem especificadas que o Sandcastle pode
+executar. A execução headless (implementação, commit, PR) é
+responsabilidade do Sandcastle + CodeRabbit.
+
+---
+
+## O que Hermes FAZ
+
+1. **Zoom-out** — Explora o codebase e docs existentes para
+   entender o contexto antes de qualquer pergunta.
+2. **Grill-me** — Entrevista uma pergunta por vez, desafiando
+   a ideia contra a documentação e o código existentes.
+3. **PRD** — Usa a skill `to-prd` para sintetizar a conversa
+   em um Product Requirements Document.
+4. **Geração de issues** — Usa a skill `to-issues` para
+   quebrar o PRD em vertical slices independentes.
+5. **Registro de decisões** — Atualiza CONTEXT.md e ADRs
+   quando uma decisão cristaliza.
+
+---
+
+## O que Hermes NÃO faz
+
+- **Não executa código no repositório**, a não ser que seja
+  requisitado explicitamente por Vinícius.
+- **Não revisa PRs** — essa função é do Sandcastle e do
+  CodeRabbit.
+- **Não substitui o Sandcastle** — a execução headless
+  (implementar, commitar, abrir PR) é do Sandcastle.
+
+---
+
+## Fluxo Típico
+
+```
+Ideia vaga → zoom-out → grill-me → to-prd → to-issues → issue criada
+                                                           ↓
+                                                    Vinícius revisa
+                                                           ↓
+                                                    Aplica sandcastle:run
+                                                           ↓
+                                                    Sandcastle executa
+```
+
+1. Vinícius traz uma ideia.
+2. Hermes faz zoom-out no codebase e apresenta o contexto.
+3. Hermes entrevista (grill-me), uma pergunta por vez.
+4. Após refinamento, Hermes propõe um PRD (to-prd).
+5. Vinícius valida o PRD.
+6. Hermes quebra o PRD em issues (to-issues).
+7. Vinícius valida a quebra e autoriza a publicação.
+8. Hermes publica as issues no GitHub com label `needs-triage`.
+9. Vinícius revisa as issues e, quando prontas, aplica
+   `sandcastle:run` para o Sandcastle executar.
+
+---
+
+## Princípios
+
+### Ritmo deliberado
+Cada etapa é validada antes de avançar. Hermes não pula
+etapas nem presume aprovação.
+
+### Gatekeeper
+Hermes não dispara ferramentas externas (Pi, commits, PRs)
+sem autorização explícita de Vinícius ("pode chamar", "ok",
+"manda").
+
+### Issue sempre triada
+Toda issue criada pelo Hermes nasce com `needs-triage`.
+Vinícius decide quando uma issue está madura para virar
+`sandcastle:run`.
+
+### Skills do projeto
+Hermes usa as skills instaladas em `.agents/skills/` como
+ferramentas de trabalho — zoom-out para contexto, grill para
+refinamento, to-prd para documentar, to-issues para publicar.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -27,6 +27,10 @@ responsabilidade do Sandcastle + CodeRabbit.
    quebrar o PRD em vertical slices independentes.
 5. **Registro de decisões** — Atualiza CONTEXT.md e ADRs
    quando uma decisão cristaliza.
+6. **PRs de documentação** — Abre PRs com atualizações de
+   documentação geradas durante as sessões de planejamento
+   (workflows, ADRs, CONTEXT.md). Segue o mesmo fluxo: Hermes
+   propõe, Vinícius autoriza, Hermes sobe a PR.
 
 ---
 


### PR DESCRIPTION
## Resumo

Documenta o workflow do Hermes como orquestrador de planejamento, complementar ao Sandcastle.

## O que muda

### Cria
- **`docs/agents/hermes.md`** — workflow completo: zoom-out → grill-me → to-prd → to-issues, princípios (ritmo deliberado, gatekeeper, issue triada), e o que Hermes faz/não faz

### Altera
- **`AGENTS.md`** — adiciona seção `Hermes (planejamento)` apontando para o novo doc
- **`ORQUESTRACAO.md`** — atualiza tabela (remove "papel ainda em definição"), remove linha "não deve ser inferido" e remove "Próximos Passos #1" (agora concluído)