### PR TITLE
fix: canvas ocupa 100% da tela em mobile com notch (#93)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#1a1a2e" />
     <title>FDP — Faz De Propósito</title>
   </head>
   <body>

--- a/src/style.css
+++ b/src/style.css
@@ -6,6 +6,7 @@ body,
   margin: 0;
   padding: 0;
   overflow: hidden;
+  background-color: #1a1a2e;
 }
 
 /* Mobile dynamic viewport height para evitar colapso durante rotação */


### PR DESCRIPTION
## O que muda

- Adiciona `viewport-fit=cover` à meta tag viewport para permitir edge-to-edge em dispositivos com notch / ilha dinâmica / gesture areas
- Adiciona `theme-color: #1a1a2e` para consistência visual da status bar no Safari
- Define `background-color: #1a1a2e` em `html`, `body` e `#app` para que eventuais faixas de 1px (arredondamento de pixels / DPR) fiquem invisíveis

## O que NÃO muda (decisão do planejamento)

- Nenhum arquivo do Phaser foi alterado
- Nenhum posicionamento de elementos (cartas, botões, labels) foi modificado
- Sem uso de `env(safe-area-inset-*)`

## Critérios de aceitação

- [ ] Canvas ocupa 100% da viewport em iPhone com notch (X, 11, 12, 13, 14, 15)
- [ ] Canvas ocupa 100% da viewport em Android edge-to-edge
- [ ] Nenhuma linha branca ou borda indesejada visível
- [ ] Comportamento em desktop permanece inalterado
- [ ] Rotação de tela (portrait ↔ landscape) mantém ocupação total

> **Nota:** se a faixa branca fina na direita/embaixo persistir, o follow-up deve ser feito via #92 (DPR / Scale Manager).

Closes #93