### PR TITLE
fix(layout): adiciona viewport-fit=cover para canvas ocupar 100% em dispositivos mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>FDP — Faz De Propósito</title>
   </head>
   <body>


### PR DESCRIPTION
Adiciona viewport-fit=cover na meta tag viewport. Isso ignora safe areas (notch, ilha dinâmica) e permite que o canvas ocupe a tela inteira em iPhones X+ e Android edge-to-edge.