### PR TITLE
feat: embaralhamento com Fisher-Yates

### DIFF
--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -1,5 +1,5 @@
 import { Scene } from 'phaser';
-import { criarBaralho, distribuir } from '@/core/Baralho';
+import { criarBaralho, distribuir, embaralhar } from '@/core/Baralho';
 import type { Jogador } from '@/types/entidades';
 import type { MaoJogador } from '@/types/estado-partida';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
@@ -42,7 +42,7 @@ export class JogoScene extends Scene {
   }
 
   private montarMaos(): MaoJogador[] {
-    const cartas = distribuir(criarBaralho(), 4, 4);
+    const cartas = distribuir(embaralhar(criarBaralho()), 4, 4);
     return JOGADORES.map((jogador, i) => ({
       jogador,
       cartas: cartas[i],

--- a/src/core/Baralho.ts
+++ b/src/core/Baralho.ts
@@ -13,6 +13,15 @@ export function criarBaralho(): Carta[] {
   return baralho;
 }
 
+export function embaralhar(baralho: Carta[]): Carta[] {
+  const copia = [...baralho];
+  for (let i = copia.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copia[i], copia[j]] = [copia[j], copia[i]];
+  }
+  return copia;
+}
+
 export function distribuir(cartas: Carta[], numeroCartas: number, numeroJogadores: number): Carta[][] {
   if (numeroCartas * numeroJogadores > cartas.length) {
     throw new Error(

--- a/tests/core/Baralho.test.ts
+++ b/tests/core/Baralho.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { criarBaralho, distribuir } from '@/core/Baralho';
+import { criarBaralho, distribuir, embaralhar } from '@/core/Baralho';
 
 describe('criarBaralho', () => {
   it('deve retornar 52 cartas', () => {
@@ -17,6 +17,30 @@ describe('criarBaralho', () => {
     const baralho = criarBaralho();
     expect(baralho[0]).toEqual({ valor: '3', naipe: '♣' });
     expect(baralho[51]).toEqual({ valor: '4', naipe: '♦' });
+  });
+});
+
+describe('embaralhar', () => {
+  it('deve preservar as 52 cartas (mesmo multiset)', () => {
+    const baralho = criarBaralho();
+    const embaralhado = embaralhar(baralho);
+    const chavesOriginal = baralho.map((c) => `${c.valor}${c.naipe}`).sort();
+    const chavesEmbaralhado = embaralhado.map((c) => `${c.valor}${c.naipe}`).sort();
+    expect(chavesEmbaralhado).toEqual(chavesOriginal);
+  });
+
+  it('deve produzir ordens diferentes em chamadas consecutivas', () => {
+    const baralho = criarBaralho();
+    const resultados: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      resultados.push(
+        embaralhar(baralho)
+          .map((c) => `${c.valor}${c.naipe}`)
+          .join(','),
+      );
+    }
+    const unicos = new Set(resultados);
+    expect(unicos.size).toBeGreaterThan(1);
   });
 });
 


### PR DESCRIPTION
Closes #75

- Adiciona `embaralhar(baralho)` no `Baralho.ts` usando Fisher-Yates
- Integra no fluxo de JogoScene: criar → embaralhar → distribuir → renderizar
- Expande `Baralho.test.ts` com testes de permutação e variabilidade