### PR TITLE
fix: renderiza nítido em telas de alta densidade (DPR > 1)

### DIFF
--- a/src/adapters/phaser/escala.ts
+++ b/src/adapters/phaser/escala.ts
@@ -1,0 +1,13 @@
+import type { Scene } from 'phaser';
+
+export function obterDpr(cena: Scene): number {
+  return 1 / cena.game.scale.zoom;
+}
+
+export function escalar(valor: number, cena: Scene): number {
+  return Math.round(valor * obterDpr(cena));
+}
+
+export function escalarFonte(tamanhoPx: number, cena: Scene): string {
+  return `${String(escalar(tamanhoPx, cena))}px`;
+}

--- a/src/adapters/phaser/renderers/carta-renderer.ts
+++ b/src/adapters/phaser/renderers/carta-renderer.ts
@@ -1,5 +1,6 @@
 import type { GameObjects, Scene } from 'phaser';
 import type { Carta } from '@/core/Carta';
+import { escalar, escalarFonte } from '../escala';
 
 export const LARGURA = 50;
 export const ALTURA = 75;
@@ -14,21 +15,28 @@ export interface ConfigCartaFrente {
 
 export function criarCartaFrente(config: ConfigCartaFrente): GameObjects.Container {
   const { cena, x, y, carta } = config;
+  const largura = escalar(LARGURA, cena);
+  const altura = escalar(ALTURA, cena);
+  const raio = escalar(RAIO, cena);
+  const bordaPx = escalar(1, cena);
   const frente = cena.add.graphics();
-  const bordaPx = 1;
-  const rx = -LARGURA / 2;
-  const ry = -ALTURA / 2;
+  const rx = -largura / 2;
+  const ry = -altura / 2;
 
   frente.fillStyle(0x333333, 1);
-  frente.fillRoundedRect(rx - bordaPx, ry - bordaPx, LARGURA + bordaPx * 2, ALTURA + bordaPx * 2, RAIO + bordaPx);
+  frente.fillRoundedRect(rx - bordaPx, ry - bordaPx, largura + bordaPx * 2, altura + bordaPx * 2, raio + bordaPx);
   frente.fillStyle(0xffffff, 1);
-  frente.fillRoundedRect(rx, ry, LARGURA, ALTURA, RAIO);
+  frente.fillRoundedRect(rx, ry, largura, altura, raio);
 
   const texto = cena.add
-    .text(0, 0, `${carta.valor}${carta.naipe}`, { fontSize: '14px', fontStyle: 'bold', color: '#000000' })
+    .text(0, 0, `${carta.valor}${carta.naipe}`, {
+      fontSize: escalarFonte(14, cena),
+      fontStyle: 'bold',
+      color: '#000000',
+    })
     .setOrigin(0.5);
 
-  return cena.add.container(Math.round(x), Math.round(y), [frente, texto]).setSize(LARGURA, ALTURA);
+  return cena.add.container(Math.round(x), Math.round(y), [frente, texto]).setSize(largura, altura);
 }
 
 export interface ConfigCartaVerso {
@@ -39,14 +47,17 @@ export interface ConfigCartaVerso {
 
 export function criarCartaVerso(config: ConfigCartaVerso): GameObjects.Container {
   const { cena, x, y } = config;
+  const largura = escalar(LARGURA, cena);
+  const altura = escalar(ALTURA, cena);
+  const raio = escalar(RAIO, cena);
+  const bordaPx = escalar(1, cena);
   const verso = cena.add.graphics();
-  const bordaPx = 1;
-  const rx = -LARGURA / 2;
-  const ry = -ALTURA / 2;
+  const rx = -largura / 2;
+  const ry = -altura / 2;
 
   verso.fillStyle(0xd9e8f5, 1);
-  verso.fillRoundedRect(rx - bordaPx, ry - bordaPx, LARGURA + bordaPx * 2, ALTURA + bordaPx * 2, RAIO + bordaPx);
+  verso.fillRoundedRect(rx - bordaPx, ry - bordaPx, largura + bordaPx * 2, altura + bordaPx * 2, raio + bordaPx);
   verso.fillStyle(0x1f4e79, 1);
-  verso.fillRoundedRect(rx, ry, LARGURA, ALTURA, RAIO);
-  return cena.add.container(Math.round(x), Math.round(y), [verso]).setSize(LARGURA, ALTURA);
+  verso.fillRoundedRect(rx, ry, largura, altura, raio);
+  return cena.add.container(Math.round(x), Math.round(y), [verso]).setSize(largura, altura);
 }

--- a/src/adapters/phaser/renderers/destaque-renderer.ts
+++ b/src/adapters/phaser/renderers/destaque-renderer.ts
@@ -1,4 +1,5 @@
 import type { Scene } from 'phaser';
+import { escalar } from '../escala';
 import { LARGURA, ALTURA, RAIO } from './carta-renderer';
 
 export interface EstadoDestaque {
@@ -19,13 +20,20 @@ export function destacarCarta(cena: Scene, container: Phaser.GameObjects.Contain
   }
   estado.highlight.setDepth(101);
   estado.highlight.clear();
-  estado.highlight.lineStyle(3, 0xffff00, 1);
+
+  const largura = escalar(LARGURA, cena);
+  const altura = escalar(ALTURA, cena);
+  const raio = escalar(RAIO, cena);
+  const offset = escalar(4, cena);
+  const espessura = escalar(3, cena);
+
+  estado.highlight.lineStyle(espessura, 0xffff00, 1);
   estado.highlight.strokeRoundedRect(
-    container.x - LARGURA / 2 - 4,
-    container.y - ALTURA / 2 - 4,
-    LARGURA + 8,
-    ALTURA + 8,
-    RAIO + 2,
+    container.x - largura / 2 - offset,
+    container.y - altura / 2 - offset,
+    largura + offset * 2,
+    altura + offset * 2,
+    raio + escalar(2, cena),
   );
 }
 

--- a/src/adapters/phaser/renderers/mao-renderer.ts
+++ b/src/adapters/phaser/renderers/mao-renderer.ts
@@ -1,5 +1,6 @@
 import type { GameObjects, Scene } from 'phaser';
 import type { Carta } from '@/core/Carta';
+import { escalarFonte } from '../escala';
 import { criarCartaFrente, criarCartaVerso } from './carta-renderer';
 
 export interface PosicaoMao {
@@ -39,5 +40,7 @@ export interface ConfigLabel {
 
 export function renderizarLabel(config: ConfigLabel): GameObjects.Text {
   const { cena, x, y, texto } = config;
-  return cena.add.text(x, y, texto, { fontSize: '16px', fontStyle: 'bold', color: '#ffffff' }).setOrigin(0.5);
+  return cena.add
+    .text(x, y, texto, { fontSize: escalarFonte(16, cena), fontStyle: 'bold', color: '#ffffff' })
+    .setOrigin(0.5);
 }

--- a/src/adapters/phaser/renderers/mesa-renderer.ts
+++ b/src/adapters/phaser/renderers/mesa-renderer.ts
@@ -1,5 +1,6 @@
 import type { Scene } from 'phaser';
 import type { Carta } from '@/core/Carta';
+import { escalar } from '../escala';
 import { criarCartaFrente } from './carta-renderer';
 
 export interface ConfigRenderizarMesa {
@@ -12,8 +13,9 @@ export function renderizarMesa(config: ConfigRenderizarMesa): void {
   const { cena, mesa, objetos } = config;
   const cx = cena.cameras.main.width / 2;
   const cy = cena.cameras.main.height / 2;
+  const espacamento = escalar(55, cena);
   mesa.forEach((carta, i) => {
-    const x = cx + (i - mesa.length / 2 + 0.5) * 55;
+    const x = cx + (i - mesa.length / 2 + 0.5) * espacamento;
     const y = cy;
     objetos.push(criarCartaFrente({ cena, x, y, carta }));
   });

--- a/src/adapters/phaser/renderers/posicoes-mao.ts
+++ b/src/adapters/phaser/renderers/posicoes-mao.ts
@@ -13,18 +13,21 @@ export interface ConfigPosicoes {
   margemInferior: number;
   espacamentoCartas: number;
   alturaCarta: number;
+  dpr: number;
 }
 
 export function calcularPosicoes(config: ConfigPosicoes): PosicaoTela[] {
-  const { largura, altura, margem, margemInferior, espacamentoCartas, alturaCarta } = config;
+  const { largura, altura, margem, margemInferior, espacamentoCartas, alturaCarta, dpr } = config;
   const cx = Math.round(largura / 2);
   const cy = Math.round(altura / 2);
-  const dl = alturaCarta / 2 + 10;
+  const offsetBase = Math.round(10 * dpr);
+  const offsetLateral = Math.round(60 * dpr);
+  const dl = alturaCarta / 2 + offsetBase;
   return [
-    posicaoHumano({ cx, altura, margemInferior, dl, espacamento: espacamentoCartas }),
-    posicaoBotEsquerda({ margem, cy, dl, espacamento: espacamentoCartas }),
-    posicaoBotTopo({ cx, margem, dl, espacamento: espacamentoCartas }),
-    posicaoBotDireita({ largura, margem, cy, dl, espacamento: espacamentoCartas }),
+    posicaoHumano({ cx, altura, margemInferior, dl, espacamento: espacamentoCartas, offsetLateral }),
+    posicaoBotEsquerda({ margem, cy, dl, espacamento: espacamentoCartas, offsetLateral }),
+    posicaoBotTopo({ cx, margem, dl, espacamento: espacamentoCartas, offsetLateral }),
+    posicaoBotDireita({ largura, margem, cy, dl, espacamento: espacamentoCartas, offsetLateral }),
   ];
 }
 
@@ -34,12 +37,13 @@ function posicaoHumano(config: {
   margemInferior: number;
   dl: number;
   espacamento: number;
+  offsetLateral: number;
 }): PosicaoTela {
   return {
     labelX: config.cx,
     labelY: Math.round(config.altura - config.margemInferior + config.dl),
     mao: {
-      x: config.cx - 60,
+      x: config.cx - config.offsetLateral,
       y: Math.round(config.altura - config.margemInferior),
       espacamento: config.espacamento,
       direcao: 'horizontal',
@@ -47,19 +51,41 @@ function posicaoHumano(config: {
   };
 }
 
-function posicaoBotEsquerda(config: { margem: number; cy: number; dl: number; espacamento: number }): PosicaoTela {
+function posicaoBotEsquerda(config: {
+  margem: number;
+  cy: number;
+  dl: number;
+  espacamento: number;
+  offsetLateral: number;
+}): PosicaoTela {
   return {
     labelX: config.margem,
-    labelY: Math.round(config.cy - 60 - config.dl),
-    mao: { x: config.margem, y: Math.round(config.cy - 60), espacamento: config.espacamento, direcao: 'vertical' },
+    labelY: Math.round(config.cy - config.offsetLateral - config.dl),
+    mao: {
+      x: config.margem,
+      y: Math.round(config.cy - config.offsetLateral),
+      espacamento: config.espacamento,
+      direcao: 'vertical',
+    },
   };
 }
 
-function posicaoBotTopo(config: { cx: number; margem: number; dl: number; espacamento: number }): PosicaoTela {
+function posicaoBotTopo(config: {
+  cx: number;
+  margem: number;
+  dl: number;
+  espacamento: number;
+  offsetLateral: number;
+}): PosicaoTela {
   return {
     labelX: config.cx,
     labelY: Math.round(config.margem - config.dl),
-    mao: { x: config.cx - 60, y: config.margem, espacamento: config.espacamento, direcao: 'horizontal' },
+    mao: {
+      x: config.cx - config.offsetLateral,
+      y: config.margem,
+      espacamento: config.espacamento,
+      direcao: 'horizontal',
+    },
   };
 }
 
@@ -69,13 +95,14 @@ function posicaoBotDireita(config: {
   cy: number;
   dl: number;
   espacamento: number;
+  offsetLateral: number;
 }): PosicaoTela {
   return {
     labelX: Math.round(config.largura - config.margem),
-    labelY: Math.round(config.cy - 60 - config.dl),
+    labelY: Math.round(config.cy - config.offsetLateral - config.dl),
     mao: {
       x: Math.round(config.largura - config.margem),
-      y: Math.round(config.cy - 60),
+      y: Math.round(config.cy - config.offsetLateral),
       espacamento: config.espacamento,
       direcao: 'vertical',
     },

--- a/src/adapters/phaser/renderers/turno-renderer.ts
+++ b/src/adapters/phaser/renderers/turno-renderer.ts
@@ -1,4 +1,5 @@
 import type { Scene } from 'phaser';
+import { escalar, escalarFonte } from '../escala';
 
 export interface ConfigIndicadorVez {
   cena: Scene;
@@ -64,9 +65,11 @@ export function animarRecolhimentoTurno(config: ConfigAnimarTurno): void {
 export function mostrarOverlayRodadaConcluida(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): void {
   const cx = cena.cameras.main.width / 2;
   const cy = cena.cameras.main.height / 2;
-  const fundo = cena.add.rectangle(cx, cy, 320, 80, 0x000000, 0.7).setDepth(200);
+  const largura = escalar(320, cena);
+  const altura = escalar(80, cena);
+  const fundo = cena.add.rectangle(cx, cy, largura, altura, 0x000000, 0.7).setDepth(200);
   const texto = cena.add
-    .text(cx, cy, 'Rodada concluída', { fontSize: '24px', color: '#ffffff' })
+    .text(cx, cy, 'Rodada concluída', { fontSize: escalarFonte(24, cena), color: '#ffffff' })
     .setOrigin(0.5)
     .setDepth(201);
   objetos.push(fundo, texto);

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -3,6 +3,7 @@ import { Partida } from '@/core/Partida';
 import type { Jogador } from '@/types/entidades';
 import type { MaoJogador } from '@/types/estado-partida';
 import { DecisorHumano } from '../DecisorHumano';
+import { obterDpr, escalar } from '../escala';
 import { fabricarPartida } from '../factories/partida-factory';
 import { criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
@@ -131,16 +132,22 @@ export class JogoScene extends Scene {
     this.atualizarIndicadorVez();
   };
 
-  private desenharMaos(maos: MaoJogador[], partida: Partida): void {
-    this.labels = [];
-    const posicoes = calcularPosicoes({
+  private calcularPosicoesMaos(): ReturnType<typeof calcularPosicoes> {
+    const dpr = obterDpr(this);
+    return calcularPosicoes({
       largura: this.cameras.main.width,
       altura: this.cameras.main.height,
-      margem: MARGEM,
-      margemInferior: MARGEM_INFERIOR,
-      espacamentoCartas: ESPACAMENTO_CARTAS,
-      alturaCarta: ALTURA_CARTA,
+      margem: escalar(MARGEM, this),
+      margemInferior: escalar(MARGEM_INFERIOR, this),
+      espacamentoCartas: escalar(ESPACAMENTO_CARTAS, this),
+      alturaCarta: escalar(ALTURA_CARTA, this),
+      dpr,
     });
+  }
+
+  private desenharMaos(maos: MaoJogador[], partida: Partida): void {
+    this.labels = [];
+    const posicoes = this.calcularPosicoesMaos();
     this.direcoesLabels = posicoes.map((p) => p.mao.direcao);
     maos.forEach((mao, i) => {
       desenharMaoNaCena({

--- a/src/adapters/phaser/scenes/MenuScene.ts
+++ b/src/adapters/phaser/scenes/MenuScene.ts
@@ -1,6 +1,7 @@
 import { Scene } from 'phaser';
 import type { GameObjects } from 'phaser';
 import { precarregarSomUi, prepararSomUi, tocarSomUi } from '../audio/som-ui';
+import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 
 type Graphics = GameObjects.Graphics;
@@ -63,7 +64,7 @@ export class MenuScene extends Scene {
   private criarTitulo(x: number, y: number): void {
     this.titulo = this.add
       .text(x, y, 'FDP', {
-        fontSize: '64px',
+        fontSize: escalarFonte(64, this),
         fontStyle: 'bold',
         color: '#ffffff',
       })
@@ -71,9 +72,9 @@ export class MenuScene extends Scene {
   }
 
   private criarBotao(x: number, y: number): void {
-    const larguraBotao = 200;
-    const alturaBotao = 56;
-    const raio = 12;
+    const larguraBotao = escalar(200, this);
+    const alturaBotao = escalar(56, this);
+    const raio = escalar(12, this);
 
     const posX = x - larguraBotao / 2;
     const posY = y - alturaBotao / 2;
@@ -84,7 +85,7 @@ export class MenuScene extends Scene {
 
     this.botaoTexto = this.add
       .text(x, y, 'Jogar', {
-        fontSize: '24px',
+        fontSize: escalarFonte(24, this),
         fontStyle: 'bold',
         color: '#ffffff',
       })

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ export function inicializarJogo(containerId?: string): Game {
   aoRedimensionar = (): void => {
     if (!jogo) return;
     const dpr = obterDpr();
+    jogo.scale.setZoom(1 / dpr);
     jogo.scale.resize(window.innerWidth * dpr, window.innerHeight * dpr);
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,18 +4,38 @@ import { MenuScene } from './adapters/phaser/scenes/MenuScene';
 import './style.css';
 
 let jogo: Game | null = null;
+let aoRedimensionar: (() => void) | null = null;
 
-export function inicializarJogo(containerId?: string): Game {
-  jogo = new Game({
+function obterDpr(): number {
+  return window.devicePixelRatio || 1;
+}
+
+function criarConfiguracaoJogo(containerId?: string): Phaser.Types.Core.GameConfig {
+  const dpr = obterDpr();
+  return {
     type: Phaser.AUTO,
-    width: window.innerWidth,
-    height: window.innerHeight,
+    width: window.innerWidth * dpr,
+    height: window.innerHeight * dpr,
     parent: containerId,
+    zoom: 1 / dpr,
     scene: [MenuScene, JogoScene],
     scale: {
-      mode: Phaser.Scale.RESIZE,
+      mode: Phaser.Scale.NONE,
     },
-  });
+  };
+}
+
+export function inicializarJogo(containerId?: string): Game {
+  jogo = new Game(criarConfiguracaoJogo(containerId));
+
+  aoRedimensionar = (): void => {
+    if (!jogo) return;
+    const dpr = obterDpr();
+    jogo.scale.resize(window.innerWidth * dpr, window.innerHeight * dpr);
+  };
+
+  window.addEventListener('resize', aoRedimensionar);
+
   return jogo;
 }
 
@@ -29,6 +49,10 @@ if (typeof window !== 'undefined') {
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
+    if (aoRedimensionar) {
+      window.removeEventListener('resize', aoRedimensionar);
+      aoRedimensionar = null;
+    }
     jogo?.destroy(true);
     jogo = null;
   });


### PR DESCRIPTION
## O que faz

Configura o Phaser para renderizar no backing store de resolução física em vez de resolução lógica, eliminando o blur perceptível em dispositivos com DPR ≥ 2 (Retina, smartphones).

## Mudanças principais

- **Phaser config**: 
  -  multiplicados por 
  -  para manter o tamanho visual correto
  -  + listener manual de 
- **Novo helper** :
  -  — obtém DPR atual a partir do zoom do Phaser
  -  — multiplica valor por DPR
  -  — gera string de fonte escalada
- **Renderers atualizados**: todas as dimensões, posições, fontes e espessuras de borda agora usam  ou 

## Critérios de aceitação

- [ ] Cartas e texto aparecem nítidos em dispositivo mobile com DPR ≥ 2
- [ ] Bordas das cartas não apresentam artefatos de sub-pixel
- [ ] Nenhuma linha branca ou artefato visual introduzido no canvas
- [ ] Comportamento em desktop (DPR 1) permanece inalterado

## Como testar

1. Abrir o deploy preview no Chrome DevTools
2. Device toolbar → iPhone 14 / Pixel 7 (DPR = 3)
3. Verificar se cartas e texto estão nítidos, sem blur
4. Alternar para desktop (DPR = 1) e confirmar que tamanhos visuais são idênticos

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic scaling for game UI elements, cards, and text based on device pixel ratio and window size
  * Automatic responsive resizing when screen dimensions change
  * Improved layout consistency across different devices and screen resolutions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->