### PR TITLE
fix(render): adiciona pixelArt para gráficos mais nítidos em telas de alta densidade

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,10 +11,10 @@ export function inicializarJogo(containerId?: string): Game {
     width: window.innerWidth,
     height: window.innerHeight,
     parent: containerId,
-    resolution: window.devicePixelRatio,
-    antialias: false,
-    roundPixels: true,
     scene: [MenuScene, JogoScene],
+    render: {
+      pixelArt: true,
+    },
     scale: {
       mode: Phaser.Scale.RESIZE,
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,9 @@ export function inicializarJogo(containerId?: string): Game {
     width: window.innerWidth,
     height: window.innerHeight,
     parent: containerId,
+    resolution: window.devicePixelRatio,
+    antialias: false,
+    roundPixels: true,
     scene: [MenuScene, JogoScene],
     scale: {
       mode: Phaser.Scale.RESIZE,


### PR DESCRIPTION
Adiciona render: { pixelArt: true } na config do Phaser. Isso desabilita antialiasing e interpolação linear no WebGL, eliminando o blur em dispositivos mobile com DPR > 1.