### PR TITLE
feat: calcula vencedor de turno, acumula vazas e encerra rodada

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,14 @@ export default defineConfig(
       globals: { ...globals.browser },
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['*.config.js', 'tests/*.test.ts', 'tests/core/*.test.ts', 'tests/e2e/*.spec.ts'],
+          allowDefaultProject: [
+            '*.config.js',
+            'tests/*.test.ts',
+            'tests/core/*.test.ts',
+            'tests/core/*.ts',
+            'tests/e2e/*.spec.ts',
+          ],
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 16,
           noWarnOnMultipleProjects: true,
         },
         tsconfigRootDir: import.meta.dirname,

--- a/src/adapters/phaser/factories/partida-factory.ts
+++ b/src/adapters/phaser/factories/partida-factory.ts
@@ -1,0 +1,31 @@
+import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
+import { Partida } from '@/core/Partida';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { Jogador } from '@/types/entidades';
+
+export interface CallbacksPartida {
+  onCartaJogada: () => void;
+  onTurnoGanho: (jogadorId: string) => void;
+  onRodadaEncerrada: () => void;
+}
+
+export function fabricarPartida(
+  jogadores: Jogador[],
+  decisorHumano: DecisorJogada,
+  callbacks: CallbacksPartida,
+): Partida {
+  const emissor = createEmissorEventos();
+  emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
+  emissor.on('TURNO_GANHO', (evento) => {
+    callbacks.onTurnoGanho(evento.jogadorId);
+  });
+  emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
+  const decisores = new Map<string, DecisorJogada>([
+    ['humano', decisorHumano],
+    ['bot1', new BotDeterministico()],
+    ['bot2', new BotDeterministico()],
+    ['bot3', new BotDeterministico()],
+  ]);
+  return new Partida(jogadores, decisores, emissor);
+}

