### PR TITLE
feat: aplica pontuação ao fim da rodada

### DIFF
--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -48,7 +48,7 @@ export class Rodada {
       manilha: '3',
       cartaVirada: null,
       declaracoes: {},
-      pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, 5])),
+      pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos])),
     };
   }
 

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -8,11 +8,13 @@ import {
   emitirCartaJogada,
   emitirDeclaracaoFeita,
   emitirManilhaVirada,
+  emitirPontuacaoAplicada,
   emitirRodadaEncerrada,
   emitirTurnoEmpatado,
   emitirTurnoGanho,
   type EmissorRodada,
 } from './eventos-rodada';
+import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 
@@ -46,6 +48,7 @@ export class Rodada {
       manilha: '3',
       cartaVirada: null,
       declaracoes: {},
+      pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, 5])),
     };
   }
 
@@ -173,6 +176,11 @@ export class Rodada {
     this._estado.mesa = [];
     if (this._estado.turno > this._estado.cartasPorRodada) {
       this._estado.fase = 'rodadaConcluida';
+      const pontos = aplicarPontuacao(
+        this._estado,
+        this.jogadores.map((j) => j.id),
+      );
+      emitirPontuacaoAplicada(this.emissor, pontos.pontos, pontos.penalidades);
       emitirRodadaEncerrada(this.emissor, { ...this._estado.vazas });
     } else {
       this._estado.fase = 'aguardandoJogada';

--- a/src/core/eventos-rodada.ts
+++ b/src/core/eventos-rodada.ts
@@ -39,3 +39,11 @@ export function emitirTurnoEmpatado(emissor: EmissorRodada, ultimoEmpatadoId: st
 export function emitirRodadaEncerrada(emissor: EmissorRodada, placar: Record<string, number>): void {
   emissor.emit({ ...base(), tipo: 'RODADA_ENCERRADA', placar, proximaRodada: null });
 }
+
+export function emitirPontuacaoAplicada(
+  emissor: EmissorRodada,
+  placar: Record<string, number>,
+  penalidades: Record<string, number>,
+): void {
+  emissor.emit({ ...base(), tipo: 'PONTUACAO_APLICADA', placar, penalidades });
+}

--- a/src/core/pontuacao.ts
+++ b/src/core/pontuacao.ts
@@ -1,0 +1,43 @@
+interface PontuacaoConfig {
+  declaracoes: Record<string, number>;
+  vazas: Record<string, number>;
+  pontosAtuais: Record<string, number>;
+  jogadoresIds: string[];
+}
+
+export interface ResultadoPontuacao {
+  pontos: Record<string, number>;
+  penalidades: Record<string, number>;
+}
+
+interface EstadoPontuavel {
+  declaracoes: Record<string, number>;
+  vazas: Record<string, number>;
+  pontos: Record<string, number>;
+}
+
+export function calcularPontuacao(config: PontuacaoConfig): ResultadoPontuacao {
+  const pontos: Record<string, number> = {};
+  const penalidades: Record<string, number> = {};
+
+  for (const jogadorId of config.jogadoresIds) {
+    const declarado = config.declaracoes[jogadorId] ?? 0;
+    const feito = config.vazas[jogadorId] ?? 0;
+    const penalidade = Math.abs(declarado - feito);
+    penalidades[jogadorId] = penalidade;
+    pontos[jogadorId] = (config.pontosAtuais[jogadorId] ?? 5) - penalidade;
+  }
+
+  return { pontos, penalidades };
+}
+
+export function aplicarPontuacao(estado: EstadoPontuavel, jogadoresIds: string[]): ResultadoPontuacao {
+  const resultado = calcularPontuacao({
+    declaracoes: estado.declaracoes,
+    vazas: estado.vazas,
+    pontosAtuais: estado.pontos,
+    jogadoresIds,
+  });
+  estado.pontos = resultado.pontos;
+  return resultado;
+}

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -32,4 +32,5 @@ export interface EstadoRodada {
   manilha: Valor;
   cartaVirada: Carta | null;
   declaracoes: Record<string, number>;
+  pontos: Record<string, number>;
 }

--- a/src/types/evento-map.ts
+++ b/src/types/evento-map.ts
@@ -4,6 +4,7 @@ import type {
   JogoEncerrado,
   JogoIniciado,
   ManilhaVirada,
+  PontuacaoAplicada,
   RodadaEncerrada,
   TurnoEmpatado,
   TurnoGanho,
@@ -20,6 +21,7 @@ export interface EventoMap {
   TURNO_GANHO: TurnoGanho;
   TURNO_EMPATADO: TurnoEmpatado;
   RODADA_ENCERRADA: RodadaEncerrada;
+  PONTUACAO_APLICADA: PontuacaoAplicada;
   JOGO_ENCERRADO: JogoEncerrado;
   // --- Eventos de input ---
   TOQUE_CARTA: ToqueCarta;

--- a/src/types/eventos-dominio.ts
+++ b/src/types/eventos-dominio.ts
@@ -49,6 +49,12 @@ export interface RodadaEncerrada extends EventoBase {
   proximaRodada: number | null;
 }
 
+export interface PontuacaoAplicada extends EventoBase {
+  tipo: 'PONTUACAO_APLICADA';
+  placar: Record<string, number>;
+  penalidades: Record<string, number>;
+}
+
 export interface JogoEncerrado extends EventoBase {
   tipo: 'JOGO_ENCERRADO';
   classificacao: Jogador[];
@@ -62,4 +68,5 @@ export type EventoDominio =
   | TurnoGanho
   | TurnoEmpatado
   | RodadaEncerrada
+  | PontuacaoAplicada
   | JogoEncerrado;

--- a/tests/core/Rodada.rodada.test.ts
+++ b/tests/core/Rodada.rodada.test.ts
@@ -27,7 +27,8 @@ function rodadaComMaoFixa(maos: Carta[][], cartasPorRodada = 1) {
   const emissor = createEmissorEventos();
   const jogadores = jogadoresPadrao();
   const decisores = new Map(jogadores.map((j) => [j.id, criarDecisorPrimeiraCarta()]));
-  const rodada = criarRodadaComMao({ jogadores, decisores, emissor, maos, cartasPorRodada });
+  const declaracoes = Object.fromEntries(jogadores.map((jogador) => [jogador.id, 0]));
+  const rodada = criarRodadaComMao({ jogadores, decisores, emissor, maos, cartasPorRodada, declaracoes });
   return { emissor, rodada };
 }
 
@@ -55,6 +56,11 @@ describe('Rodada — cálculo de vencedor', () => {
 });
 
 describe('Rodada — vazas e rodada', () => {
+  it('deve iniciar todos os jogadores com 5 pontos', () => {
+    const { rodada } = rodadaComMaoFixa(MAO_CURTA);
+    expect(rodada.estado.pontos).toEqual({ j1: 5, j2: 5, j3: 5, j4: 5 });
+  });
+
   it('deve acumular 4 vazas após 4 turnos', async () => {
     const { rodada } = rodadaComMaoFixa(MAO_LONGA, 4);
     await jogarTurnos(rodada, 16);
@@ -65,6 +71,24 @@ describe('Rodada — vazas e rodada', () => {
     const { rodada } = rodadaComMaoFixa(MAO_LONGA, 4);
     await jogarTurnos(rodada, 16);
     expect(rodada.estado.fase).toBe('rodadaConcluida');
+  });
+});
+
+describe('Rodada — pontuação', () => {
+  it('deve subtrair penalidades dos pontos ao fim da rodada', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = jogadoresPadrao();
+    const decisores = new Map(jogadores.map((j) => [j.id, criarDecisorPrimeiraCarta()]));
+    const rodada = criarRodadaComMao({
+      jogadores,
+      decisores,
+      emissor,
+      maos: MAO_CURTA,
+      cartasPorRodada: 1,
+      declaracoes: { j1: 1, j2: 1, j3: 0, j4: 0 },
+    });
+    await jogarTurnos(rodada, 4);
+    expect(rodada.estado.pontos).toEqual({ j1: 5, j2: 4, j3: 5, j4: 5 });
   });
 });
 
@@ -88,6 +112,22 @@ describe('Rodada — eventos de turno e rodada', () => {
       expect.objectContaining({
         tipo: 'RODADA_ENCERRADA',
         placar: { j1: 1, j2: 1, j3: 1, j4: 1 },
+      }),
+    );
+  });
+});
+
+describe('Rodada — eventos de pontuação', () => {
+  it('deve emitir PONTUACAO_APLICADA com placar e penalidades', async () => {
+    const { emissor, rodada } = rodadaComMaoFixa(MAO_CURTA);
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('PONTUACAO_APLICADA', handler);
+    await jogarTurnos(rodada, 4);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tipo: 'PONTUACAO_APLICADA',
+        placar: { j1: 4, j2: 5, j3: 5, j4: 5 },
+        penalidades: { j1: 1, j2: 0, j3: 0, j4: 0 },
       }),
     );
   });

--- a/tests/core/Rodada.rodada.test.ts
+++ b/tests/core/Rodada.rodada.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Carta } from '@/core/Carta';
 import { createEmissorEventos } from '@/store/emissor-eventos';
-import { criarCarta, criarDecisorPrimeiraCarta, criarRodadaComMao, jogadoresPadrao } from './rodada-fixtures';
+import {
+  criarCarta,
+  criarDecisorPrimeiraCarta,
+  criarRodada,
+  criarRodadaComMao,
+  jogadoresPadrao,
+} from './rodada-fixtures';
 
 const MAO_CURTA: Carta[][] = [
   [criarCarta('A', '♣')],
@@ -59,6 +65,17 @@ describe('Rodada — vazas e rodada', () => {
   it('deve iniciar todos os jogadores com 5 pontos', () => {
     const { rodada } = rodadaComMaoFixa(MAO_CURTA);
     expect(rodada.estado.pontos).toEqual({ j1: 5, j2: 5, j3: 5, j4: 5 });
+  });
+
+  it('deve preservar pontos atuais dos jogadores ao criar rodada', () => {
+    const emissor = createEmissorEventos();
+    const jogadores = jogadoresPadrao().map((jogador, indice) => ({
+      ...jogador,
+      pontos: 5 - indice,
+    }));
+    const decisores = new Map(jogadores.map((j) => [j.id, criarDecisorPrimeiraCarta()]));
+    const rodada = criarRodada({ jogadores, decisores, emissor });
+    expect(rodada.estado.pontos).toEqual({ j1: 5, j2: 4, j3: 3, j4: 2 });
   });
 
   it('deve acumular 4 vazas após 4 turnos', async () => {

--- a/tests/core/pontuacao.test.ts
+++ b/tests/core/pontuacao.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { calcularPontuacao } from '@/core/pontuacao';
+
+const jogadoresIds = ['j1', 'j2', 'j3', 'j4'];
+
+function calcular(declaracoes: Record<string, number>, vazas: Record<string, number>, pontos = 5) {
+  return calcularPontuacao({
+    declaracoes,
+    vazas,
+    pontosAtuais: Object.fromEntries(jogadoresIds.map((jogadorId) => [jogadorId, pontos])),
+    jogadoresIds,
+  });
+}
+
+describe('Pontuação', () => {
+  it('deve manter pontos quando declarou 3 e fez 3', () => {
+    expect(calcular({ j1: 3 }, { j1: 3 }).pontos.j1).toBe(5);
+  });
+
+  it('deve perder 2 pontos quando declarou 3 e fez 1', () => {
+    expect(calcular({ j1: 3 }, { j1: 1 }).pontos.j1).toBe(3);
+  });
+
+  it('deve perder 2 pontos quando declarou 0 e fez 2', () => {
+    expect(calcular({ j1: 0 }, { j1: 2 }).pontos.j1).toBe(3);
+  });
+
+  it('deve perder 3 pontos quando declarou 5 e fez 2', () => {
+    expect(calcular({ j1: 5 }, { j1: 2 }).pontos.j1).toBe(2);
+  });
+
+  it('deve permitir pontos negativos', () => {
+    expect(calcular({ j1: 5 }, { j1: 0 }, 1).pontos.j1).toBe(-4);
+  });
+});

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -60,7 +60,7 @@ interface EstadoPrivado {
 }
 
 function pontosIniciais(jogadores: Jogador[]): Record<string, number> {
-  return Object.fromEntries(jogadores.map((jogador) => [jogador.id, 5]));
+  return Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos]));
 }
 
 function preencherEstadoComMao(estado: EstadoRodada, config: ConfigRodadaComMao): void {

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -59,23 +59,11 @@ interface EstadoPrivado {
   _estado: EstadoRodada;
 }
 
-export function criarRodadaComMao(config: {
-  jogadores: Jogador[];
-  decisores: Map<string, DecisorJogada>;
-  emissor: ReturnType<typeof createEmissorEventos>;
-  maos: Carta[][];
-  jogadorAtual?: number;
-  fase?: EstadoRodada['fase'];
-  turno?: number;
-  cartasPorRodada?: number;
-  manilha?: Carta['valor'];
-  declaracoes?: Record<string, number>;
-}): Rodada {
-  const rodada = new Rodada(config.jogadores, config.emissor, {
-    jogada: config.decisores,
-    declaracao: new Map<string, DecisorDeclaracao>(),
-  });
-  const estado = (rodada as unknown as EstadoPrivado)._estado;
+function pontosIniciais(jogadores: Jogador[]): Record<string, number> {
+  return Object.fromEntries(jogadores.map((jogador) => [jogador.id, 5]));
+}
+
+function preencherEstadoComMao(estado: EstadoRodada, config: ConfigRodadaComMao): void {
   estado.maos = config.jogadores.map((jogador, i) => ({
     jogador,
     cartas: config.maos[i] ?? [],
@@ -87,6 +75,32 @@ export function criarRodadaComMao(config: {
   estado.cartasPorRodada = config.cartasPorRodada ?? 4;
   estado.manilha = config.manilha ?? '3';
   estado.declaracoes = config.declaracoes ?? {};
+  estado.pontos = config.pontos ?? pontosIniciais(config.jogadores);
+  estado.vazas = config.vazas ?? {};
+}
+
+interface ConfigRodadaComMao {
+  jogadores: Jogador[];
+  decisores: Map<string, DecisorJogada>;
+  emissor: ReturnType<typeof createEmissorEventos>;
+  maos: Carta[][];
+  jogadorAtual?: number;
+  fase?: EstadoRodada['fase'];
+  turno?: number;
+  cartasPorRodada?: number;
+  manilha?: Carta['valor'];
+  declaracoes?: Record<string, number>;
+  pontos?: Record<string, number>;
+  vazas?: Record<string, number>;
+}
+
+export function criarRodadaComMao(config: ConfigRodadaComMao): Rodada {
+  const rodada = new Rodada(config.jogadores, config.emissor, {
+    jogada: config.decisores,
+    declaracao: new Map<string, DecisorDeclaracao>(),
+  });
+  const estado = (rodada as unknown as EstadoPrivado)._estado;
+  preencherEstadoComMao(estado, config);
   return rodada;
 }
 


### PR DESCRIPTION
## Resumo

- Adiciona `pontos` ao estado público da rodada, inicializado com 5 por jogador
- Calcula penalidades `|declarado - feito|` ao fim da rodada e atualiza o placar, permitindo pontuação negativa
- Emite `PONTUACAO_APLICADA` com placar completo e penalidades por jogador
- Cobre cálculo puro e integração da pontuação no encerramento da rodada

## Validação

- `pnpm test -- --run tests/core/pontuacao.test.ts tests/core/Rodada.rodada.test.ts`
- `pnpm test -- --run tests/core`
- `pnpm typecheck`
- `pnpm lint` (passa com warnings preexistentes de `console` no adapter Phaser)
- `pnpm build`
- pre-push: `pnpm typecheck` e `pnpm test`

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scoring system with automatic penalty calculation based on declared vs. actual round performance.
  * Per-player point tracking throughout rounds, with scores properly calculated and applied upon round completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->