### PR TITLE
feat: adiciona loop de rodadas

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,7 @@ export default defineConfig(
             'tests/core/*.ts',
             'tests/e2e/*.spec.ts',
           ],
-          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 16,
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 32,
           noWarnOnMultipleProjects: true,
         },
         tsconfigRootDir: import.meta.dirname,

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -17,43 +17,7 @@ export interface CallbacksRodada {
   onRodadaIniciada?: () => void;
 }
 
-export function fabricarRodada(
-  jogadores: Jogador[],
-  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
-  callbacks: CallbacksRodada,
-): Rodada {
-  const emissor = createEmissorEventos();
-  emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
-  emissor.on('TURNO_GANHO', (evento) => {
-    callbacks.onTurnoGanho(evento.jogadorId);
-  });
-  emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
-  emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
-  emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
-  emissor.on('MANILHA_VIRADA', (evento) => {
-    callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha);
-  });
-  const decisores = new Map<string, DecisorJogada>([
-    ['humano', decisoresHumanos.jogada],
-    ['bot1', new BotDeterministico()],
-    ['bot2', new BotDeterministico()],
-    ['bot3', new BotDeterministico()],
-  ]);
-  const decisoresDeclaracao = new Map<string, DecisorDeclaracao>([
-    ['humano', decisoresHumanos.declaracao],
-    ['bot1', new DecisorDeclaracaoBot()],
-    ['bot2', new DecisorDeclaracaoBot()],
-    ['bot3', new DecisorDeclaracaoBot()],
-  ]);
-  return new Rodada(jogadores, emissor, { jogada: decisores, declaracao: decisoresDeclaracao });
-}
-
-export function fabricarPartida(
-  jogadores: Jogador[],
-  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
-  callbacks: CallbacksRodada,
-): Partida {
-  const emissor = createEmissorEventos();
+function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, callbacks: CallbacksRodada): void {
   emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
   emissor.on('TURNO_GANHO', (evento) => {
     callbacks.onTurnoGanho(evento.jogadorId);
@@ -62,17 +26,45 @@ export function fabricarPartida(
   emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
   emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
   emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
-  const decisores = new Map<string, DecisorJogada>([
+}
+
+function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao }): {
+  jogada: Map<string, DecisorJogada>;
+  declaracao: Map<string, DecisorDeclaracao>;
+} {
+  const jogada = new Map<string, DecisorJogada>([
     ['humano', decisoresHumanos.jogada],
     ['bot1', new BotDeterministico()],
     ['bot2', new BotDeterministico()],
     ['bot3', new BotDeterministico()],
   ]);
-  const decisoresDeclaracao = new Map<string, DecisorDeclaracao>([
+  const declaracao = new Map<string, DecisorDeclaracao>([
     ['humano', decisoresHumanos.declaracao],
     ['bot1', new DecisorDeclaracaoBot()],
     ['bot2', new DecisorDeclaracaoBot()],
     ['bot3', new DecisorDeclaracaoBot()],
   ]);
-  return new Partida(jogadores, emissor, { jogada: decisores, declaracao: decisoresDeclaracao });
+  return { jogada, declaracao };
+}
+
+export function fabricarRodada(
+  jogadores: Jogador[],
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  callbacks: CallbacksRodada,
+): Rodada {
+  const emissor = createEmissorEventos();
+  registrarCallbacks(emissor, callbacks);
+  const decisores = criarDecisores(decisoresHumanos);
+  return new Rodada(jogadores, emissor, decisores);
+}
+
+export function fabricarPartida(
+  jogadores: Jogador[],
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  callbacks: CallbacksRodada,
+): Partida {
+  const emissor = createEmissorEventos();
+  registrarCallbacks(emissor, callbacks);
+  const decisores = criarDecisores(decisoresHumanos);
+  return new Partida(jogadores, emissor, decisores);
 }

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,6 +1,7 @@
 import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import type { Carta, Valor } from '@/core/Carta';
+import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
@@ -13,6 +14,7 @@ export interface CallbacksRodada {
   onTurnoEmpatado: () => void;
   onRodadaEncerrada: () => void;
   onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
+  onRodadaIniciada?: () => void;
 }
 
 export function fabricarRodada(
@@ -27,6 +29,7 @@ export function fabricarRodada(
   });
   emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
   emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
+  emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
   emissor.on('MANILHA_VIRADA', (evento) => {
     callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha);
   });
@@ -43,4 +46,33 @@ export function fabricarRodada(
     ['bot3', new DecisorDeclaracaoBot()],
   ]);
   return new Rodada(jogadores, emissor, { jogada: decisores, declaracao: decisoresDeclaracao });
+}
+
+export function fabricarPartida(
+  jogadores: Jogador[],
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  callbacks: CallbacksRodada,
+): Partida {
+  const emissor = createEmissorEventos();
+  emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
+  emissor.on('TURNO_GANHO', (evento) => {
+    callbacks.onTurnoGanho(evento.jogadorId);
+  });
+  emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
+  emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
+  emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
+  emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
+  const decisores = new Map<string, DecisorJogada>([
+    ['humano', decisoresHumanos.jogada],
+    ['bot1', new BotDeterministico()],
+    ['bot2', new BotDeterministico()],
+    ['bot3', new BotDeterministico()],
+  ]);
+  const decisoresDeclaracao = new Map<string, DecisorDeclaracao>([
+    ['humano', decisoresHumanos.declaracao],
+    ['bot1', new DecisorDeclaracaoBot()],
+    ['bot2', new DecisorDeclaracaoBot()],
+    ['bot3', new DecisorDeclaracaoBot()],
+  ]);
+  return new Partida(jogadores, emissor, { jogada: decisores, declaracao: decisoresDeclaracao });
 }

--- a/src/adapters/phaser/renderers/indicador-rodada-renderer.ts
+++ b/src/adapters/phaser/renderers/indicador-rodada-renderer.ts
@@ -1,0 +1,28 @@
+import type { Scene } from 'phaser';
+import type { Valor } from '@/core/Carta';
+import { escalar, escalarFonte } from '../escala';
+import { limparObjetos } from './limpar-objetos';
+
+export interface ConfigIndicadorRodada {
+  cena: Scene;
+  numeroRodada: number;
+  manilha: Valor;
+  objetos: Phaser.GameObjects.GameObject[];
+}
+
+export function desenharIndicadorRodada(config: ConfigIndicadorRodada): void {
+  const { cena, numeroRodada, manilha, objetos } = config;
+  limparObjetos(objetos);
+  const x = cena.cameras.main.width / 2;
+  const y = escalar(24, cena);
+  const texto = cena.add
+    .text(x, y, `Rodada ${numeroRodada.toString()} · Manilha: ${manilha}`, {
+      fontSize: escalarFonte(16, cena),
+      color: '#ffffff',
+      backgroundColor: '#00000099',
+      padding: { x: escalar(10, cena), y: escalar(6, cena) },
+    })
+    .setOrigin(0.5, 0)
+    .setDepth(120);
+  objetos.push(texto);
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -1,32 +1,24 @@
 import { Scene } from 'phaser';
+import { Partida } from '@/core/Partida';
 import { Rodada } from '@/core/Rodada';
-import type { Jogador } from '@/types/entidades';
-import type { MaoJogador } from '@/types/estado-rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import { DecisorHumano } from '../DecisorHumano';
-import { obterDpr, escalar } from '../escala';
-import { fabricarRodada } from '../factories/rodada-factory';
+import { fabricarPartida } from '../factories/rodada-factory';
 import { criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
+import { desenharIndicadorRodada } from '../renderers/indicador-rodada-renderer';
 import { limparObjetos } from '../renderers/limpar-objetos';
 import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
-import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
-import { calcularPosicoes } from '../renderers/posicoes-mao';
 import {
   animarRecolhimentoTurno,
   atualizarIndicadorVez,
   mostrarOverlayRodadaConcluida,
 } from '../renderers/turno-renderer';
+import { desenharMaosJogo } from './desenhar-maos-jogo';
+import { JOGADORES } from './jogadores';
 import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
-
-const JOGADORES: Jogador[] = [
-  { id: 'humano', nome: 'Você', pontos: 5 },
-  { id: 'bot1', nome: 'Bot 1', pontos: 5 },
-  { id: 'bot2', nome: 'Bot 2', pontos: 5 },
-  { id: 'bot3', nome: 'Bot 3', pontos: 5 },
-];
 
 export class JogoScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
@@ -36,46 +28,44 @@ export class JogoScene extends Scene {
   private mesaObjetos: Phaser.GameObjects.GameObject[] = [];
   private objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
   private destaque: EstadoDestaque = {};
-  private rodada?: Rodada;
+  private partida?: Partida;
   private labels: Phaser.GameObjects.Text[] = [];
   private direcoesLabels: ('horizontal' | 'vertical')[] = [];
   private tweenVez?: Phaser.Tweens.Tween;
   private turnoAnterior = 1;
   private vencedorTurno?: string;
   private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
+  private indicadorRodadaObjetos: Phaser.GameObjects.GameObject[] = [];
 
   constructor() {
     super({ key: 'JogoScene' });
   }
   create(): void {
     this.cameras.main.setBackgroundColor('#1a1a2e');
-    this.rodada = this.criarRodada();
-    this.rodada.distribuir(4);
-    this.atualizarManilha();
-    this.desenharMaos(this.rodada.estado.maos);
-    this.atualizarIndicadorVez();
-    this.iniciarFluxoDeclaracao();
+    this.partida = this.criarPartida();
+    this.iniciarNovaRodada();
     this.redesenhar = criarDebounceResize(this, this.redesenharTela);
     this.scale.on('resize', this.redesenhar);
     this.events.once('shutdown', this.aoEncerrar);
   }
   private iniciarFluxoDeclaracao(): void {
-    if (!this.rodada) return;
+    const rodada = this.partida?.rodadaAtual;
+    if (!rodada) return;
     void processarDeclaracoes({
       cena: this,
-      rodada: this.rodada,
+      rodada,
       objetos: this.objetosDeclaracao,
       decisorHumano: this.decisorDeclaracaoHumano,
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),
-    }).catch((erro: unknown) => {
-      console.error('Erro no fluxo de declaração:', erro);
-    });
+    }).catch(() => undefined);
   }
   private async iniciarFluxoTurno(): Promise<void> {
+    const rodada = this.partida?.rodadaAtual;
+    if (!rodada) return;
     await iniciarProcessamentoTurno({
       cena: this,
-      rodada: this.rodada as Rodada,
+      rodada,
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
       turnoAnteriorRef: { valor: this.turnoAnterior },
@@ -85,8 +75,8 @@ export class JogoScene extends Scene {
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
     });
   }
-  private criarRodada(): Rodada {
-    return fabricarRodada(
+  private criarPartida(): Partida {
+    return fabricarPartida(
       JOGADORES,
       { jogada: this.decisorHumano, declaracao: this.decisorDeclaracaoHumano },
       {
@@ -97,30 +87,52 @@ export class JogoScene extends Scene {
         onTurnoEmpatado: () => {
           this.vencedorTurno = undefined;
         },
-        onRodadaEncerrada: this.mostrarOverlayRodadaConcluida.bind(this),
+        onRodadaEncerrada: this.transicionarRodada.bind(this),
         onManilhaVirada: this.atualizarManilha.bind(this),
+        onRodadaIniciada: this.atualizarIndicadorRodada.bind(this),
       },
     );
   }
+  private iniciarNovaRodada(): void {
+    this.turnoAnterior = 1;
+    this.vencedorTurno = undefined;
+    this.partida?.iniciarProximaRodada();
+    this.atualizarManilha();
+    this.redesenharTela();
+    this.iniciarFluxoDeclaracao();
+  }
   private atualizarManilha(): void {
     limparManilha(this.manilhaObjetos);
-    if (!this.rodada) return;
-    const { cartaVirada, manilha } = this.rodada.estado;
+    const estado = this.partida?.estado;
+    if (!estado) return;
+    const { cartaVirada, manilha } = estado;
     if (!cartaVirada) return;
     desenharManilha({ cena: this, cartaVirada, manilha, objetos: this.manilhaObjetos });
   }
+  private atualizarIndicadorRodada(): void {
+    const estado = this.partida?.estado;
+    if (!estado?.numeroRodada) return;
+    desenharIndicadorRodada({
+      cena: this,
+      numeroRodada: estado.numeroRodada,
+      manilha: estado.manilha,
+      objetos: this.indicadorRodadaObjetos,
+    });
+  }
   private atualizarMesa(): void {
     limparObjetos(this.mesaObjetos);
-    if (!this.rodada) return;
-    const cartas = this.rodada.estado.mesa.map((m) => m.carta);
+    const estado = this.partida?.estado;
+    if (!estado) return;
+    const cartas = estado.mesa.map((m) => m.carta);
     renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos });
   }
   private atualizarIndicadorVez(): void {
-    if (!this.rodada) return;
+    const estado = this.partida?.estado;
+    if (!estado) return;
     this.tweenVez = atualizarIndicadorVez({
       cena: this,
       labels: this.labels,
-      jogadorAtual: this.rodada.estado.jogadorAtual,
+      jogadorAtual: estado.jogadorAtual,
       tweenAtual: this.tweenVez,
     });
   }
@@ -128,38 +140,24 @@ export class JogoScene extends Scene {
     destruirDestaque(this.destaque);
     limparObjetos(this.objetos);
     this.atualizarManilha();
+    this.atualizarIndicadorRodada();
     limparObjetos(this.mesaObjetos);
-    if (!this.rodada) return;
-    this.desenharMaos(this.rodada.estado.maos);
+    const estado = this.partida?.estado;
+    if (!estado) return;
+    this.desenharMaos(estado.maos);
     this.atualizarMesa();
     this.atualizarIndicadorVez();
   };
-  private calcularPosicoesMaos(): ReturnType<typeof calcularPosicoes> {
-    return calcularPosicoes({
-      largura: this.cameras.main.width,
-      altura: this.cameras.main.height,
-      margem: escalar(60, this),
-      margemInferior: escalar(80, this),
-      espacamentoCartas: escalar(40, this),
-      alturaCarta: escalar(75, this),
-      dpr: obterDpr(this),
-    });
-  }
-  private desenharMaos(maos: MaoJogador[]): void {
+  private desenharMaos(maos: Parameters<typeof desenharMaosJogo>[0]['maos']): void {
     this.labels = [];
-    const posicoes = this.calcularPosicoesMaos();
-    this.direcoesLabels = posicoes.map((p) => p.mao.direcao);
-    maos.forEach((mao, i) => {
-      desenharMaoNaCena({
-        cena: this,
-        mao,
-        posicao: posicoes[i],
-        rodada: this.rodada as Rodada,
-        decisorHumano: this.decisorHumano,
-        destaque: this.destaque,
-        objetos: this.objetos,
-        labels: this.labels,
-      });
+    this.direcoesLabels = desenharMaosJogo({
+      cena: this,
+      maos,
+      rodada: this.partida?.rodadaAtual as Rodada,
+      decisorHumano: this.decisorHumano,
+      destaque: this.destaque,
+      objetos: this.objetos,
+      labels: this.labels,
     });
     criarFundoInterativo({
       cena: this,
@@ -181,6 +179,7 @@ export class JogoScene extends Scene {
     }
     limparObjetos(this.objetos);
     limparObjetos(this.mesaObjetos);
+    limparObjetos(this.indicadorRodadaObjetos);
     limparManilha(this.manilhaObjetos);
     destruirDestaque(this.destaque);
   };
@@ -195,7 +194,8 @@ export class JogoScene extends Scene {
     this.vencedorTurno = undefined;
     this.mesaObjetos = [];
   }
-  private mostrarOverlayRodadaConcluida(): void {
+  private transicionarRodada(): void {
     mostrarOverlayRodadaConcluida(this, this.objetos);
+    this.time.delayedCall(900, this.iniciarNovaRodada.bind(this));
   }
 }

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -1,0 +1,33 @@
+import type { Rodada } from '@/core/Rodada';
+import type { MaoJogador } from '@/types/estado-rodada';
+import type { DecisorHumano } from '../DecisorHumano';
+import { obterDpr, escalar } from '../escala';
+import type { EstadoDestaque } from '../renderers/destaque-renderer';
+import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
+import { calcularPosicoes } from '../renderers/posicoes-mao';
+
+interface ConfigDesenharMaos {
+  cena: Phaser.Scene;
+  maos: MaoJogador[];
+  rodada: Rodada;
+  decisorHumano: DecisorHumano;
+  destaque: EstadoDestaque;
+  objetos: Phaser.GameObjects.GameObject[];
+  labels: Phaser.GameObjects.Text[];
+}
+
+export function desenharMaosJogo(config: ConfigDesenharMaos): ('horizontal' | 'vertical')[] {
+  const posicoes = calcularPosicoes({
+    largura: config.cena.cameras.main.width,
+    altura: config.cena.cameras.main.height,
+    margem: escalar(60, config.cena),
+    margemInferior: escalar(80, config.cena),
+    espacamentoCartas: escalar(40, config.cena),
+    alturaCarta: escalar(75, config.cena),
+    dpr: obterDpr(config.cena),
+  });
+  config.maos.forEach((mao, i) => {
+    desenharMaoNaCena({ ...config, mao, posicao: posicoes[i] });
+  });
+  return posicoes.map((p) => p.mao.direcao);
+}

--- a/src/adapters/phaser/scenes/jogadores.ts
+++ b/src/adapters/phaser/scenes/jogadores.ts
@@ -1,0 +1,8 @@
+import type { Jogador } from '@/types/entidades';
+
+export const JOGADORES: Jogador[] = [
+  { id: 'humano', nome: 'Você', pontos: 5 },
+  { id: 'bot1', nome: 'Bot 1', pontos: 5 },
+  { id: 'bot2', nome: 'Bot 2', pontos: 5 },
+  { id: 'bot3', nome: 'Bot 3', pontos: 5 },
+];

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -1,0 +1,116 @@
+import type { Jogador } from '@/types/entidades';
+import type { EstadoPartida } from '@/types/estado-partida';
+import type { EventoDominio } from '@/types/eventos-dominio';
+import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
+import type { DecisorJogada } from './portas/DecisorJogada';
+import { Rodada } from './Rodada';
+
+interface EmissorPartida {
+  emit(evento: EventoDominio): void;
+}
+
+interface DecisoresPartida {
+  jogada: Map<string, DecisorJogada>;
+  declaracao: Map<string, DecisorDeclaracao>;
+}
+
+function eventoBase() {
+  return { id: crypto.randomUUID(), timestamp: Date.now() };
+}
+
+export class Partida {
+  private jogadores: Jogador[];
+  private decisores: DecisoresPartida;
+  private emissor: EmissorPartida;
+  private numeroRodada = 0;
+  private rodada?: Rodada;
+  private embaralhadorIndice: number;
+
+  constructor(jogadores: Jogador[], emissor: EmissorPartida, decisores: DecisoresPartida) {
+    this.jogadores = jogadores;
+    this.emissor = emissor;
+    this.decisores = decisores;
+    this.embaralhadorIndice = jogadores.length - 1;
+  }
+
+  get rodadaAtual(): Rodada | undefined {
+    return this.rodada;
+  }
+
+  get estado(): EstadoPartida {
+    if (!this.rodada) return this.estadoInicial();
+    return {
+      ...this.rodada.estado,
+      numeroRodada: this.numeroRodada,
+      jogadoresAtivos: this.jogadoresAtivos(),
+      embaralhadorId: this.embaralhadorAtual().id,
+    };
+  }
+
+  iniciarProximaRodada(): Rodada {
+    this.atualizarPontos();
+    this.numeroRodada += 1;
+    if (this.numeroRodada > 1) this.rotacionarEmbaralhador();
+    this.rodada = new Rodada(this.jogadores, this.emissor, this.decisores);
+    const cartasPorRodada = Math.min(this.numeroRodada, 13);
+    this.rodada.distribuir(cartasPorRodada);
+    this.emitirRodadaIniciada(cartasPorRodada);
+    return this.rodada;
+  }
+
+  avancarSeRodadaConcluida(): boolean {
+    if (this.rodada?.estado.fase !== 'rodadaConcluida') return false;
+    this.iniciarProximaRodada();
+    return true;
+  }
+
+  private estadoInicial(): EstadoPartida {
+    return {
+      fase: 'distribuindo',
+      jogadorAtual: 0,
+      mesa: [],
+      maos: [],
+      vazas: {},
+      turno: 1,
+      cartasPorRodada: 0,
+      manilha: '3',
+      cartaVirada: null,
+      declaracoes: {},
+      pontos: Object.fromEntries(this.jogadores.map((jogador) => [jogador.id, jogador.pontos])),
+      numeroRodada: this.numeroRodada,
+      jogadoresAtivos: this.jogadoresAtivos(),
+      embaralhadorId: this.embaralhadorAtual().id,
+    };
+  }
+
+  private atualizarPontos(): void {
+    if (!this.rodada) return;
+    this.jogadores = this.jogadores.map((jogador) => ({
+      ...jogador,
+      pontos: this.rodada?.estado.pontos[jogador.id] ?? jogador.pontos,
+    }));
+  }
+
+  private emitirRodadaIniciada(cartasPorRodada: number): void {
+    this.emissor.emit({
+      ...eventoBase(),
+      tipo: 'RODADA_INICIADA',
+      numeroRodada: this.numeroRodada,
+      cartasPorRodada,
+      embaralhadorId: this.embaralhadorAtual().id,
+      jogadoresAtivos: this.jogadoresAtivos(),
+    });
+  }
+
+  private rotacionarEmbaralhador(): void {
+    this.embaralhadorIndice = (this.embaralhadorIndice + 1) % this.jogadores.length;
+  }
+
+  private embaralhadorAtual(): Jogador {
+    return this.jogadores[this.embaralhadorIndice];
+  }
+
+  private jogadoresAtivos(): string[] {
+    return this.jogadores.map((jogador) => jogador.id);
+  }
+}

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -58,7 +58,8 @@ export class Rodada {
 
   distribuir(numeroCartas: number, baralhoEntrada?: Carta[]): void {
     const baralho = baralhoEntrada ?? embaralhar(criarBaralho());
-    const cartaVirada = baralho.length > 0 ? baralho[0] : null;
+    const precisaDistribuir = numeroCartas * this.jogadores.length;
+    const cartaVirada = baralho.length > precisaDistribuir ? baralho[0] : null;
     const baralhoRestante = cartaVirada ? baralho.slice(1) : baralho;
     const manilha = cartaVirada ? obterProximoValor(cartaVirada.valor) : '3';
 

--- a/src/types/estado-partida.ts
+++ b/src/types/estado-partida.ts
@@ -1,0 +1,7 @@
+import type { EstadoRodada } from './estado-rodada';
+
+export interface EstadoPartida extends EstadoRodada {
+  numeroRodada: number;
+  jogadoresAtivos: string[];
+  embaralhadorId: string;
+}

--- a/src/types/evento-map.ts
+++ b/src/types/evento-map.ts
@@ -5,6 +5,7 @@ import type {
   JogoIniciado,
   ManilhaVirada,
   PontuacaoAplicada,
+  RodadaIniciada,
   RodadaEncerrada,
   TurnoEmpatado,
   TurnoGanho,
@@ -21,6 +22,7 @@ export interface EventoMap {
   TURNO_GANHO: TurnoGanho;
   TURNO_EMPATADO: TurnoEmpatado;
   RODADA_ENCERRADA: RodadaEncerrada;
+  RODADA_INICIADA: RodadaIniciada;
   PONTUACAO_APLICADA: PontuacaoAplicada;
   JOGO_ENCERRADO: JogoEncerrado;
   // --- Eventos de input ---

--- a/src/types/eventos-dominio.ts
+++ b/src/types/eventos-dominio.ts
@@ -49,6 +49,14 @@ export interface RodadaEncerrada extends EventoBase {
   proximaRodada: number | null;
 }
 
+export interface RodadaIniciada extends EventoBase {
+  tipo: 'RODADA_INICIADA';
+  numeroRodada: number;
+  cartasPorRodada: number;
+  embaralhadorId: string;
+  jogadoresAtivos: string[];
+}
+
 export interface PontuacaoAplicada extends EventoBase {
   tipo: 'PONTUACAO_APLICADA';
   placar: Record<string, number>;
@@ -68,5 +76,6 @@ export type EventoDominio =
   | TurnoGanho
   | TurnoEmpatado
   | RodadaEncerrada
+  | RodadaIniciada
   | PontuacaoAplicada
   | JogoEncerrado;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './entidades';
+export * from './estado-partida';
 export * from './estado-rodada';
 export * from './eventos-dominio';
 export * from './eventos-input';

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Partida } from '@/core/Partida';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { Jogador } from '@/types/entidades';
+import { criarDecisorPrimeiraCarta, jogadoresPadrao } from './rodada-fixtures';
+
+function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
+  const decisoresJogada = new Map(jogadores.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+  return new Partida(jogadores, createEmissorEventos(), {
+    jogada: decisoresJogada,
+    declaracao: new Map(),
+  });
+}
+
+describe('Partida — contagem de cartas', () => {
+  it('deve iniciar rodadas com contagem de cartas até 13 e manter em 13', () => {
+    const partida = criarPartida();
+    const cartasPorRodada: number[] = [];
+    for (let i = 0; i < 15; i++) {
+      partida.iniciarProximaRodada();
+      cartasPorRodada.push(partida.estado.cartasPorRodada);
+    }
+    expect(cartasPorRodada).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 13]);
+  });
+});
+
+describe('Partida — estado público', () => {
+  it('deve incrementar numeroRodada e expor jogadoresAtivos', () => {
+    const jogadores = jogadoresPadrao();
+    const partida = criarPartida(jogadores);
+    partida.iniciarProximaRodada();
+    partida.iniciarProximaRodada();
+    expect(partida.estado.numeroRodada).toBe(2);
+    expect(partida.estado.jogadoresAtivos).toEqual(jogadores.map((jogador) => jogador.id));
+  });
+});
+
+describe('Partida — embaralhador', () => {
+  it('deve rotacionar o embaralhador para o jogador à direita', () => {
+    const partida = criarPartida();
+    const embaralhadores: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      partida.iniciarProximaRodada();
+      embaralhadores.push(partida.estado.embaralhadorId);
+    }
+    expect(embaralhadores).toEqual(['j4', 'j1', 'j2', 'j3', 'j4']);
+  });
+});
+
+describe('Partida — eventos', () => {
+  it('deve emitir RODADA_INICIADA no início de cada rodada', () => {
+    const emissor = createEmissorEventos();
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('RODADA_INICIADA', handler);
+    const jogadores = jogadoresPadrao();
+    const decisoresJogada = new Map(jogadores.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+    const partida = new Partida(jogadores, emissor, { jogada: decisoresJogada, declaracao: new Map() });
+    partida.iniciarProximaRodada();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tipo: 'RODADA_INICIADA',
+        numeroRodada: 1,
+        cartasPorRodada: 1,
+        jogadoresAtivos: ['j1', 'j2', 'j3', 'j4'],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Cria `Partida` para orquestrar rodadas sequenciais, número da rodada, jogadores ativos e rotação do embaralhador.
- Emite `RODADA_INICIADA` e expõe `EstadoPartida` com campos públicos para o adapter.
- Atualiza a scene Phaser para iniciar novas rodadas, renderizar `Rodada N · Manilha: X` e manter transição simples entre rodadas.

Closes #114

## Verificações

- `pnpm test -- --run`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`