--- a/src/adapters/phaser/input/input-humano.ts
+++ b/src/adapters/phaser/input/input-humano.ts
@@ -18,7 +18,10 @@ export function configurarInteracaoHumano(config: ConfigInteracaoHumano): void {
   objetosMao.forEach((objeto, j) => {
     const container = objeto as Phaser.GameObjects.Container;
     container.setInteractive();
-    const carta = cartas[j];
+    const carta = cartas.at(j);
+    if (!carta) {
+      return;
+    }
     container.setData('carta', carta);
     container.on('pointerdown', () => {
       aoClicarCarta({ cena, container, carta, partida, decisorHumano, destaque });

--- a/src/adapters/phaser/input/input-humano.ts
+++ b/src/adapters/phaser/input/input-humano.ts
@@ -1,0 +1,70 @@
+import type { Scene } from 'phaser';
+import type { Carta } from '@/core/Carta';
+import type { Partida } from '@/core/Partida';
+import type { DecisorHumano } from '../DecisorHumano';
+import { destacarCarta, removerDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
+
+export interface ConfigInteracaoHumano {
+  cena: Scene;
+  objetosMao: Phaser.GameObjects.GameObject[];
+  cartas: Carta[];
+  partida: Partida;
+  decisorHumano: DecisorHumano;
+  destaque: EstadoDestaque;
+}
+
+export function configurarInteracaoHumano(config: ConfigInteracaoHumano): void {
+  const { cena, objetosMao, cartas, partida, decisorHumano, destaque } = config;
+  objetosMao.forEach((objeto, j) => {
+    const container = objeto as Phaser.GameObjects.Container;
+    container.setInteractive();
+    const carta = cartas[j];
+    container.setData('carta', carta);
+    container.on('pointerdown', () => {
+      aoClicarCarta({ cena, container, carta, partida, decisorHumano, destaque });
+    });
+  });
+}
+
+export interface ConfigFundo {
+  cena: Scene;
+  objetos: Phaser.GameObjects.GameObject[];
+  decisorHumano: DecisorHumano;
+  destaque: EstadoDestaque;
+}
+
+export function criarFundoInterativo(config: ConfigFundo): void {
+  const { cena, objetos, decisorHumano, destaque } = config;
+  const { width: largura, height: altura } = cena.cameras.main;
+  const fundo = cena.add
+    .rectangle(largura / 2, altura / 2, largura, altura, 0x000000, 0)
+    .setInteractive()
+    .setDepth(-100);
+  objetos.push(fundo);
+  fundo.on('pointerdown', () => {
+    decisorHumano.desmarcar();
+    removerDestaque(destaque);
+  });
+}
+
+interface ConfigClicarCarta {
+  cena: Scene;
+  container: Phaser.GameObjects.Container;
+  carta: Carta;
+  partida: Partida;
+  decisorHumano: DecisorHumano;
+  destaque: EstadoDestaque;
+}
+
+function aoClicarCarta(config: ConfigClicarCarta): void {
+  const { cena, container, carta, partida, decisorHumano, destaque } = config;
+  if (partida.estado.maos[partida.estado.jogadorAtual].jogador.id !== 'humano') {
+    return;
+  }
+  if (destaque.container === container) {
+    decisorHumano.confirmar();
+    return;
+  }
+  decisorHumano.selecionar(carta);
+  destacarCarta(cena, container, destaque);
+}

--- a/src/adapters/phaser/renderers/turno-renderer.ts
+++ b/src/adapters/phaser/renderers/turno-renderer.ts
@@ -1,0 +1,73 @@
+import type { Scene } from 'phaser';
+
+export interface ConfigIndicadorVez {
+  cena: Scene;
+  labels: Phaser.GameObjects.Text[];
+  jogadorAtual: number;
+  tweenAtual?: Phaser.Tweens.Tween;
+}
+
+export function atualizarIndicadorVez(config: ConfigIndicadorVez): Phaser.Tweens.Tween {
+  const { cena, labels, jogadorAtual, tweenAtual } = config;
+  labels.forEach((label, i) => {
+    label.setColor(i === jogadorAtual ? '#ffff00' : '#ffffff');
+  });
+  if (tweenAtual) {
+    tweenAtual.stop();
+    tweenAtual.remove();
+  }
+  return cena.tweens.add({
+    targets: labels[jogadorAtual],
+    scale: { from: 1, to: 1.2 },
+    duration: 500,
+    yoyo: true,
+    repeat: -1,
+    ease: 'Sine.easeInOut',
+  });
+}
+
+export interface ConfigAnimarTurno {
+  cena: Scene;
+  labels: Phaser.GameObjects.Text[];
+  jogadores: { id: string }[];
+  vencedorId?: string;
+  mesaObjetos: Phaser.GameObjects.GameObject[];
+}
+
+export function animarRecolhimentoTurno(config: ConfigAnimarTurno): void {
+  const { cena, labels, jogadores, vencedorId, mesaObjetos } = config;
+  if (vencedorId) {
+    const indice = jogadores.findIndex((j) => j.id === vencedorId);
+    if (indice >= 0) {
+      const label = labels[indice];
+      cena.tweens.add({
+        targets: label,
+        scale: 1.4,
+        duration: 300,
+        yoyo: true,
+        ease: 'Sine.easeInOut',
+      });
+    }
+  }
+  mesaObjetos.forEach((obj) => {
+    cena.tweens.add({
+      targets: obj,
+      alpha: 0,
+      duration: 400,
+      onComplete: () => {
+        obj.destroy();
+      },
+    });
+  });
+}
+
+export function mostrarOverlayRodadaConcluida(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): void {
+  const cx = cena.cameras.main.width / 2;
+  const cy = cena.cameras.main.height / 2;
+  const fundo = cena.add.rectangle(cx, cy, 320, 80, 0x000000, 0.7).setDepth(200);
+  const texto = cena.add
+    .text(cx, cy, 'Rodada concluída', { fontSize: '24px', color: '#ffffff' })
+    .setOrigin(0.5)
+    .setDepth(201);
+  objetos.push(fundo, texto);
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -1,16 +1,20 @@
 import { Scene } from 'phaser';
-import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
-import type { Carta } from '@/core/Carta';
 import { Partida } from '@/core/Partida';
-import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
 import type { MaoJogador } from '@/types/estado-partida';
 import { DecisorHumano } from '../DecisorHumano';
+import { fabricarPartida } from '../factories/partida-factory';
+import { configurarInteracaoHumano, criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
-import { destacarCarta, destruirDestaque, removerDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
+import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 import { renderizarLabel, renderizarMao } from '../renderers/mao-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
 import { calcularPosicoes } from '../renderers/posicoes-mao';
+import {
+  animarRecolhimentoTurno,
+  atualizarIndicadorVez,
+  mostrarOverlayRodadaConcluida,
+} from '../renderers/turno-renderer';
 
 const JOGADORES: Jogador[] = [
   { id: 'humano', nome: 'Você', pontos: 5 },
@@ -33,6 +37,8 @@ export class JogoScene extends Scene {
   private partida?: Partida;
   private labels: Phaser.GameObjects.Text[] = [];
   private tweenVez?: Phaser.Tweens.Tween;
+  private turnoAnterior = 1;
+  private vencedorTurno?: string;
 
   constructor() {
     super({ key: 'JogoScene' });
@@ -42,7 +48,8 @@ export class JogoScene extends Scene {
     this.cameras.main.setBackgroundColor('#1a1a2e');
     this.partida = this.criarPartida();
     this.partida.distribuir(4);
-    this.desenharMaos(this.partida.estado.maos);
+    this.turnoAnterior = 1;
+    this.desenharMaos(this.partida.estado.maos, this.partida);
     this.atualizarIndicadorVez();
     void this.iniciarProcessamentoTurno();
     this.redesenhar = criarDebounceResize(this, this.redesenharTela);
@@ -51,25 +58,30 @@ export class JogoScene extends Scene {
   }
 
   private criarPartida(): Partida {
-    const emissor = createEmissorEventos();
-    emissor.on('CARTA_JOGADA', () => {
-      this.redesenharTela();
+    return fabricarPartida(JOGADORES, this.decisorHumano, {
+      onCartaJogada: () => {
+        this.redesenharTela();
+      },
+      onTurnoGanho: (id) => {
+        this.vencedorTurno = id;
+      },
+      onRodadaEncerrada: () => {
+        this.mostrarOverlayRodadaConcluida();
+      },
     });
-    const decisores = new Map<string, import('@/core/portas/DecisorJogada').DecisorJogada>([
-      ['humano', this.decisorHumano],
-      ['bot1', new BotDeterministico()],
-      ['bot2', new BotDeterministico()],
-      ['bot3', new BotDeterministico()],
-    ]);
-    return new Partida(JOGADORES, decisores, emissor);
   }
 
   private async iniciarProcessamentoTurno(): Promise<void> {
-    while (this.partida && this.partida.estado.fase !== 'turnoConcluido') {
+    while (this.partida && this.partida.estado.fase !== 'rodadaConcluida') {
       const jogadorAtual = this.partida.estado.jogadorAtual;
       const ehBot = this.partida.estado.maos[jogadorAtual].jogador.id !== 'humano';
       if (ehBot) await this.esperar(500);
       await this.partida.jogarTurno();
+      if (this.partida.estado.turno > this.turnoAnterior) {
+        this.turnoAnterior = this.partida.estado.turno;
+        this.animarRecolhimentoTurno();
+        await this.esperar(800);
+      }
       this.atualizarIndicadorVez();
     }
   }
@@ -80,42 +92,32 @@ export class JogoScene extends Scene {
 
   private atualizarMesa(): void {
     this.limparMesa();
-    if (this.partida) renderizarMesa({ cena: this, mesa: this.partida.estado.mesa, objetos: this.mesaObjetos });
+    if (!this.partida) return;
+    const cartas = this.partida.estado.mesa.map((m) => m.carta);
+    renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos });
   }
 
   private atualizarIndicadorVez(): void {
-    this.labels.forEach((label, i) => {
-      label.setColor(this.partida && i === this.partida.estado.jogadorAtual ? '#ffff00' : '#ffffff');
+    if (!this.partida) return;
+    this.tweenVez = atualizarIndicadorVez({
+      cena: this,
+      labels: this.labels,
+      jogadorAtual: this.partida.estado.jogadorAtual,
+      tweenAtual: this.tweenVez,
     });
-    if (this.tweenVez) {
-      this.tweenVez.stop();
-      this.tweenVez.remove();
-      this.tweenVez = undefined;
-    }
-    if (this.partida) {
-      this.tweenVez = this.tweens.add({
-        targets: this.labels[this.partida.estado.jogadorAtual],
-        scale: { from: 1, to: 1.2 },
-        duration: 500,
-        yoyo: true,
-        repeat: -1,
-        ease: 'Sine.easeInOut',
-      });
-    }
   }
 
   private redesenharTela = (): void => {
     destruirDestaque(this.destaque);
     this.limparObjetos();
     this.limparMesa();
-    if (this.partida) {
-      this.desenharMaos(this.partida.estado.maos);
-      this.atualizarMesa();
-      this.atualizarIndicadorVez();
-    }
+    if (!this.partida) return;
+    this.desenharMaos(this.partida.estado.maos, this.partida);
+    this.atualizarMesa();
+    this.atualizarIndicadorVez();
   };
 
-  private desenharMaos(maos: MaoJogador[]): void {
+  private desenharMaos(maos: MaoJogador[], partida: Partida): void {
     this.labels = [];
     const posicoes = calcularPosicoes({
       largura: this.cameras.main.width,
@@ -126,57 +128,37 @@ export class JogoScene extends Scene {
       alturaCarta: ALTURA_CARTA,
     });
     maos.forEach((mao, i) => {
-      const p = posicoes[i];
-      const label = renderizarLabel({ cena: this, x: p.labelX, y: p.labelY, texto: mao.jogador.nome });
-      label.setDepth(10);
-      this.objetos.push(label);
-      this.labels.push(label);
-      const objetosMao = renderizarMao({ cena: this, posicao: p.mao, cartas: mao.cartas, visivel: mao.visivel });
-      this.objetos.push(...objetosMao);
-      if (mao.jogador.id === 'humano') this.configurarInteracaoHumano(objetosMao, mao.cartas);
+      this.desenharMao(mao, posicoes[i], partida);
     });
-    this.criarFundoInterativo();
-  }
-
-  private criarFundoInterativo(): void {
-    const { width: largura, height: altura } = this.cameras.main;
-    const fundo = this.add
-      .rectangle(largura / 2, altura / 2, largura, altura, 0x000000, 0)
-      .setInteractive()
-      .setDepth(-100);
-    this.objetos.push(fundo);
-    fundo.on('pointerdown', () => {
-      this.aoClicarFundo();
+    criarFundoInterativo({
+      cena: this,
+      objetos: this.objetos,
+      decisorHumano: this.decisorHumano,
+      destaque: this.destaque,
     });
   }
 
-  private configurarInteracaoHumano(objetosMao: Phaser.GameObjects.GameObject[], cartas: Carta[]): void {
-    objetosMao.forEach((objeto, j) => {
-      const container = objeto as Phaser.GameObjects.Container;
-      container.setInteractive();
-      const carta = cartas[j];
-      container.setData('carta', carta);
-      container.on('pointerdown', () => {
-        this.aoClicarCarta(container, carta);
+  private desenharMao(mao: MaoJogador, posicao: ReturnType<typeof calcularPosicoes>[number], partida: Partida): void {
+    const label = renderizarLabel({
+      cena: this,
+      x: posicao.labelX,
+      y: posicao.labelY,
+      texto: mao.jogador.nome,
+    }).setDepth(10);
+    this.objetos.push(label);
+    this.labels.push(label);
+    const objetosMao = renderizarMao({ cena: this, posicao: posicao.mao, cartas: mao.cartas, visivel: mao.visivel });
+    this.objetos.push(...objetosMao);
+    if (mao.jogador.id === 'humano') {
+      configurarInteracaoHumano({
+        cena: this,
+        objetosMao,
+        cartas: mao.cartas,
+        partida,
+        decisorHumano: this.decisorHumano,
+        destaque: this.destaque,
       });
-    });
-  }
-
-  private aoClicarCarta(container: Phaser.GameObjects.Container, carta: Carta): void {
-    if (!this.partida || this.partida.estado.maos[this.partida.estado.jogadorAtual].jogador.id !== 'humano') {
-      return;
     }
-    if (this.destaque.container === container) {
-      this.decisorHumano.confirmar();
-      return;
-    }
-    this.decisorHumano.selecionar(carta);
-    destacarCarta(this, container, this.destaque);
-  }
-
-  private aoClicarFundo(): void {
-    this.decisorHumano.desmarcar();
-    removerDestaque(this.destaque);
   }
 
   private aoEncerrar = (): void => {
@@ -200,6 +182,22 @@ export class JogoScene extends Scene {
       o.destroy();
     });
     this.objetos = [];
+  }
+
+  private animarRecolhimentoTurno(): void {
+    animarRecolhimentoTurno({
+      cena: this,
+      labels: this.labels,
+      jogadores: JOGADORES,
+      vencedorId: this.vencedorTurno,
+      mesaObjetos: this.mesaObjetos,
+    });
+    this.vencedorTurno = undefined;
+    this.mesaObjetos = [];
+  }
+
+  private mostrarOverlayRodadaConcluida(): void {
+    mostrarOverlayRodadaConcluida(this, this.objetos);
   }
 
   private limparMesa(): void {

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -76,7 +76,12 @@ export class JogoScene extends Scene {
       const jogadorAtual = this.partida.estado.jogadorAtual;
       const ehBot = this.partida.estado.maos[jogadorAtual].jogador.id !== 'humano';
       if (ehBot) await this.esperar(500);
-      await this.partida.jogarTurno();
+      try {
+        await this.partida.jogarTurno();
+      } catch (erro) {
+        console.error('Falha ao processar turno', erro);
+        break;
+      }
       if (this.partida.estado.turno > this.turnoAnterior) {
         this.turnoAnterior = this.partida.estado.turno;
         this.animarRecolhimentoTurno();

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -2,6 +2,7 @@ import type { Jogador } from '@/types/entidades';
 import type { EstadoPartida } from '@/types/estado-partida';
 import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
+import { compararNaipe, compararValor } from './Carta';
 import type { Carta } from './Carta';
 import type { DecisorJogada } from './portas/DecisorJogada';
 
@@ -24,6 +25,9 @@ export class Partida {
       jogadorAtual: 0,
       mesa: [],
       maos: [],
+      vazas: {},
+      turno: 1,
+      cartasPorRodada: 0,
     };
   }
 
@@ -39,6 +43,7 @@ export class Partida {
       cartas: cartas[i],
       visivel: jogador.id === 'humano',
     }));
+    this._estado.cartasPorRodada = numeroCartas;
     this._estado.fase = 'aguardandoJogada';
   }
 
@@ -69,7 +74,7 @@ export class Partida {
       throw new Error(`Jogada inválida para jogador ${jogador.id}`);
     }
     this.removerCartaDaMao(indiceCarta);
-    this._estado.mesa.push(carta);
+    this._estado.mesa.push({ jogadorId: jogador.id, carta });
     this.emitirCartaJogada(jogador, carta);
     this.avancarJogador();
   }
@@ -91,11 +96,64 @@ export class Partida {
   }
 
   private avancarJogador(): void {
+    if (this._estado.mesa.length === this.jogadores.length) {
+      this.resolverTurno();
+      return;
+    }
     this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
-    if (this._estado.jogadorAtual === 0) {
-      this._estado.fase = 'turnoConcluido';
+    this._estado.fase = 'aguardandoJogada';
+  }
+
+  private resolverTurno(): void {
+    const vencedor = this.calcularVencedorTurno();
+    this._estado.vazas[vencedor.id] = (this._estado.vazas[vencedor.id] ?? 0) + 1;
+    this.emitirTurnoGanho(vencedor);
+    this._estado.turno += 1;
+    this._estado.mesa = [];
+
+    if (this._estado.turno > this._estado.cartasPorRodada) {
+      this._estado.fase = 'rodadaConcluida';
+      this.emitirRodadaEncerrada();
     } else {
       this._estado.fase = 'aguardandoJogada';
+      this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === vencedor.id);
     }
+  }
+
+  private calcularVencedorTurno(): Jogador {
+    let indiceMelhor = 0;
+    for (let i = 1; i < this._estado.mesa.length; i++) {
+      const cartaAtual = this._estado.mesa[i].carta;
+      const cartaMelhor = this._estado.mesa[indiceMelhor].carta;
+      if (compararValor(cartaAtual, cartaMelhor)) {
+        indiceMelhor = i;
+      } else if (!compararValor(cartaMelhor, cartaAtual) && compararNaipe(cartaAtual, cartaMelhor)) {
+        indiceMelhor = i;
+      }
+    }
+    const jogadorId = this._estado.mesa[indiceMelhor].jogadorId;
+    const vencedor = this.jogadores.find((j) => j.id === jogadorId);
+    if (!vencedor) throw new Error('Vencedor não encontrado');
+    return vencedor;
+  }
+
+  private emitirTurnoGanho(vencedor: Jogador): void {
+    this.emissor.emit({
+      id: crypto.randomUUID(),
+      timestamp: Date.now(),
+      tipo: 'TURNO_GANHO',
+      jogadorId: vencedor.id,
+      cartas: this._estado.mesa.map((m) => m.carta),
+    });
+  }
+
+  private emitirRodadaEncerrada(): void {
+    this.emissor.emit({
+      id: crypto.randomUUID(),
+      timestamp: Date.now(),
+      tipo: 'RODADA_ENCERRADA',
+      placar: { ...this._estado.vazas },
+      proximaRodada: null,
+    });
   }
 }

--- a/src/types/estado-partida.ts
+++ b/src/types/estado-partida.ts
@@ -1,7 +1,12 @@
 import type { Carta } from '@/core/Carta';
 import type { Jogador } from './entidades';
 
-export type FasePartida = 'distribuindo' | 'aguardandoJogada' | 'processandoTurno' | 'turnoConcluido';
+export type FasePartida =
+  | 'distribuindo'
+  | 'aguardandoJogada'
+  | 'processandoTurno'
+  | 'turnoConcluido'
+  | 'rodadaConcluida';
 
 export interface MaoJogador {
   jogador: Jogador;
@@ -9,9 +14,17 @@ export interface MaoJogador {
   visivel: boolean;
 }
 
+export interface MesaItem {
+  jogadorId: string;
+  carta: Carta;
+}
+
 export interface EstadoPartida {
   fase: FasePartida;
   jogadorAtual: number;
-  mesa: Carta[];
+  mesa: MesaItem[];
   maos: MaoJogador[];
+  vazas: Record<string, number>;
+  turno: number;
+  cartasPorRodada: number;
 }

--- a/tests/core/Partida.hardening.test.ts
+++ b/tests/core/Partida.hardening.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import { criarCarta, criarJogador, criarDecisor, criarPartida, criarPartidaComMao } from './partida-fixtures';
+
+describe('Partida — hardening do decisor', () => {
+  it('deve restaurar fase para aguardandoJogada quando decisor rejeita', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'Jogador 1')];
+    const decisor = { decidirJogada: vi.fn().mockRejectedValue(new Error('Erro do decisor')) };
+    const partida = criarPartida({ jogadores, decisores: new Map([['j1', decisor]]), emissor });
+    await expect(partida.jogarTurno()).rejects.toThrow('Erro do decisor');
+    expect(partida.estado.fase).toBe('aguardandoJogada');
+  });
+});
+
+describe('Partida — hardening da jogada', () => {
+  it('deve restaurar fase quando carta retornada não está na mão', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'Jogador 1')];
+    const decisor = criarDecisor(criarCarta('5', '♥'));
+    const partida = criarPartidaComMao({
+      jogadores,
+      decisores: new Map([['j1', decisor]]),
+      emissor,
+      maos: [[criarCarta('4', '♣')]],
+    });
+    await expect(partida.jogarTurno()).rejects.toThrow('Jogada inválida');
+    expect(partida.estado.fase).toBe('aguardandoJogada');
+  });
+
+  it('deve restaurar fase quando decisor não é encontrado', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'Jogador 1')];
+    const partida = criarPartidaComMao({
+      jogadores,
+      decisores: new Map(),
+      emissor,
+      maos: [[criarCarta('4', '♣')]],
+    });
+    await expect(partida.jogarTurno()).rejects.toThrow('Decisor não encontrado');
+    expect(partida.estado.fase).toBe('aguardandoJogada');
+  });
+});

--- a/tests/core/Partida.mesa.test.ts
+++ b/tests/core/Partida.mesa.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import {
+  criarCarta,
+  criarJogador,
+  criarDecisor,
+  criarDecisorPrimeiraCarta,
+  criarPartida,
+  criarPartidaComMao,
+} from './partida-fixtures';
+
+describe('Partida — mesa remoção', () => {
+  it('deve remover carta jogada da mão do jogador', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'Jogador 1'), criarJogador('j2', 'Jogador 2')];
+    const decisores = new Map([
+      ['j1', criarDecisorPrimeiraCarta()],
+      ['j2', criarDecisorPrimeiraCarta()],
+    ]);
+    const partida = criarPartida({ jogadores, decisores, emissor });
+    const cartaEsperada = partida.estado.maos[0].cartas[0];
+    const maoAntes = partida.estado.maos[0].cartas.length;
+    await partida.jogarTurno();
+    expect(partida.estado.maos[0].cartas).toHaveLength(maoAntes - 1);
+    expect(partida.estado.mesa).toContainEqual(expect.objectContaining({ carta: cartaEsperada, jogadorId: 'j1' }));
+  });
+});
+
+describe('Partida — mesa referência', () => {
+  it('deve remover carta por valor/naipe mesmo com referência diferente', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'Jogador 1'), criarJogador('j2', 'Jogador 2')];
+    const decisor = criarDecisor(criarCarta('4', '♣'));
+    const partida = criarPartidaComMao({
+      jogadores,
+      decisores: new Map([
+        ['j1', decisor],
+        ['j2', criarDecisor(criarCarta('5', '♥'))],
+      ]),
+      emissor,
+      maos: [[criarCarta('4', '♣')], [criarCarta('5', '♥')]],
+      cartasPorRodada: 2,
+    });
+    await partida.jogarTurno();
+    expect(partida.estado.maos[0].cartas).toHaveLength(0);
+    expect(partida.estado.mesa).toContainEqual(
+      expect.objectContaining({ carta: criarCarta('4', '♣'), jogadorId: 'j1' }),
+    );
+  });
+});

--- a/tests/core/Partida.rodada.test.ts
+++ b/tests/core/Partida.rodada.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Carta } from '@/core/Carta';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import { criarCarta, criarDecisorPrimeiraCarta, criarPartidaComMao, jogadoresPadrao } from './partida-fixtures';
+
+const MAO_CURTA: Carta[][] = [
+  [criarCarta('A', '♣')],
+  [criarCarta('K', '♥')],
+  [criarCarta('Q', '♠')],
+  [criarCarta('J', '♦')],
+];
+
+const MAO_LONGA: Carta[][] = [
+  [criarCarta('A', '♣'), criarCarta('4', '♣'), criarCarta('4', '♣'), criarCarta('4', '♣')],
+  [criarCarta('K', '♥'), criarCarta('A', '♥'), criarCarta('4', '♥'), criarCarta('4', '♥')],
+  [criarCarta('Q', '♠'), criarCarta('K', '♠'), criarCarta('A', '♠'), criarCarta('4', '♠')],
+  [criarCarta('J', '♦'), criarCarta('Q', '♦'), criarCarta('K', '♦'), criarCarta('A', '♦')],
+];
+
+async function jogarTurnos(partida: ReturnType<typeof criarPartidaComMao>, quantidade: number): Promise<void> {
+  for (let i = 0; i < quantidade; i++) {
+    await partida.jogarTurno();
+  }
+}
+
+function partidaComMaoFixa(maos: Carta[][], cartasPorRodada = 1) {
+  const emissor = createEmissorEventos();
+  const jogadores = jogadoresPadrao();
+  const decisores = new Map(jogadores.map((j) => [j.id, criarDecisorPrimeiraCarta()]));
+  const partida = criarPartidaComMao({ jogadores, decisores, emissor, maos, cartasPorRodada });
+  return { emissor, partida };
+}
+
+describe('Partida — cálculo de vencedor', () => {
+  it('deve definir maior valor como vencedor do turno', async () => {
+    const { partida } = partidaComMaoFixa(MAO_CURTA);
+    await jogarTurnos(partida, 4);
+    expect(partida.estado.vazas['j1']).toBe(1);
+  });
+
+  it('deve desempatar pelo naipe quando valores são iguais', async () => {
+    const { partida } = partidaComMaoFixa([
+      [criarCarta('4', '♦')],
+      [criarCarta('4', '♠')],
+      [criarCarta('4', '♥')],
+      [criarCarta('4', '♣')],
+    ]);
+    await jogarTurnos(partida, 4);
+    expect(partida.estado.vazas['j4']).toBe(1);
+  });
+});
+
+describe('Partida — vazas e rodada', () => {
+  it('deve acumular 4 vazas após 4 turnos', async () => {
+    const { partida } = partidaComMaoFixa(MAO_LONGA, 4);
+    await jogarTurnos(partida, 16);
+    const totalVazas = Object.values(partida.estado.vazas).reduce((a, b) => a + b, 0);
+    expect(totalVazas).toBe(4);
+  });
+
+  it('deve transitar para rodadaConcluida após o último turno', async () => {
+    const { partida } = partidaComMaoFixa(MAO_LONGA, 4);
+    await jogarTurnos(partida, 16);
+    expect(partida.estado.fase).toBe('rodadaConcluida');
+  });
+});
+
+describe('Partida — eventos de turno e rodada', () => {
+  it('deve emitir TURNO_GANHO ao resolver um turno', async () => {
+    const { emissor, partida } = partidaComMaoFixa(MAO_CURTA);
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('TURNO_GANHO', handler);
+    await jogarTurnos(partida, 4);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ tipo: 'TURNO_GANHO', jogadorId: 'j1' }));
+  });
+
+  it('deve emitir RODADA_ENCERRADA ao fim da rodada', async () => {
+    const { emissor, partida } = partidaComMaoFixa(MAO_LONGA, 4);
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('RODADA_ENCERRADA', handler);
+    await jogarTurnos(partida, 16);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ tipo: 'RODADA_ENCERRADA' }));
+  });
+});

