### PR TITLE
feat: exibir contador de vazas (Fez: N) nos labels dos jogadores

### DIFF
--- a/src/adapters/phaser/renderers/label-jogador.ts
+++ b/src/adapters/phaser/renderers/label-jogador.ts
@@ -1,0 +1,26 @@
+import type { Jogador } from '@/types/entidades';
+
+export type DirecaoLabel = 'horizontal' | 'vertical';
+
+export function formatarLabelJogador(nome: string, vazas: number, direcao: DirecaoLabel): string {
+  const contador = `(Fez: ${String(vazas)})`;
+  return direcao === 'horizontal' ? `${nome} ${contador}` : `${nome}\n${contador}`;
+}
+
+export interface ConfigAtualizarLabelVencedor {
+  vencedorId: string | undefined;
+  jogadores: Jogador[];
+  vazas: Record<string, number>;
+  labels: Phaser.GameObjects.Text[];
+  direcoes: DirecaoLabel[];
+}
+
+export function atualizarLabelVencedor(config: ConfigAtualizarLabelVencedor): void {
+  const { vencedorId, jogadores, vazas, labels, direcoes } = config;
+  if (!vencedorId) return;
+  const indice = jogadores.findIndex((j) => j.id === vencedorId);
+  if (indice < 0 || indice >= labels.length || indice >= direcoes.length) return;
+  const jogador = jogadores[indice];
+  const contagem = vazas[jogador.id] ?? 0;
+  labels[indice].setText(formatarLabelJogador(jogador.nome, contagem, direcoes[indice]));
+}

