### PR TITLE
feat: adiciona turno 0 de declaração

### DIFF
--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -1,0 +1,7 @@
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
+
+export class DecisorDeclaracaoBot implements DecisorDeclaracao {
+  declarar(): Promise<number> {
+    return Promise.resolve(0);
+  }
+}

--- a/src/adapters/phaser/DecisorDeclaracaoHumano.ts
+++ b/src/adapters/phaser/DecisorDeclaracaoHumano.ts
@@ -1,0 +1,19 @@
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
+
+export class DecisorDeclaracaoHumano implements DecisorDeclaracao {
+  private resolver?: (valor: number) => void;
+
+  declarar(): Promise<number> {
+    return new Promise((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  confirmar(valor: number): void {
+    if (!this.resolver) {
+      throw new Error('Declaração não iniciada');
+    }
+    this.resolver(valor);
+    this.resolver = undefined;
+  }
+}

--- a/src/adapters/phaser/DecisorDeclaracaoHumano.ts
+++ b/src/adapters/phaser/DecisorDeclaracaoHumano.ts
@@ -2,11 +2,14 @@ import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 
 export class DecisorDeclaracaoHumano implements DecisorDeclaracao {
   private resolver?: (valor: number) => void;
+  private declaracaoPendente?: Promise<number>;
 
   declarar(): Promise<number> {
-    return new Promise((resolve) => {
+    if (this.declaracaoPendente) return this.declaracaoPendente;
+    this.declaracaoPendente = new Promise((resolve) => {
       this.resolver = resolve;
     });
+    return this.declaracaoPendente;
   }
 
   confirmar(valor: number): void {
@@ -15,5 +18,6 @@ export class DecisorDeclaracaoHumano implements DecisorDeclaracao {
     }
     this.resolver(valor);
     this.resolver = undefined;
+    this.declaracaoPendente = undefined;
   }
 }

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,5 +1,7 @@
 import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
+import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import type { Carta, Valor } from '@/core/Carta';
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
@@ -12,7 +14,11 @@ export interface CallbacksRodada {
   onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
 }
 
-export function fabricarRodada(jogadores: Jogador[], decisorHumano: DecisorJogada, callbacks: CallbacksRodada): Rodada {
+export function fabricarRodada(
+  jogadores: Jogador[],
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  callbacks: CallbacksRodada,
+): Rodada {
   const emissor = createEmissorEventos();
   emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
   emissor.on('TURNO_GANHO', (evento) => {
@@ -23,10 +29,16 @@ export function fabricarRodada(jogadores: Jogador[], decisorHumano: DecisorJogad
     callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha);
   });
   const decisores = new Map<string, DecisorJogada>([
-    ['humano', decisorHumano],
+    ['humano', decisoresHumanos.jogada],
     ['bot1', new BotDeterministico()],
     ['bot2', new BotDeterministico()],
     ['bot3', new BotDeterministico()],
   ]);
-  return new Rodada(jogadores, decisores, emissor);
+  const decisoresDeclaracao = new Map<string, DecisorDeclaracao>([
+    ['humano', decisoresHumanos.declaracao],
+    ['bot1', new DecisorDeclaracaoBot()],
+    ['bot2', new DecisorDeclaracaoBot()],
+    ['bot3', new DecisorDeclaracaoBot()],
+  ]);
+  return new Rodada(jogadores, emissor, { jogada: decisores, declaracao: decisoresDeclaracao });
 }

--- a/src/adapters/phaser/input/input-humano.ts
+++ b/src/adapters/phaser/input/input-humano.ts
@@ -61,7 +61,7 @@ interface ConfigClicarCarta {
 
 function aoClicarCarta(config: ConfigClicarCarta): void {
   const { cena, container, carta, rodada, decisorHumano, destaque } = config;
-  if (rodada.estado.fase !== 'aguardandoJogada') {
+  if (rodada.estado.fase !== 'aguardandoJogada' && rodada.estado.fase !== 'processandoTurno') {
     return;
   }
   if (rodada.estado.maos[rodada.estado.jogadorAtual].jogador.id !== 'humano') {

--- a/src/adapters/phaser/input/input-humano.ts
+++ b/src/adapters/phaser/input/input-humano.ts
@@ -61,6 +61,9 @@ interface ConfigClicarCarta {
 
 function aoClicarCarta(config: ConfigClicarCarta): void {
   const { cena, container, carta, rodada, decisorHumano, destaque } = config;
+  if (rodada.estado.fase !== 'aguardandoJogada') {
+    return;
+  }
   if (rodada.estado.maos[rodada.estado.jogadorAtual].jogador.id !== 'humano') {
     return;
   }

--- a/src/adapters/phaser/renderers/declaracao-renderer.ts
+++ b/src/adapters/phaser/renderers/declaracao-renderer.ts
@@ -1,0 +1,46 @@
+import type { Scene } from 'phaser';
+import { escalar } from '../escala';
+
+export interface ConfigDeclaracaoRenderer {
+  cena: Scene;
+  maximo: number;
+  objetos: Phaser.GameObjects.GameObject[];
+  onSelecionar: (valor: number) => void;
+}
+
+export function desenharBotoesDeclaracao(config: ConfigDeclaracaoRenderer): void {
+  const { cena, maximo, objetos, onSelecionar } = config;
+  const centroX = cena.cameras.main.width / 2;
+  const centroY = cena.cameras.main.height / 2;
+  const titulo = cena.add
+    .text(centroX, centroY - escalar(30, cena), 'Declare quantas vai fazer:', {
+      fontSize: `${String(escalar(20, cena))}px`,
+      color: '#ffffff',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+  objetos.push(titulo);
+  for (let i = 0; i <= maximo; i++) {
+    const botao = cena.add
+      .text(centroX + (i - maximo / 2) * escalar(40, cena), centroY + escalar(10, cena), String(i), {
+        fontSize: `${String(escalar(24, cena))}px`,
+        color: '#f1c40f',
+        fontFamily: 'Arial',
+        backgroundColor: '#2c3e50',
+        padding: { x: escalar(8, cena), y: escalar(4, cena) },
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => {
+        onSelecionar(i);
+      });
+    objetos.push(botao);
+  }
+}
+
+export function limparObjetosDeclaracao(objetos: Phaser.GameObjects.GameObject[]): void {
+  objetos.forEach((obj) => {
+    obj.destroy();
+  });
+  objetos.length = 0;
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -68,6 +68,8 @@ export class JogoScene extends Scene {
       decisorHumano: this.decisorDeclaracaoHumano,
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),
+    }).catch((erro: unknown) => {
+      console.error('Erro no fluxo de declaração:', erro);
     });
   }
   private async iniciarFluxoTurno(): Promise<void> {

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -74,8 +74,8 @@ export class JogoScene extends Scene {
     await iniciarProcessamentoTurno({
       cena: this,
       rodada: this.rodada as Rodada,
-      labels: this.labels,
-      direcoesLabels: this.direcoesLabels,
+      getLabels: () => this.labels,
+      getDirecoesLabels: () => this.direcoesLabels,
       turnoAnteriorRef: { valor: this.turnoAnterior },
       jogadores: JOGADORES,
       getVencedorTurno: () => this.vencedorTurno,

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -29,20 +29,20 @@ const JOGADORES: Jogador[] = [
 ];
 
 export class JogoScene extends Scene {
-  objetos: Phaser.GameObjects.GameObject[] = [];
-  redesenhar?: ResizeDebouncer;
-  decisorHumano = new DecisorHumano();
-  decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
-  mesaObjetos: Phaser.GameObjects.GameObject[] = [];
-  objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
-  destaque: EstadoDestaque = {};
-  rodada?: Rodada;
-  labels: Phaser.GameObjects.Text[] = [];
-  direcoesLabels: ('horizontal' | 'vertical')[] = [];
-  tweenVez?: Phaser.Tweens.Tween;
-  turnoAnterior = 1;
-  vencedorTurno?: string;
-  manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
+  private objetos: Phaser.GameObjects.GameObject[] = [];
+  private redesenhar?: ResizeDebouncer;
+  private decisorHumano = new DecisorHumano();
+  private decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
+  private mesaObjetos: Phaser.GameObjects.GameObject[] = [];
+  private objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
+  private destaque: EstadoDestaque = {};
+  private rodada?: Rodada;
+  private labels: Phaser.GameObjects.Text[] = [];
+  private direcoesLabels: ('horizontal' | 'vertical')[] = [];
+  private tweenVez?: Phaser.Tweens.Tween;
+  private turnoAnterior = 1;
+  private vencedorTurno?: string;
+  private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
 
   constructor() {
     super({ key: 'JogoScene' });

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -2,13 +2,13 @@ import { Scene } from 'phaser';
 import { Rodada } from '@/core/Rodada';
 import type { Jogador } from '@/types/entidades';
 import type { MaoJogador } from '@/types/estado-rodada';
+import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import { DecisorHumano } from '../DecisorHumano';
 import { obterDpr, escalar } from '../escala';
 import { fabricarRodada } from '../factories/rodada-factory';
 import { criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
-import { atualizarLabelVencedor } from '../renderers/label-jogador';
 import { limparObjetos } from '../renderers/limpar-objetos';
 import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
 import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
@@ -19,6 +19,7 @@ import {
   atualizarIndicadorVez,
   mostrarOverlayRodadaConcluida,
 } from '../renderers/turno-renderer';
+import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
 
 const JOGADORES: Jogador[] = [
   { id: 'humano', nome: 'Você', pontos: 5 },
@@ -28,18 +29,20 @@ const JOGADORES: Jogador[] = [
 ];
 
 export class JogoScene extends Scene {
-  private objetos: Phaser.GameObjects.GameObject[] = [];
-  private redesenhar?: ResizeDebouncer;
-  private decisorHumano = new DecisorHumano();
-  private mesaObjetos: Phaser.GameObjects.GameObject[] = [];
-  private destaque: EstadoDestaque = {};
-  private rodada?: Rodada;
-  private labels: Phaser.GameObjects.Text[] = [];
-  private direcoesLabels: ('horizontal' | 'vertical')[] = [];
-  private tweenVez?: Phaser.Tweens.Tween;
-  private turnoAnterior = 1;
-  private vencedorTurno?: string;
-  private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
+  objetos: Phaser.GameObjects.GameObject[] = [];
+  redesenhar?: ResizeDebouncer;
+  decisorHumano = new DecisorHumano();
+  decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
+  mesaObjetos: Phaser.GameObjects.GameObject[] = [];
+  objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
+  destaque: EstadoDestaque = {};
+  rodada?: Rodada;
+  labels: Phaser.GameObjects.Text[] = [];
+  direcoesLabels: ('horizontal' | 'vertical')[] = [];
+  tweenVez?: Phaser.Tweens.Tween;
+  turnoAnterior = 1;
+  vencedorTurno?: string;
+  manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
 
   constructor() {
     super({ key: 'JogoScene' });
@@ -48,30 +51,51 @@ export class JogoScene extends Scene {
     this.cameras.main.setBackgroundColor('#1a1a2e');
     this.rodada = this.criarRodada();
     this.rodada.distribuir(4);
-    this.turnoAnterior = 1;
     this.atualizarManilha();
     this.desenharMaos(this.rodada.estado.maos);
     this.atualizarIndicadorVez();
-    void this.iniciarProcessamentoTurno();
+    this.iniciarFluxoDeclaracao();
     this.redesenhar = criarDebounceResize(this, this.redesenharTela);
     this.scale.on('resize', this.redesenhar);
     this.events.once('shutdown', this.aoEncerrar);
   }
-  private criarRodada(): Rodada {
-    return fabricarRodada(JOGADORES, this.decisorHumano, {
-      onCartaJogada: () => {
-        this.redesenharTela();
-      },
-      onTurnoGanho: (id) => {
-        this.vencedorTurno = id;
-      },
-      onRodadaEncerrada: () => {
-        this.mostrarOverlayRodadaConcluida();
-      },
-      onManilhaVirada: () => {
-        this.atualizarManilha();
-      },
+  private iniciarFluxoDeclaracao(): void {
+    if (!this.rodada) return;
+    void processarDeclaracoes({
+      cena: this,
+      rodada: this.rodada,
+      objetos: this.objetosDeclaracao,
+      decisorHumano: this.decisorDeclaracaoHumano,
+      atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
+      iniciarTurnos: this.iniciarFluxoTurno.bind(this),
     });
+  }
+  private async iniciarFluxoTurno(): Promise<void> {
+    await iniciarProcessamentoTurno({
+      cena: this,
+      rodada: this.rodada as Rodada,
+      labels: this.labels,
+      direcoesLabels: this.direcoesLabels,
+      turnoAnteriorRef: { valor: this.turnoAnterior },
+      jogadores: JOGADORES,
+      getVencedorTurno: () => this.vencedorTurno,
+      animarRecolhimento: this.animarRecolhimentoTurno.bind(this),
+      atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
+    });
+  }
+  private criarRodada(): Rodada {
+    return fabricarRodada(
+      JOGADORES,
+      { jogada: this.decisorHumano, declaracao: this.decisorDeclaracaoHumano },
+      {
+        onCartaJogada: this.redesenharTela,
+        onTurnoGanho: (id) => {
+          this.vencedorTurno = id;
+        },
+        onRodadaEncerrada: this.mostrarOverlayRodadaConcluida.bind(this),
+        onManilhaVirada: this.atualizarManilha.bind(this),
+      },
+    );
   }
   private atualizarManilha(): void {
     limparManilha(this.manilhaObjetos);
@@ -79,32 +103,6 @@ export class JogoScene extends Scene {
     const { cartaVirada, manilha } = this.rodada.estado;
     if (!cartaVirada) return;
     desenharManilha({ cena: this, cartaVirada, manilha, objetos: this.manilhaObjetos });
-  }
-  private async iniciarProcessamentoTurno(): Promise<void> {
-    while (this.rodada && this.rodada.estado.fase !== 'rodadaConcluida') {
-      const jogadorAtual = this.rodada.estado.jogadorAtual;
-      const ehBot = this.rodada.estado.maos[jogadorAtual].jogador.id !== 'humano';
-      if (ehBot) await new Promise((resolve) => this.time.delayedCall(500, resolve));
-      try {
-        await this.rodada.jogarTurno();
-      } catch {
-        break;
-      }
-      if (this.rodada.estado.turno > this.turnoAnterior) {
-        this.turnoAnterior = this.rodada.estado.turno;
-        const vencedorId = this.vencedorTurno;
-        this.animarRecolhimentoTurno();
-        await new Promise((resolve) => this.time.delayedCall(800, resolve));
-        atualizarLabelVencedor({
-          vencedorId,
-          jogadores: JOGADORES,
-          vazas: this.rodada.estado.vazas,
-          labels: this.labels,
-          direcoes: this.direcoesLabels,
-        });
-      }
-      this.atualizarIndicadorVez();
-    }
   }
   private atualizarMesa(): void {
     limparObjetos(this.mesaObjetos);

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -35,7 +35,11 @@ export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<v
     limparObjetosDeclaracao(config.objetos);
     config.atualizarIndicadorVez();
   }
-  if (rodada.estado.fase === 'aguardandoJogada') void config.iniciarTurnos();
+  if (rodada.estado.fase === 'aguardandoJogada') {
+    void config.iniciarTurnos().catch((erro: unknown) => {
+      console.error('Erro nos turnos:', erro);
+    });
+  }
 }
 
 async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void> {

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -17,8 +17,8 @@ interface ConfigDeclaracoes {
 interface ConfigTurnos {
   cena: JogoScene;
   rodada: Rodada;
-  labels: Phaser.GameObjects.Text[];
-  direcoesLabels: ('horizontal' | 'vertical')[];
+  getLabels: () => Phaser.GameObjects.Text[];
+  getDirecoesLabels: () => ('horizontal' | 'vertical')[];
   turnoAnteriorRef: { valor: number };
   jogadores: Jogador[];
   getVencedorTurno: () => string | undefined;
@@ -83,8 +83,8 @@ async function atualizarFimDeTurno(config: ConfigTurnos): Promise<void> {
     vencedorId,
     jogadores: config.jogadores,
     vazas: rodada.estado.vazas,
-    labels: config.labels,
-    direcoes: config.direcoesLabels,
+    labels: config.getLabels(),
+    direcoes: config.getDirecoesLabels(),
   });
 }
 

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -100,7 +100,8 @@ async function tentarDeclarar(rodada: Rodada): Promise<boolean> {
   try {
     await rodada.declarar();
     return true;
-  } catch {
+  } catch (erro) {
+    console.error('Falha em declarar:', erro);
     return false;
   }
 }
@@ -109,7 +110,8 @@ async function tentarJogarTurno(rodada: Rodada): Promise<boolean> {
   try {
     await rodada.jogarTurno();
     return true;
-  } catch {
+  } catch (erro) {
+    console.error('Falha em jogarTurno:', erro);
     return false;
   }
 }

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -1,0 +1,117 @@
+import type { Rodada } from '@/core/Rodada';
+import type { Jogador } from '@/types/entidades';
+import type { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
+import { desenharBotoesDeclaracao, limparObjetosDeclaracao } from '../renderers/declaracao-renderer';
+import { atualizarLabelVencedor } from '../renderers/label-jogador';
+import type { JogoScene } from './JogoScene';
+
+interface ConfigDeclaracoes {
+  cena: JogoScene;
+  rodada: Rodada;
+  objetos: Phaser.GameObjects.GameObject[];
+  decisorHumano: DecisorDeclaracaoHumano;
+  atualizarIndicadorVez: () => void;
+  iniciarTurnos: () => Promise<void>;
+}
+
+interface ConfigTurnos {
+  cena: JogoScene;
+  rodada: Rodada;
+  labels: Phaser.GameObjects.Text[];
+  direcoesLabels: ('horizontal' | 'vertical')[];
+  turnoAnteriorRef: { valor: number };
+  jogadores: Jogador[];
+  getVencedorTurno: () => string | undefined;
+  animarRecolhimento: () => void;
+  atualizarIndicadorVez: () => void;
+}
+
+export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<void> {
+  const { rodada } = config;
+  while (faseDeclaracao(rodada)) {
+    await prepararDeclaracaoAtual(config);
+    const declarou = await tentarDeclarar(rodada);
+    if (!declarou) return;
+    limparObjetosDeclaracao(config.objetos);
+    config.atualizarIndicadorVez();
+  }
+  if (rodada.estado.fase === 'aguardandoJogada') void config.iniciarTurnos();
+}
+
+async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void> {
+  const { cena, rodada } = config;
+  const maoAtual = rodada.estado.maos[rodada.estado.jogadorAtual];
+  if (maoAtual.jogador.id !== 'humano') {
+    await esperar(cena, 400);
+    return;
+  }
+  limparObjetosDeclaracao(config.objetos);
+  desenharBotoesDeclaracao({
+    cena,
+    maximo: rodada.estado.cartasPorRodada,
+    objetos: config.objetos,
+    onSelecionar: (valor: number) => {
+      config.decisorHumano.confirmar(valor);
+    },
+  });
+}
+
+export async function iniciarProcessamentoTurno(config: ConfigTurnos): Promise<void> {
+  const { rodada } = config;
+  while (rodada.estado.fase !== 'rodadaConcluida') {
+    await aguardarBotAtual(config);
+    const jogou = await tentarJogarTurno(rodada);
+    if (!jogou) return;
+    await atualizarFimDeTurno(config);
+    config.atualizarIndicadorVez();
+  }
+}
+
+async function aguardarBotAtual(config: ConfigTurnos): Promise<void> {
+  const maoAtual = config.rodada.estado.maos[config.rodada.estado.jogadorAtual];
+  if (maoAtual.jogador.id !== 'humano') await esperar(config.cena, 500);
+}
+
+async function atualizarFimDeTurno(config: ConfigTurnos): Promise<void> {
+  const { rodada, turnoAnteriorRef } = config;
+  if (rodada.estado.turno <= turnoAnteriorRef.valor) return;
+  turnoAnteriorRef.valor = rodada.estado.turno;
+  const vencedorId = config.getVencedorTurno();
+  config.animarRecolhimento();
+  await esperar(config.cena, 800);
+  atualizarLabelVencedor({
+    vencedorId,
+    jogadores: config.jogadores,
+    vazas: rodada.estado.vazas,
+    labels: config.labels,
+    direcoes: config.direcoesLabels,
+  });
+}
+
+function faseDeclaracao(rodada: Rodada): boolean {
+  return rodada.estado.fase === 'aguardandoDeclaracao' || rodada.estado.fase === 'processandoDeclaracao';
+}
+
+async function tentarDeclarar(rodada: Rodada): Promise<boolean> {
+  try {
+    await rodada.declarar();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tentarJogarTurno(rodada: Rodada): Promise<boolean> {
+  try {
+    await rodada.jogarTurno();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function esperar(cena: JogoScene, ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    cena.time.delayedCall(ms, resolve);
+  });
+}

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -87,12 +87,20 @@ export class Rodada {
     }
     try {
       const declaracao = await decisor.declarar(this._estado, this._estado.maos[this._estado.jogadorAtual].cartas);
+      this.validarDeclaracao(declaracao);
       this._estado.declaracoes[jogador.id] = declaracao;
       emitirDeclaracaoFeita(this.emissor, jogador.id, declaracao);
       this.avancarDeclaracao();
     } catch (erro) {
       this._estado.fase = 'aguardandoDeclaracao';
       throw erro;
+    }
+  }
+
+  private validarDeclaracao(declaracao: number): void {
+    const maximo = this._estado.cartasPorRodada;
+    if (!Number.isInteger(declaracao) || declaracao < 0 || declaracao > maximo) {
+      throw new Error(`Declaração inválida: ${String(declaracao)}`);
     }
   }
 

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -2,8 +2,10 @@ import type { Jogador } from '@/types/entidades';
 import type { EstadoRodada } from '@/types/estado-rodada';
 import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
-import { compararNaipe, compararValor, ehManilha, obterProximoValor } from './Carta';
+import { obterProximoValor } from './Carta';
 import type { Carta } from './Carta';
+import { calcularIndiceVencedor } from './comparador-carta';
+import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 
 interface Emissor {
@@ -13,12 +15,21 @@ interface Emissor {
 export class Rodada {
   private _estado: EstadoRodada;
   private decisores: Map<string, DecisorJogada>;
+  private decisoresDeclaracao: Map<string, DecisorDeclaracao>;
   private emissor: Emissor;
   private jogadores: Jogador[];
 
-  constructor(jogadores: Jogador[], decisores: Map<string, DecisorJogada>, emissor: Emissor) {
+  constructor(
+    jogadores: Jogador[],
+    emissor: Emissor,
+    decisores: {
+      jogada: Map<string, DecisorJogada>;
+      declaracao: Map<string, DecisorDeclaracao>;
+    },
+  ) {
     this.jogadores = jogadores;
-    this.decisores = decisores;
+    this.decisores = decisores.jogada;
+    this.decisoresDeclaracao = decisores.declaracao;
     this.emissor = emissor;
     this._estado = {
       fase: 'distribuindo',
@@ -30,6 +41,7 @@ export class Rodada {
       cartasPorRodada: 0,
       manilha: '3',
       cartaVirada: null,
+      declaracoes: {},
     };
   }
 
@@ -52,7 +64,8 @@ export class Rodada {
     this._estado.cartasPorRodada = numeroCartas;
     this._estado.manilha = manilha;
     this._estado.cartaVirada = cartaVirada;
-    this._estado.fase = 'aguardandoJogada';
+    this._estado.declaracoes = {};
+    this._estado.fase = 'aguardandoDeclaracao';
 
     if (cartaVirada) {
       this.emissor.emit({
@@ -62,6 +75,45 @@ export class Rodada {
         cartaVirada,
         manilha,
       });
+    }
+  }
+
+  async declarar(): Promise<void> {
+    if (this._estado.fase !== 'aguardandoDeclaracao') {
+      throw new Error(`Não é possível declarar na fase ${this._estado.fase}`);
+    }
+    this._estado.fase = 'processandoDeclaracao';
+    const jogador = this.jogadores[this._estado.jogadorAtual];
+    const decisor = this.decisoresDeclaracao.get(jogador.id);
+    if (!decisor) {
+      this._estado.fase = 'aguardandoDeclaracao';
+      throw new Error(`Decisor de declaração não encontrado para jogador ${jogador.id}`);
+    }
+    try {
+      const declaracao = await decisor.declarar(this._estado, this._estado.maos[this._estado.jogadorAtual].cartas);
+      this._estado.declaracoes[jogador.id] = declaracao;
+      this.emissor.emit({
+        id: crypto.randomUUID(),
+        timestamp: Date.now(),
+        tipo: 'DECLARACAO_FEITA',
+        jogadorId: jogador.id,
+        declarado: declaracao,
+      });
+      this.avancarDeclaracao();
+    } catch (erro) {
+      this._estado.fase = 'aguardandoDeclaracao';
+      throw erro;
+    }
+  }
+
+  private avancarDeclaracao(): void {
+    const totalDeclaracoes = Object.keys(this._estado.declaracoes).length;
+    if (totalDeclaracoes === this.jogadores.length) {
+      this._estado.fase = 'aguardandoJogada';
+      this._estado.jogadorAtual = 0;
+    } else {
+      this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
+      this._estado.fase = 'aguardandoDeclaracao';
     }
   }
 
@@ -88,21 +140,9 @@ export class Rodada {
     const mao = this._estado.maos[this._estado.jogadorAtual].cartas;
     const carta = await decisor.decidirJogada(mao, this._estado);
     const indiceCarta = mao.findIndex((c) => c.valor === carta.valor && c.naipe === carta.naipe);
-    if (indiceCarta === -1) {
-      throw new Error(`Jogada inválida para jogador ${jogador.id}`);
-    }
-    this.removerCartaDaMao(indiceCarta);
+    if (indiceCarta === -1) throw new Error(`Jogada inválida para jogador ${jogador.id}`);
+    this._estado.maos[this._estado.jogadorAtual].cartas = [...mao.slice(0, indiceCarta), ...mao.slice(indiceCarta + 1)];
     this._estado.mesa.push({ jogadorId: jogador.id, carta });
-    this.emitirCartaJogada(jogador, carta);
-    this.avancarJogador();
-  }
-
-  private removerCartaDaMao(indice: number): void {
-    const mao = this._estado.maos[this._estado.jogadorAtual].cartas;
-    this._estado.maos[this._estado.jogadorAtual].cartas = [...mao.slice(0, indice), ...mao.slice(indice + 1)];
-  }
-
-  private emitirCartaJogada(jogador: Jogador, carta: Carta): void {
     this.emissor.emit({
       id: crypto.randomUUID(),
       timestamp: Date.now(),
@@ -111,6 +151,7 @@ export class Rodada {
       carta,
       posicaoMesa: this._estado.mesa.length - 1,
     });
+    this.avancarJogador();
   }
 
   private avancarJogador(): void {
@@ -125,48 +166,6 @@ export class Rodada {
   private resolverTurno(): void {
     const vencedor = this.calcularVencedorTurno();
     this._estado.vazas[vencedor.id] = (this._estado.vazas[vencedor.id] ?? 0) + 1;
-    this.emitirTurnoGanho(vencedor);
-    this._estado.turno += 1;
-    this._estado.mesa = [];
-
-    if (this._estado.turno > this._estado.cartasPorRodada) {
-      this._estado.fase = 'rodadaConcluida';
-      this.emitirRodadaEncerrada();
-    } else {
-      this._estado.fase = 'aguardandoJogada';
-      this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === vencedor.id);
-    }
-  }
-
-  private calcularVencedorTurno(): Jogador {
-    let indiceMelhor = 0;
-    for (let i = 1; i < this._estado.mesa.length; i++) {
-      const cartaAtual = this._estado.mesa[i].carta;
-      const cartaMelhor = this._estado.mesa[indiceMelhor].carta;
-      if (this.cartaVence(cartaAtual, cartaMelhor)) {
-        indiceMelhor = i;
-      }
-    }
-    const jogadorId = this._estado.mesa[indiceMelhor].jogadorId;
-    const vencedor = this.jogadores.find((j) => j.id === jogadorId);
-    if (!vencedor) throw new Error('Vencedor não encontrado');
-    return vencedor;
-  }
-
-  private cartaVence(carta: Carta, outra: Carta): boolean {
-    const cartaEhManilha = ehManilha(carta, this._estado.manilha);
-    const outraEhManilha = ehManilha(outra, this._estado.manilha);
-
-    if (cartaEhManilha && !outraEhManilha) return true;
-    if (!cartaEhManilha && outraEhManilha) return false;
-    if (cartaEhManilha && outraEhManilha) return compararNaipe(carta, outra);
-
-    if (compararValor(carta, outra)) return true;
-    if (compararValor(outra, carta)) return false;
-    return compararNaipe(carta, outra);
-  }
-
-  private emitirTurnoGanho(vencedor: Jogador): void {
     this.emissor.emit({
       id: crypto.randomUUID(),
       timestamp: Date.now(),
@@ -174,15 +173,28 @@ export class Rodada {
       jogadorId: vencedor.id,
       cartas: this._estado.mesa.map((m) => m.carta),
     });
+    this._estado.turno += 1;
+    this._estado.mesa = [];
+    if (this._estado.turno > this._estado.cartasPorRodada) {
+      this._estado.fase = 'rodadaConcluida';
+      this.emissor.emit({
+        id: crypto.randomUUID(),
+        timestamp: Date.now(),
+        tipo: 'RODADA_ENCERRADA',
+        placar: { ...this._estado.vazas },
+        proximaRodada: null,
+      });
+    } else {
+      this._estado.fase = 'aguardandoJogada';
+      this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === vencedor.id);
+    }
   }
 
-  private emitirRodadaEncerrada(): void {
-    this.emissor.emit({
-      id: crypto.randomUUID(),
-      timestamp: Date.now(),
-      tipo: 'RODADA_ENCERRADA',
-      placar: { ...this._estado.vazas },
-      proximaRodada: null,
-    });
+  private calcularVencedorTurno(): Jogador {
+    const indiceMelhor = calcularIndiceVencedor(this._estado.mesa, this._estado.manilha);
+    const jogadorId = this._estado.mesa[indiceMelhor].jogadorId;
+    const vencedor = this.jogadores.find((j) => j.id === jogadorId);
+    if (!vencedor) throw new Error('Vencedor não encontrado');
+    return vencedor;
   }
 }

--- a/src/core/comparador-carta.ts
+++ b/src/core/comparador-carta.ts
@@ -11,7 +11,7 @@ export function cartaVence(carta: Carta, outra: Carta, manilha: Carta['valor']):
 
   if (compararValor(carta, outra)) return true;
   if (compararValor(outra, carta)) return false;
-  return compararNaipe(carta, outra);
+  return false;
 }
 
 export function calcularIndiceVencedor(mesa: { carta: Carta }[], manilha: Carta['valor']): number {

--- a/src/core/comparador-carta.ts
+++ b/src/core/comparador-carta.ts
@@ -1,0 +1,27 @@
+import { compararNaipe, compararValor, ehManilha } from './Carta';
+import type { Carta } from './Carta';
+
+export function cartaVence(carta: Carta, outra: Carta, manilha: Carta['valor']): boolean {
+  const cartaEhManilha = ehManilha(carta, manilha);
+  const outraEhManilha = ehManilha(outra, manilha);
+
+  if (cartaEhManilha && !outraEhManilha) return true;
+  if (!cartaEhManilha && outraEhManilha) return false;
+  if (cartaEhManilha && outraEhManilha) return compararNaipe(carta, outra);
+
+  if (compararValor(carta, outra)) return true;
+  if (compararValor(outra, carta)) return false;
+  return compararNaipe(carta, outra);
+}
+
+export function calcularIndiceVencedor(mesa: { carta: Carta }[], manilha: Carta['valor']): number {
+  let indiceMelhor = 0;
+  for (let i = 1; i < mesa.length; i++) {
+    const cartaAtual = mesa[i].carta;
+    const cartaMelhor = mesa[indiceMelhor].carta;
+    if (cartaVence(cartaAtual, cartaMelhor, manilha)) {
+      indiceMelhor = i;
+    }
+  }
+  return indiceMelhor;
+}

--- a/src/core/portas/DecisorDeclaracao.ts
+++ b/src/core/portas/DecisorDeclaracao.ts
@@ -1,0 +1,6 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoRodada } from '@/types/estado-rodada';
+
+export interface DecisorDeclaracao {
+  declarar(estado: EstadoRodada, mao: Carta[]): Promise<number>;
+}

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -3,6 +3,8 @@ import type { Jogador } from './entidades';
 
 export type FaseRodada =
   | 'distribuindo'
+  | 'aguardandoDeclaracao'
+  | 'processandoDeclaracao'
   | 'aguardandoJogada'
   | 'processandoTurno'
   | 'turnoConcluido'
@@ -29,4 +31,5 @@ export interface EstadoRodada {
   cartasPorRodada: number;
   manilha: Valor;
   cartaVirada: Carta | null;
+  declaracoes: Record<string, number>;
 }

--- a/tests/core/Rodada.declaracao.test.ts
+++ b/tests/core/Rodada.declaracao.test.ts
@@ -157,3 +157,23 @@ describe('Rodada — declaração — hardening', () => {
     expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
   });
 });
+
+describe('Rodada — declaração — valores invalidos', () => {
+  it.each([
+    ['negativa', -1],
+    ['fracionaria', 1.5],
+    ['maior que cartas da rodada', 3],
+  ])('deve rejeitar declaracao %s', async (_caso, valor) => {
+    const emissor = createEmissorEventos();
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('DECLARACAO_FEITA', handler);
+    const jogadores = [criarJogador('j1', 'J1')];
+    const decisoresDeclaracao = new Map([['j1', criarDecisorDeclaracao(valor)]]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    await expect(rodada.declarar()).rejects.toThrow('Declaração inválida');
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
+    expect(rodada.estado.declaracoes).toEqual({});
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/core/Rodada.declaracao.test.ts
+++ b/tests/core/Rodada.declaracao.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
+import { Rodada } from '@/core/Rodada';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import { criarJogador, jogadoresPadrao } from './rodada-fixtures';
+
+function criarDecisorDeclaracao(valor: number): DecisorDeclaracao {
+  return { declarar: vi.fn().mockResolvedValue(valor) };
+}
+
+describe('Rodada — declaração — transições', () => {
+  it('deve iniciar na fase aguardandoDeclaracao apos distribuir', () => {
+    const emissor = createEmissorEventos();
+    const jogadores = jogadoresPadrao();
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
+    expect(rodada.estado.fase).toBe('distribuindo');
+    rodada.distribuir(1);
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
+    expect(rodada.estado.jogadorAtual).toBe(0);
+    expect(rodada.estado.cartasPorRodada).toBe(1);
+    expect(rodada.estado.declaracoes).toEqual({});
+  });
+
+  it('deve rejeitar jogarTurno na fase aguardandoDeclaracao', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = jogadoresPadrao();
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
+    rodada.distribuir(1);
+    await expect(rodada.jogarTurno()).rejects.toThrow('Não é possível jogar na fase aguardandoDeclaracao');
+  });
+});
+
+describe('Rodada — declaração — decisor', () => {
+  it('deve chamar DecisorDeclaracao para o jogador atual', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2')];
+    const mockDecisor = criarDecisorDeclaracao(1);
+    const decisoresDeclaracao = new Map([['j1', mockDecisor]]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    await rodada.declarar();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockDecisor.declarar).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockDecisor.declarar).toHaveBeenCalledWith(rodada.estado, expect.any(Array));
+  });
+});
+
+describe('Rodada — declaração — estado', () => {
+  it('deve armazenar declaracao no estado', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2')];
+    const decisoresDeclaracao = new Map([
+      ['j1', criarDecisorDeclaracao(2)],
+      ['j2', criarDecisorDeclaracao(0)],
+    ]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(3);
+    await rodada.declarar();
+    await rodada.declarar();
+    expect(rodada.estado.declaracoes).toEqual({ j1: 2, j2: 0 });
+  });
+});
+
+describe('Rodada — declaração — eventos', () => {
+  it('deve emitir evento DECLARACAO_FEITA por jogador', async () => {
+    const emissor = createEmissorEventos();
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('DECLARACAO_FEITA', handler);
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2')];
+    const decisoresDeclaracao = new Map([
+      ['j1', criarDecisorDeclaracao(1)],
+      ['j2', criarDecisorDeclaracao(0)],
+    ]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    await rodada.declarar();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ tipo: 'DECLARACAO_FEITA', jogadorId: 'j1', declarado: 1 }),
+    );
+    await rodada.declarar();
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ tipo: 'DECLARACAO_FEITA', jogadorId: 'j2', declarado: 0 }),
+    );
+  });
+});
+
+describe('Rodada — declaração — ordem', () => {
+  it('deve avancar jogadorAtual em ordem anti-horaria durante declaracao', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3')];
+    const decisoresDeclaracao = new Map([
+      ['j1', criarDecisorDeclaracao(1)],
+      ['j2', criarDecisorDeclaracao(1)],
+      ['j3', criarDecisorDeclaracao(1)],
+    ]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    expect(rodada.estado.jogadorAtual).toBe(0);
+    await rodada.declarar();
+    expect(rodada.estado.jogadorAtual).toBe(1);
+    await rodada.declarar();
+    expect(rodada.estado.jogadorAtual).toBe(2);
+  });
+});
+
+describe('Rodada — declaração — transicao', () => {
+  it('deve transitar para aguardandoJogada apos todos declararem', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2')];
+    const decisoresDeclaracao = new Map([
+      ['j1', criarDecisorDeclaracao(1)],
+      ['j2', criarDecisorDeclaracao(0)],
+    ]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    await rodada.declarar();
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
+    await rodada.declarar();
+    expect(rodada.estado.fase).toBe('aguardandoJogada');
+    expect(rodada.estado.jogadorAtual).toBe(0);
+  });
+});
+
+describe('Rodada — declaração — valor zero', () => {
+  it('deve permitir declarar 0', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1')];
+    const decisoresDeclaracao = new Map([['j1', criarDecisorDeclaracao(0)]]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(3);
+    await rodada.declarar();
+    expect(rodada.estado.declaracoes['j1']).toBe(0);
+  });
+});
+
+describe('Rodada — declaração — hardening', () => {
+  it('deve restaurar fase para aguardandoDeclaracao quando decisor rejeita', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1')];
+    const decisor = { declarar: vi.fn().mockRejectedValue(new Error('Erro do decisor')) };
+    const decisoresDeclaracao = new Map([['j1', decisor]]);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
+    rodada.distribuir(2);
+    await expect(rodada.declarar()).rejects.toThrow('Erro do decisor');
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
+  });
+
+  it('deve restaurar fase quando decisor de declaracao nao eh encontrado', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1')];
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
+    rodada.distribuir(2);
+    await expect(rodada.declarar()).rejects.toThrow('Decisor de declaração não encontrado');
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
+  });
+});

--- a/tests/core/Rodada.manilha.test.ts
+++ b/tests/core/Rodada.manilha.test.ts
@@ -16,7 +16,7 @@ describe('Rodada — carta virada removida', () => {
       criarCarta('J', '♦'),
       criarCarta('10', '♣'),
     ];
-    const rodada = new Rodada(jogadores, new Map(), emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
     rodada.distribuir(2, baralho);
     const todasCartas = rodada.estado.maos.flatMap((m) => m.cartas);
     expect(todasCartas).toHaveLength(4);
@@ -33,7 +33,7 @@ describe('Rodada — evento MANILHA_VIRADA', () => {
     emissor.on('MANILHA_VIRADA', handler);
     const jogadores = [criarJogador('j1', 'J1')];
     const baralho: Carta[] = [criarCarta('5', '♥'), criarCarta('4', '♣')];
-    const rodada = new Rodada(jogadores, new Map(), emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
     rodada.distribuir(1, baralho);
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(
@@ -50,7 +50,7 @@ describe('Rodada — sem carta para virar', () => {
   it('deve definir manilha como 3 quando não há carta para virar', () => {
     const emissor = createEmissorEventos();
     const jogadores = [criarJogador('j1', 'J1')];
-    const rodada = new Rodada(jogadores, new Map(), emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
     rodada.distribuir(0, []);
     expect(rodada.estado.manilha).toBe('3');
     expect(rodada.estado.cartaVirada).toBeNull();
@@ -65,7 +65,7 @@ describe('Rodada — manilha vence não-manilha', () => {
       ['j1', criarDecisorPrimeiraCarta()],
       ['j2', criarDecisorPrimeiraCarta()],
     ]);
-    const rodada = new Rodada(jogadores, decisores, emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
       _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
     };
@@ -86,7 +86,7 @@ describe('Rodada — desempate de manilhas', () => {
       ['j1', criarDecisorPrimeiraCarta()],
       ['j2', criarDecisorPrimeiraCarta()],
     ]);
-    const rodada = new Rodada(jogadores, decisores, emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
       _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
     };

--- a/tests/core/Rodada.test.ts
+++ b/tests/core/Rodada.test.ts
@@ -13,10 +13,10 @@ describe('Rodada — transições', () => {
       ['j1', criarDecisor(criarCarta('4', '♣'))],
       ['j2', criarDecisor(criarCarta('5', '♥'))],
     ]);
-    const rodada = new Rodada(jogadores, decisores, emissor);
+    const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     expect(rodada.estado.fase).toBe('distribuindo');
     rodada.distribuir(1);
-    expect(rodada.estado.fase).toBe('aguardandoJogada');
+    expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
     expect(rodada.estado.jogadorAtual).toBe(0);
     expect(rodada.estado.cartasPorRodada).toBe(1);
   });

--- a/tests/core/comparador-carta.test.ts
+++ b/tests/core/comparador-carta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cartaVence, calcularIndiceVencedor } from '@/core/comparador-carta';
+import { cartaVence, calcularIndiceVencedor, cartasEmpatam } from '@/core/comparador-carta';
 import { criarCarta } from './rodada-fixtures';
 
 describe('comparador-carta', () => {
@@ -26,5 +26,23 @@ describe('comparador-carta', () => {
   it('deve calcular índice do vencedor na mesa', () => {
     const mesa = [{ carta: criarCarta('2', '♥') }, { carta: criarCarta('3', '♠') }, { carta: criarCarta('A', '♦') }];
     expect(calcularIndiceVencedor(mesa, '4')).toBe(1);
+  });
+});
+
+describe('cartasEmpatam', () => {
+  it('deve identificar empate entre cartas não-manilha de mesmo valor', () => {
+    expect(cartasEmpatam(criarCarta('3', '♣'), criarCarta('3', '♦'), '4')).toBe(true);
+  });
+
+  it('deve rejeitar empate entre manilha e não-manilha', () => {
+    expect(cartasEmpatam(criarCarta('4', '♣'), criarCarta('3', '♦'), '4')).toBe(false);
+  });
+
+  it('deve rejeitar empate entre duas manilhas', () => {
+    expect(cartasEmpatam(criarCarta('4', '♣'), criarCarta('4', '♦'), '4')).toBe(false);
+  });
+
+  it('deve rejeitar empate entre cartas de valores diferentes', () => {
+    expect(cartasEmpatam(criarCarta('3', '♣'), criarCarta('2', '♦'), '4')).toBe(false);
   });
 });

--- a/tests/core/comparador-carta.test.ts
+++ b/tests/core/comparador-carta.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { cartaVence, calcularIndiceVencedor } from '@/core/comparador-carta';
+import { criarCarta } from './rodada-fixtures';
+
+describe('comparador-carta', () => {
+  it('deve fazer manilha vencer carta não-manilha', () => {
+    expect(cartaVence(criarCarta('4', '♣'), criarCarta('3', '♦'), '4')).toBe(true);
+    expect(cartaVence(criarCarta('3', '♦'), criarCarta('4', '♣'), '4')).toBe(false);
+  });
+
+  it('deve desempatar manilhas pelo naipe', () => {
+    expect(cartaVence(criarCarta('4', '♣'), criarCarta('4', '♦'), '4')).toBe(true);
+    expect(cartaVence(criarCarta('4', '♦'), criarCarta('4', '♣'), '4')).toBe(false);
+  });
+
+  it('deve comparar valor quando nenhuma é manilha', () => {
+    expect(cartaVence(criarCarta('3', '♣'), criarCarta('2', '♦'), '4')).toBe(true);
+    expect(cartaVence(criarCarta('2', '♦'), criarCarta('3', '♣'), '4')).toBe(false);
+  });
+
+  it('deve desempatar pelo naipe quando valores são iguais', () => {
+    expect(cartaVence(criarCarta('3', '♣'), criarCarta('3', '♦'), '4')).toBe(true);
+    expect(cartaVence(criarCarta('3', '♦'), criarCarta('3', '♣'), '4')).toBe(false);
+  });
+
+  it('deve calcular índice do vencedor na mesa', () => {
+    const mesa = [{ carta: criarCarta('2', '♥') }, { carta: criarCarta('3', '♠') }, { carta: criarCarta('A', '♦') }];
+    expect(calcularIndiceVencedor(mesa, '4')).toBe(1);
+  });
+});

--- a/tests/core/comparador-carta.test.ts
+++ b/tests/core/comparador-carta.test.ts
@@ -18,8 +18,8 @@ describe('comparador-carta', () => {
     expect(cartaVence(criarCarta('2', '♦'), criarCarta('3', '♣'), '4')).toBe(false);
   });
 
-  it('deve desempatar pelo naipe quando valores são iguais', () => {
-    expect(cartaVence(criarCarta('3', '♣'), criarCarta('3', '♦'), '4')).toBe(true);
+  it('deve empatar quando cartas não-manilha têm o mesmo valor', () => {
+    expect(cartaVence(criarCarta('3', '♣'), criarCarta('3', '♦'), '4')).toBe(false);
     expect(cartaVence(criarCarta('3', '♦'), criarCarta('3', '♣'), '4')).toBe(false);
   });
 

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import type { Carta } from '@/core/Carta';
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
@@ -41,9 +42,16 @@ export function criarRodada(config: {
   decisores: Map<string, DecisorJogada>;
   emissor: ReturnType<typeof createEmissorEventos>;
   cartasPorRodada?: number;
+  decisoresDeclaracao?: Map<string, DecisorDeclaracao>;
 }): Rodada {
-  const rodada = new Rodada(config.jogadores, config.decisores, config.emissor);
+  const rodada = new Rodada(config.jogadores, config.emissor, {
+    jogada: config.decisores,
+    declaracao: config.decisoresDeclaracao ?? new Map<string, DecisorDeclaracao>(),
+  });
   rodada.distribuir(config.cartasPorRodada ?? 1);
+  const estado = (rodada as unknown as EstadoPrivado)._estado;
+  estado.fase = 'aguardandoJogada';
+  estado.declaracoes = {};
   return rodada;
 }
 
@@ -61,8 +69,12 @@ export function criarRodadaComMao(config: {
   turno?: number;
   cartasPorRodada?: number;
   manilha?: Carta['valor'];
+  declaracoes?: Record<string, number>;
 }): Rodada {
-  const rodada = new Rodada(config.jogadores, config.decisores, config.emissor);
+  const rodada = new Rodada(config.jogadores, config.emissor, {
+    jogada: config.decisores,
+    declaracao: new Map<string, DecisorDeclaracao>(),
+  });
   const estado = (rodada as unknown as EstadoPrivado)._estado;
   estado.maos = config.jogadores.map((jogador, i) => ({
     jogador,
@@ -71,11 +83,10 @@ export function criarRodadaComMao(config: {
   }));
   estado.fase = config.fase ?? 'aguardandoJogada';
   estado.jogadorAtual = config.jogadorAtual ?? 0;
-  estado.vazas = {};
   estado.turno = config.turno ?? 1;
   estado.cartasPorRodada = config.cartasPorRodada ?? 4;
   estado.manilha = config.manilha ?? '3';
-  estado.cartaVirada = null;
+  estado.declaracoes = config.declaracoes ?? {};
   return rodada;
 }
 


### PR DESCRIPTION
## Resumo

- Cria o port `DecisorDeclaracao` e o fluxo de declaração sequencial na `Rodada`
- Expõe `declaracoes` no estado público e emite `DECLARACAO_FEITA`
- Adiciona decisores de declaração humano/bot e UI de seleção antes das jogadas
- Integra com as mudanças de empate vindas de `origin/main`

## Validação

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run tests/core`
- `pnpm build`
- pre-push: `pnpm typecheck` e `pnpm test`

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a declaration phase before card play with UI buttons and human confirm flow; AI opponents also declare.
* **Improvements**
  * Refined turn processing and winner resolution to handle asynchronous declarations and produce more consistent outcomes.
* **Tests**
  * Added comprehensive tests for declaration flow and card-comparison logic covering normal and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->