--- a/tests/core/Partida.rodada.test.ts
+++ b/tests/core/Partida.rodada.test.ts
@@ -54,8 +54,7 @@ describe('Partida — vazas e rodada', () => {
   it('deve acumular 4 vazas após 4 turnos', async () => {
     const { partida } = partidaComMaoFixa(MAO_LONGA, 4);
     await jogarTurnos(partida, 16);
-    const totalVazas = Object.values(partida.estado.vazas).reduce((a, b) => a + b, 0);
-    expect(totalVazas).toBe(4);
+    expect(partida.estado.vazas).toEqual({ j1: 1, j2: 1, j3: 1, j4: 1 });
   });
 
   it('deve transitar para rodadaConcluida após o último turno', async () => {
@@ -81,6 +80,11 @@ describe('Partida — eventos de turno e rodada', () => {
     emissor.on('RODADA_ENCERRADA', handler);
     await jogarTurnos(partida, 16);
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ tipo: 'RODADA_ENCERRADA' }));
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tipo: 'RODADA_ENCERRADA',
+        placar: { j1: 1, j2: 1, j3: 1, j4: 1 },
+      }),
+    );
   });
 });

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -3,61 +3,7 @@ import type { Carta } from '@/core/Carta';
 import { Partida } from '@/core/Partida';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