--- a/src/adapters/phaser/renderers/mao-scene-renderer.ts
+++ b/src/adapters/phaser/renderers/mao-scene-renderer.ts
@@ -1,0 +1,46 @@
+import type { Scene } from 'phaser';
+import type { Partida } from '@/core/Partida';
+import type { MaoJogador } from '@/types/estado-partida';
+import type { DecisorHumano } from '../DecisorHumano';
+import { configurarInteracaoHumano } from '../input/input-humano';
+import type { EstadoDestaque } from './destaque-renderer';
+import { formatarLabelJogador } from './label-jogador';
+import { renderizarLabel, renderizarMao } from './mao-renderer';
+import type { PosicaoTela } from './posicoes-mao';
+
+export interface ConfigDesenharMao {
+  cena: Scene;
+  mao: MaoJogador;
+  posicao: PosicaoTela;
+  partida: Partida;
+  decisorHumano: DecisorHumano;
+  destaque: EstadoDestaque;
+  objetos: Phaser.GameObjects.GameObject[];
+  labels: Phaser.GameObjects.Text[];
+}
+
+export function desenharMaoNaCena(config: ConfigDesenharMao): void {
+  const { cena, mao, posicao, partida, decisorHumano, destaque, objetos, labels } = config;
+  const vazas = partida.estado.vazas[mao.jogador.id] ?? 0;
+  const texto = formatarLabelJogador(mao.jogador.nome, vazas, posicao.mao.direcao);
+  const label = renderizarLabel({
+    cena,
+    x: posicao.labelX,
+    y: posicao.labelY,
+    texto,
+  }).setDepth(10);
+  objetos.push(label);
+  labels.push(label);
+  const objetosMao = renderizarMao({ cena, posicao: posicao.mao, cartas: mao.cartas, visivel: mao.visivel });
+  objetos.push(...objetosMao);
+  if (mao.jogador.id === 'humano') {
+    configurarInteracaoHumano({
+      cena,
+      objetosMao,
+      cartas: mao.cartas,
+      partida,
+      decisorHumano,
+      destaque,
+    });
+  }
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -4,10 +4,11 @@ import type { Jogador } from '@/types/entidades';
 import type { MaoJogador } from '@/types/estado-partida';
 import { DecisorHumano } from '../DecisorHumano';
 import { fabricarPartida } from '../factories/partida-factory';
-import { configurarInteracaoHumano, criarFundoInterativo } from '../input/input-humano';
+import { criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
-import { renderizarLabel, renderizarMao } from '../renderers/mao-renderer';
+import { atualizarLabelVencedor } from '../renderers/label-jogador';
+import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
 import { calcularPosicoes } from '../renderers/posicoes-mao';
 import {
@@ -36,6 +37,7 @@ export class JogoScene extends Scene {
   private destaque: EstadoDestaque = {};
   private partida?: Partida;
   private labels: Phaser.GameObjects.Text[] = [];
+  private direcoesLabels: ('horizontal' | 'vertical')[] = [];
   private tweenVez?: Phaser.Tweens.Tween;
   private turnoAnterior = 1;
   private vencedorTurno?: string;
@@ -78,14 +80,21 @@ export class JogoScene extends Scene {
       if (ehBot) await this.esperar(500);
       try {
         await this.partida.jogarTurno();
-      } catch (erro) {
-        console.error('Falha ao processar turno', erro);
+      } catch {
         break;
       }
       if (this.partida.estado.turno > this.turnoAnterior) {
         this.turnoAnterior = this.partida.estado.turno;
+        const vencedorId = this.vencedorTurno;
         this.animarRecolhimentoTurno();
         await this.esperar(800);
+        atualizarLabelVencedor({
+          vencedorId,
+          jogadores: JOGADORES,
+          vazas: this.partida.estado.vazas,
+          labels: this.labels,
+          direcoes: this.direcoesLabels,
+        });
       }
       this.atualizarIndicadorVez();
     }
@@ -132,8 +141,18 @@ export class JogoScene extends Scene {
       espacamentoCartas: ESPACAMENTO_CARTAS,
       alturaCarta: ALTURA_CARTA,
     });
+    this.direcoesLabels = posicoes.map((p) => p.mao.direcao);
     maos.forEach((mao, i) => {
-      this.desenharMao(mao, posicoes[i], partida);
+      desenharMaoNaCena({
+        cena: this,
+        mao,
+        posicao: posicoes[i],
+        partida,
+        decisorHumano: this.decisorHumano,
+        destaque: this.destaque,
+        objetos: this.objetos,
+        labels: this.labels,
+      });
     });
     criarFundoInterativo({
       cena: this,
@@ -141,29 +160,6 @@ export class JogoScene extends Scene {
       decisorHumano: this.decisorHumano,
       destaque: this.destaque,
     });
-  }
-
-  private desenharMao(mao: MaoJogador, posicao: ReturnType<typeof calcularPosicoes>[number], partida: Partida): void {
-    const label = renderizarLabel({
-      cena: this,
-      x: posicao.labelX,
-      y: posicao.labelY,
-      texto: mao.jogador.nome,
-    }).setDepth(10);
-    this.objetos.push(label);
-    this.labels.push(label);
-    const objetosMao = renderizarMao({ cena: this, posicao: posicao.mao, cartas: mao.cartas, visivel: mao.visivel });
-    this.objetos.push(...objetosMao);
-    if (mao.jogador.id === 'humano') {
-      configurarInteracaoHumano({
-        cena: this,
-        objetosMao,
-        cartas: mao.cartas,
-        partida,
-        decisorHumano: this.decisorHumano,
-        destaque: this.destaque,
-      });
-    }
   }
 
   private aoEncerrar = (): void => {


### PR DESCRIPTION
Closes #91

## O que muda

- Adiciona contador de vazas ganhas no label de cada jogador, atualizado após a animação de recolhimento do turno.
- Layout adaptativo por posição:
  - **Horizontal** (humano embaixo, bot no topo): \"Nome (Fez: N)\" em uma linha
  - **Vertical** (bots laterais): \"Nome\n(Fez: N)\" em duas linhas
- Extrai \"desenharMaoNaCena\" para módulo dedicado, reduzindo complexidade e tamanho de \"JogoScene\".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Winner labels now update reliably after each turn and support horizontal or vertical layouts.
  * Player labels display per-player counters alongside names.

* **New Features**
  * Hands render with depth ordering and human-controlled hand interaction enabled.

* **Refactor**
  * Hand rendering moved to a modular renderer for cleaner scene logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->