### PR TITLE
feat(ui): exibe contador de vazas ao lado do nome de cada jogador

### DIFF
--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -144,11 +144,12 @@ export class JogoScene extends Scene {
   }
 
   private desenharMao(mao: MaoJogador, posicao: ReturnType<typeof calcularPosicoes>[number], partida: Partida): void {
+    const vazas = partida.estado.vazas[mao.jogador.id] ?? 0;
     const label = renderizarLabel({
       cena: this,
       x: posicao.labelX,
       y: posicao.labelY,
-      texto: mao.jogador.nome,
+      texto: `${mao.jogador.nome} · Fez: ${String(vazas)}`,
     }).setDepth(10);
     this.objetos.push(label);
     this.labels.push(label);


### PR DESCRIPTION
Mostra 'Fez: N' no label de cada jogador durante a rodada. O core ja calculava mas o adapter nao exibia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hand display to show the number of tricks each player has won alongside their name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->