-import type { Jogador } from '@/types/entidades';
-import type { EstadoPartida } from '@/types/estado-partida';
-
-function criarCarta(valor: Carta['valor'], naipe: Carta['naipe']): Carta {
-  return { valor, naipe };
-}
-
-function criarJogador(id: string, nome: string): Jogador {
-  return { id, nome, pontos: 5 };
-}
-
-function criarDecisor(carta: Carta): DecisorJogada {
-  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>().mockResolvedValue(carta);
-  return { decidirJogada: mock };
-}
-
-function criarDecisorPrimeiraCarta(): DecisorJogada {
-  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>();
-  mock.mockImplementation((mao: Carta[]) => Promise.resolve(mao[0]));
-  return { decidirJogada: mock };
-}
-
-function criarPartida(config: {
-  jogadores: Jogador[];
-  decisores: Map<string, DecisorJogada>;
-  emissor: ReturnType<typeof createEmissorEventos>;
-}): Partida {
-  const partida = new Partida(config.jogadores, config.decisores, config.emissor);
-  partida.distribuir(1);
-  return partida;
-}
-
-interface EstadoPrivado {
-  _estado: EstadoPartida;
-}
-
-function criarPartidaComMao(config: {
-  jogadores: Jogador[];
-  decisores: Map<string, DecisorJogada>;
-  emissor: ReturnType<typeof createEmissorEventos>;
-  maos: Carta[][];
-  jogadorAtual?: number;
-  fase?: EstadoPartida['fase'];
-}): Partida {
-  const partida = new Partida(config.jogadores, config.decisores, config.emissor);
-  const estado = (partida as unknown as EstadoPrivado)._estado;
-  estado.maos = config.jogadores.map((jogador, i) => ({
-    jogador,
-    cartas: config.maos[i] ?? [],
-    visivel: jogador.id === 'humano',
-  }));
-  estado.fase = config.fase ?? 'aguardandoJogada';
-  estado.jogadorAtual = config.jogadorAtual ?? 0;
-  return partida;
-}
+import { criarCarta, criarJogador, criarDecisor, criarPartida } from './partida-fixtures';
 
 describe('Partida — transições', () => {
   it('deve iniciar na fase distribuindo e avançar para aguardandoJogada', () => {
@@ -72,6 +18,7 @@ describe('Partida — transições', () => {
     partida.distribuir(1);
     expect(partida.estado.fase).toBe('aguardandoJogada');
     expect(partida.estado.jogadorAtual).toBe(0);
+    expect(partida.estado.cartasPorRodada).toBe(1);
   });
 });
 
@@ -80,15 +27,18 @@ describe('Partida — avanço de jogadorAtual', () => {
     const emissor = createEmissorEventos();
     const ids = ['j1', 'j2', 'j3', 'j4'];
     const jogadores = ids.map((id) => criarJogador(id, `Jogador ${id}`));
-    const decisores = new Map<string, DecisorJogada>(ids.map((id) => [id, criarDecisorPrimeiraCarta()]));
-    const partida = criarPartida({ jogadores, decisores, emissor });
+    const decisores = new Map<string, DecisorJogada>(
+      ids.map((id) => [id, { decidirJogada: (mao: Carta[]) => Promise.resolve(mao[0]) }]),
+    );
+    const partida = criarPartida({ jogadores, decisores, emissor, cartasPorRodada: 4 });
     expect(partida.estado.jogadorAtual).toBe(0);
     for (let i = 0; i < 3; i++) {
       await partida.jogarTurno();
       expect(partida.estado.jogadorAtual).toBe(i + 1);
     }
     await partida.jogarTurno();
-    expect(partida.estado.fase).toBe('turnoConcluido');
+    expect(partida.estado.fase).toBe('aguardandoJogada');
+    expect(partida.estado.turno).toBe(2);
   });
 });
 
@@ -97,10 +47,10 @@ describe('Partida — DecisorJogada', () => {
     const emissor = createEmissorEventos();
     const jogadores = [criarJogador('j1', 'Jogador 1'), criarJogador('j2', 'Jogador 2')];
     const mock1 = vi
-      .fn<(mao: Carta[], estado: unknown) => Promise<Carta>>()
+      .fn<(mao: import('@/core/Carta').Carta[], estado: unknown) => Promise<import('@/core/Carta').Carta>>()
       .mockImplementation((mao) => Promise.resolve(mao[0]));
     const mock2 = vi
-      .fn<(mao: Carta[], estado: unknown) => Promise<Carta>>()
+      .fn<(mao: import('@/core/Carta').Carta[], estado: unknown) => Promise<import('@/core/Carta').Carta>>()
       .mockImplementation((mao) => Promise.resolve(mao[0]));
     const decisores = new Map<string, DecisorJogada>([
       ['j1', { decidirJogada: mock1 }],
@@ -116,41 +66,15 @@ describe('Partida — DecisorJogada', () => {
   });
 });
 
-describe('Partida — mesa', () => {
-  it('deve remover carta jogada da mão do jogador', async () => {
-    const emissor = createEmissorEventos();
-    const jogadores = [criarJogador('j1', 'Jogador 1'), criarJogador('j2', 'Jogador 2')];
-    const decisores = new Map<string, DecisorJogada>([
-      ['j1', criarDecisorPrimeiraCarta()],
-      ['j2', criarDecisorPrimeiraCarta()],
-    ]);
-    const partida = criarPartida({ jogadores, decisores, emissor });
-    const cartaEsperada = partida.estado.maos[0].cartas[0];
-    const maoAntes = partida.estado.maos[0].cartas.length;
-    await partida.jogarTurno();
-    expect(partida.estado.maos[0].cartas).toHaveLength(maoAntes - 1);
-    expect(partida.estado.mesa).toContainEqual(cartaEsperada);
-  });
-
-  it('deve remover carta por valor/naipe mesmo com referência diferente', async () => {
-    const emissor = createEmissorEventos();
-    const jogadores = [criarJogador('j1', 'Jogador 1')];
-    const mao = [criarCarta('4', '♣')];
-    const decisor = criarDecisor(criarCarta('4', '♣'));
-    const partida = criarPartidaComMao({ jogadores, decisores: new Map([['j1', decisor]]), emissor, maos: [mao] });
-    await partida.jogarTurno();
-    expect(partida.estado.maos[0].cartas).toHaveLength(0);
-    expect(partida.estado.mesa).toContainEqual(criarCarta('4', '♣'));
-  });
-});
-
 describe('Partida — eventos', () => {
   it('deve emitir evento CARTA_JOGADA ao jogar', async () => {
     const emissor = createEmissorEventos();
-    const handler = vi.fn();
+    const handler = vi.fn<(ev: unknown) => void>();
     emissor.on('CARTA_JOGADA', handler);
     const jogadores = [criarJogador('j1', 'Jogador 1')];
-    const decisores = new Map<string, DecisorJogada>([['j1', criarDecisorPrimeiraCarta()]]);
+    const decisores = new Map<string, DecisorJogada>([
+      ['j1', { decidirJogada: (mao: Carta[]) => Promise.resolve(mao[0]) }],
+    ]);
     const partida = criarPartida({ jogadores, decisores, emissor });
     const cartaEsperada = partida.estado.maos[0].cartas[0];
     await partida.jogarTurno();
@@ -162,34 +86,5 @@ describe('Partida — eventos', () => {
         carta: cartaEsperada,
       }),
     );
-  });
-});
-
-describe('Partida — hardening', () => {
-  it('deve restaurar fase para aguardandoJogada quando decisor rejeita', async () => {
-    const emissor = createEmissorEventos();
-    const jogadores = [criarJogador('j1', 'Jogador 1')];
-    const decisor = { decidirJogada: vi.fn().mockRejectedValue(new Error('Erro do decisor')) };
-    const partida = criarPartida({ jogadores, decisores: new Map([['j1', decisor]]), emissor });
-    await expect(partida.jogarTurno()).rejects.toThrow('Erro do decisor');
-    expect(partida.estado.fase).toBe('aguardandoJogada');
-  });
-
-  it('deve restaurar fase quando carta retornada não está na mão', async () => {
-    const emissor = createEmissorEventos();
-    const jogadores = [criarJogador('j1', 'Jogador 1')];
-    const mao = [criarCarta('4', '♣')];
-    const decisor = criarDecisor(criarCarta('5', '♥'));
-    const partida = criarPartidaComMao({ jogadores, decisores: new Map([['j1', decisor]]), emissor, maos: [mao] });
-    await expect(partida.jogarTurno()).rejects.toThrow('Jogada inválida');
-    expect(partida.estado.fase).toBe('aguardandoJogada');
-  });
-
-  it('deve restaurar fase quando decisor não é encontrado', async () => {
-    const emissor = createEmissorEventos();
-    const jogadores = [criarJogador('j1', 'Jogador 1')];
-    const partida = criarPartidaComMao({ jogadores, decisores: new Map(), emissor, maos: [[criarCarta('4', '♣')]] });
-    await expect(partida.jogarTurno()).rejects.toThrow('Decisor não encontrado');
-    expect(partida.estado.fase).toBe('aguardandoJogada');
   });
 });

--- a/tests/core/partida-fixtures.ts
+++ b/tests/core/partida-fixtures.ts
@@ -1,0 +1,89 @@
+import { vi } from 'vitest';
+import type { Carta } from '@/core/Carta';
+import { Partida } from '@/core/Partida';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoPartida } from '@/types/estado-partida';
+
+export function criarCarta(valor: Carta['valor'], naipe: Carta['naipe']): Carta {
+  return { valor, naipe };
+}
+
+export function criarJogador(id: string, nome: string): Jogador {
+  return { id, nome, pontos: 5 };
+}
+
+export function criarDecisor(carta: Carta): DecisorJogada {
+  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>().mockResolvedValue(carta);
+  return { decidirJogada: mock };
+}
+
+export function criarDecisorPrimeiraCarta(): DecisorJogada {
+  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>();
+  mock.mockImplementation((mao: Carta[]) => Promise.resolve(mao[0]));
+  return { decidirJogada: mock };
+}
+
+export function criarDecisorSequencia(cartas: Carta[]): DecisorJogada {
+  let indice = 0;
+  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>();
+  mock.mockImplementation(() => {
+    const carta = cartas[indice];
+    indice += 1;
+    return Promise.resolve(carta);
+  });
+  return { decidirJogada: mock };
+}
+
+export function criarPartida(config: {
+  jogadores: Jogador[];
+  decisores: Map<string, DecisorJogada>;
+  emissor: ReturnType<typeof createEmissorEventos>;
+  cartasPorRodada?: number;
+}): Partida {
+  const partida = new Partida(config.jogadores, config.decisores, config.emissor);
+  partida.distribuir(config.cartasPorRodada ?? 1);
+  return partida;
+}
+
+interface EstadoPrivado {
+  _estado: EstadoPartida;
+}
+
+export function criarPartidaComMao(config: {
+  jogadores: Jogador[];
+  decisores: Map<string, DecisorJogada>;
+  emissor: ReturnType<typeof createEmissorEventos>;
+  maos: Carta[][];
+  jogadorAtual?: number;
+  fase?: EstadoPartida['fase'];
+  turno?: number;
+  cartasPorRodada?: number;
+}): Partida {
+  const partida = new Partida(config.jogadores, config.decisores, config.emissor);
+  const estado = (partida as unknown as EstadoPrivado)._estado;
+  estado.maos = config.jogadores.map((jogador, i) => ({
+    jogador,
+    cartas: config.maos[i] ?? [],
+    visivel: jogador.id === 'humano',
+  }));
+  estado.fase = config.fase ?? 'aguardandoJogada';
+  estado.jogadorAtual = config.jogadorAtual ?? 0;
+  estado.vazas = {};
+  estado.turno = config.turno ?? 1;
+  estado.cartasPorRodada = config.cartasPorRodada ?? 4;
+  return partida;
+}
+
+export function jogadoresPadrao(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('j4', 'J4')];
+}
+
+export function decisoresPorMaos(jogadores: Jogador[], maos: Carta[][]): Map<string, DecisorJogada> {
+  return new Map(jogadores.map((j) => [j.id, criarDecisor(maos[jogadores.indexOf(j)][0])]));
+}
+
+export function decisoresPrimeiraCarta(jogadores: Jogador[]): Map<string, DecisorJogada> {
+  return new Map(jogadores.map((j) => [j.id, criarDecisorPrimeiraCarta()]));
+}


### PR DESCRIPTION
## Resumo

- Adiciona  com desempate por naipe
- Acumula vazas por jogador em 
- Transiciona para  após último turno
- Emite eventos  e 
- Implementa destaque visual do vencedor e fade out das cartas
- Adiciona overlay 'Rodada concluída' ao fim da rodada
- Expande testes unitários do core ()
- Refatora  extraindo input, factory e renderers de turno

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented turn winner determination and score tracking across rounds.
  * Added visual animations and overlays for turn transitions and round completion.
  * Enhanced player card interaction with highlight, selection, and confirmation feedback.
  * Introduced proper round phase management with automatic game state progression.

* **Tests**
  * Added comprehensive test coverage for game state, turn resolution, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->