### PR TITLE
feat: renderiza placar de pontuação

### DIFF
--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -15,6 +15,7 @@ export interface CallbacksRodada {
   onRodadaEncerrada: () => void;
   onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
   onRodadaIniciada?: () => void;
+  onPontuacaoAplicada?: () => void;
 }
 
 function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, callbacks: CallbacksRodada): void {
@@ -25,6 +26,7 @@ function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, ca
   emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
   emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
   emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
+  emissor.on('PONTUACAO_APLICADA', () => callbacks.onPontuacaoAplicada?.());
   emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
 }
 

--- a/src/adapters/phaser/renderers/placar-renderer.ts
+++ b/src/adapters/phaser/renderers/placar-renderer.ts
@@ -1,0 +1,97 @@
+import type { Scene } from 'phaser';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoRodada } from '@/types/estado-rodada';
+import { escalar, escalarFonte } from '../escala';
+
+interface ConfigPlacar {
+  cena: Scene;
+  jogadores: Jogador[];
+  estado: EstadoRodada;
+  objetos: Phaser.GameObjects.GameObject[];
+}
+
+interface LinhaPlacar {
+  jogador: Jogador;
+  declarado: number | null;
+  feito: number;
+  pontos: number;
+}
+
+interface TextoPlacar {
+  texto: string;
+  x: number;
+  y: number;
+  cor: string;
+}
+
+interface ConfigLinhaPlacar {
+  cena: Scene;
+  objetos: Phaser.GameObjects.GameObject[];
+  linha: LinhaPlacar;
+  indice: number;
+}
+
+export function limparPlacar(objetos: Phaser.GameObjects.GameObject[]): void {
+  objetos.forEach((objeto) => {
+    objeto.destroy();
+  });
+  objetos.length = 0;
+}
+
+export function desenharPlacar(config: ConfigPlacar): void {
+  limparPlacar(config.objetos);
+  const linhas = criarLinhas(config.jogadores, config.estado);
+  desenharFundo(config.cena, config.objetos, linhas.length);
+  desenharCabecalho(config.cena, config.objetos);
+  linhas.forEach((linha, indice) => {
+    desenharLinha({ cena: config.cena, objetos: config.objetos, linha, indice });
+  });
+}
+
+function criarLinhas(jogadores: Jogador[], estado: EstadoRodada): LinhaPlacar[] {
+  return jogadores.map((jogador) => ({
+    jogador,
+    declarado: estado.declaracoes[jogador.id] ?? null,
+    feito: estado.vazas[jogador.id] ?? 0,
+    pontos: estado.pontos[jogador.id] ?? jogador.pontos,
+  }));
+}
+
+function desenharFundo(cena: Scene, objetos: Phaser.GameObjects.GameObject[], totalLinhas: number): void {
+  const largura = escalar(214, cena);
+  const altura = escalar(34 + totalLinhas * 24, cena);
+  const fundo = cena.add.rectangle(escalar(10, cena), escalar(10, cena), largura, altura, 0x101827, 0.82);
+  fundo.setOrigin(0, 0).setStrokeStyle(escalar(1, cena), 0xffffff, 0.18).setDepth(50);
+  objetos.push(fundo);
+}
+
+function desenharCabecalho(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): void {
+  const y = escalar(18, cena);
+  adicionarTexto(cena, objetos, { texto: 'Jogador', x: 18, y, cor: '#dbeafe' });
+  adicionarTexto(cena, objetos, { texto: 'D', x: 102, y, cor: '#dbeafe' });
+  adicionarTexto(cena, objetos, { texto: 'F', x: 132, y, cor: '#dbeafe' });
+  adicionarTexto(cena, objetos, { texto: 'Pts', x: 164, y, cor: '#dbeafe' });
+}
+
+function desenharLinha(config: ConfigLinhaPlacar): void {
+  const { cena, objetos, linha, indice } = config;
+  const y = escalar(42 + indice * 24, cena);
+  const declarado = linha.declarado === null ? '-' : String(linha.declarado);
+  const corPontos = linha.pontos < 0 ? '#ff6b6b' : '#ffffff';
+  adicionarTexto(cena, objetos, { texto: linha.jogador.nome, x: 18, y, cor: '#ffffff' });
+  adicionarTexto(cena, objetos, { texto: declarado, x: 106, y, cor: '#ffffff' });
+  adicionarTexto(cena, objetos, { texto: String(linha.feito), x: 136, y, cor: '#ffffff' });
+  adicionarTexto(cena, objetos, { texto: String(linha.pontos), x: 170, y, cor: corPontos });
+}
+
+function adicionarTexto(cena: Scene, objetos: Phaser.GameObjects.GameObject[], config: TextoPlacar): void {
+  const objeto = cena.add
+    .text(escalar(config.x, cena), config.y, config.texto, {
+      fontSize: escalarFonte(11, cena),
+      color: config.cor,
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0, 0.5)
+    .setDepth(51);
+  objetos.push(objeto);
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -4,18 +4,15 @@ import { Rodada } from '@/core/Rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import { DecisorHumano } from '../DecisorHumano';
 import { fabricarPartida } from '../factories/rodada-factory';
-import { criarFundoInterativo } from '../input/input-humano';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 import { desenharIndicadorRodada } from '../renderers/indicador-rodada-renderer';
 import { limparObjetos } from '../renderers/limpar-objetos';
 import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
-import {
-  animarRecolhimentoTurno,
-  atualizarIndicadorVez,
-  mostrarOverlayRodadaConcluida,
-} from '../renderers/turno-renderer';
+import { desenharPlacar } from '../renderers/placar-renderer';
+import { animarRecolhimentoTurno, atualizarIndicadorVez } from '../renderers/turno-renderer';
+import { aoEncerrarCena, transicionarRodada } from './ciclo-vida-cena';
 import { desenharMaosJogo } from './desenhar-maos-jogo';
 import { JOGADORES } from './jogadores';
 import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
@@ -36,6 +33,7 @@ export class JogoScene extends Scene {
   private vencedorTurno?: string;
   private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
   private indicadorRodadaObjetos: Phaser.GameObjects.GameObject[] = [];
+  private placarObjetos: Phaser.GameObjects.GameObject[] = [];
 
   constructor() {
     super({ key: 'JogoScene' });
@@ -57,6 +55,7 @@ export class JogoScene extends Scene {
       objetos: this.objetosDeclaracao,
       decisorHumano: this.decisorDeclaracaoHumano,
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
+      atualizarPlacar: this.atualizarPlacar.bind(this),
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),
     }).catch(() => undefined);
   }
@@ -87,9 +86,10 @@ export class JogoScene extends Scene {
         onTurnoEmpatado: () => {
           this.vencedorTurno = undefined;
         },
-        onRodadaEncerrada: this.transicionarRodada.bind(this),
+        onRodadaEncerrada: this.aoEncerrarRodada.bind(this),
         onManilhaVirada: this.atualizarManilha.bind(this),
         onRodadaIniciada: this.atualizarIndicadorRodada.bind(this),
+        onPontuacaoAplicada: this.atualizarPlacar.bind(this),
       },
     );
   }
@@ -119,6 +119,52 @@ export class JogoScene extends Scene {
       objetos: this.indicadorRodadaObjetos,
     });
   }
+  private atualizarPlacar(): void {
+    const estado = this.partida?.estado;
+    if (!estado) return;
+    desenharPlacar({ cena: this, jogadores: JOGADORES, estado, objetos: this.placarObjetos });
+  }
+  private redesenharTela = (): void => {
+    destruirDestaque(this.destaque);
+    limparObjetos(this.objetos);
+    this.atualizarManilha();
+    this.atualizarIndicadorRodada();
+    this.atualizarPlacar();
+    limparObjetos(this.mesaObjetos);
+    const estado = this.partida?.estado;
+    if (!estado) return;
+    this.desenharMaos(estado.maos);
+    this.atualizarMesa();
+    this.atualizarIndicadorVez();
+  };
+  private desenharMaos(maos: Parameters<typeof desenharMaosJogo>[0]['maos']): void {
+    const rodada = this.partida?.rodadaAtual as Rodada;
+    const resultado = desenharMaosJogo({
+      cena: this,
+      maos,
+      rodada,
+      decisorHumano: this.decisorHumano,
+      destaque: this.destaque,
+      objetos: this.objetos,
+    });
+    this.labels = resultado.labels;
+    this.direcoesLabels = resultado.direcoes;
+  }
+  private aoEncerrar = (): void => {
+    const resultado = aoEncerrarCena({
+      cena: this,
+      redesenhar: this.redesenhar,
+      tweenVez: this.tweenVez,
+      objetos: this.objetos,
+      mesaObjetos: this.mesaObjetos,
+      indicadorRodadaObjetos: this.indicadorRodadaObjetos,
+      manilhaObjetos: this.manilhaObjetos,
+      placarObjetos: this.placarObjetos,
+      destaque: this.destaque,
+    });
+    this.redesenhar = resultado.redesenhar;
+    this.tweenVez = resultado.tweenVez;
+  };
   private atualizarMesa(): void {
     limparObjetos(this.mesaObjetos);
     const estado = this.partida?.estado;
@@ -136,53 +182,6 @@ export class JogoScene extends Scene {
       tweenAtual: this.tweenVez,
     });
   }
-  private redesenharTela = (): void => {
-    destruirDestaque(this.destaque);
-    limparObjetos(this.objetos);
-    this.atualizarManilha();
-    this.atualizarIndicadorRodada();
-    limparObjetos(this.mesaObjetos);
-    const estado = this.partida?.estado;
-    if (!estado) return;
-    this.desenharMaos(estado.maos);
-    this.atualizarMesa();
-    this.atualizarIndicadorVez();
-  };
-  private desenharMaos(maos: Parameters<typeof desenharMaosJogo>[0]['maos']): void {
-    this.labels = [];
-    this.direcoesLabels = desenharMaosJogo({
-      cena: this,
-      maos,
-      rodada: this.partida?.rodadaAtual as Rodada,
-      decisorHumano: this.decisorHumano,
-      destaque: this.destaque,
-      objetos: this.objetos,
-      labels: this.labels,
-    });
-    criarFundoInterativo({
-      cena: this,
-      objetos: this.objetos,
-      decisorHumano: this.decisorHumano,
-      destaque: this.destaque,
-    });
-  }
-  private aoEncerrar = (): void => {
-    if (this.redesenhar) {
-      this.scale.off('resize', this.redesenhar);
-      this.redesenhar.limpar();
-      this.redesenhar = undefined;
-    }
-    if (this.tweenVez) {
-      this.tweenVez.stop();
-      this.tweenVez.remove();
-      this.tweenVez = undefined;
-    }
-    limparObjetos(this.objetos);
-    limparObjetos(this.mesaObjetos);
-    limparObjetos(this.indicadorRodadaObjetos);
-    limparManilha(this.manilhaObjetos);
-    destruirDestaque(this.destaque);
-  };
   private animarRecolhimentoTurno(): void {
     animarRecolhimentoTurno({
       cena: this,
@@ -194,8 +193,7 @@ export class JogoScene extends Scene {
     this.vencedorTurno = undefined;
     this.mesaObjetos = [];
   }
-  private transicionarRodada(): void {
-    mostrarOverlayRodadaConcluida(this, this.objetos);
-    this.time.delayedCall(900, this.iniciarNovaRodada.bind(this));
+  private aoEncerrarRodada(): void {
+    transicionarRodada(this, this.objetos, this.iniciarNovaRodada.bind(this));
   }
 }

--- a/src/adapters/phaser/scenes/ciclo-vida-cena.ts
+++ b/src/adapters/phaser/scenes/ciclo-vida-cena.ts
@@ -1,0 +1,46 @@
+import type { ResizeDebouncer } from '../redimensionamento';
+import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
+import { limparObjetos } from '../renderers/limpar-objetos';
+import { limparManilha } from '../renderers/manilha-renderer';
+import { limparPlacar } from '../renderers/placar-renderer';
+import { mostrarOverlayRodadaConcluida } from '../renderers/turno-renderer';
+
+interface ConfigEncerramento {
+  cena: Phaser.Scene;
+  redesenhar?: ResizeDebouncer;
+  tweenVez?: Phaser.Tweens.Tween;
+  objetos: Phaser.GameObjects.GameObject[];
+  mesaObjetos: Phaser.GameObjects.GameObject[];
+  indicadorRodadaObjetos: Phaser.GameObjects.GameObject[];
+  manilhaObjetos: Phaser.GameObjects.GameObject[];
+  placarObjetos: Phaser.GameObjects.GameObject[];
+  destaque: EstadoDestaque;
+}
+
+export function aoEncerrarCena(config: ConfigEncerramento): {
+  redesenhar?: ResizeDebouncer;
+  tweenVez?: Phaser.Tweens.Tween;
+} {
+  if (config.redesenhar) {
+    config.cena.scale.off('resize', config.redesenhar);
+    config.redesenhar.limpar();
+  }
+  config.tweenVez?.stop();
+  config.tweenVez?.remove();
+  limparObjetos(config.objetos);
+  limparObjetos(config.mesaObjetos);
+  limparObjetos(config.indicadorRodadaObjetos);
+  limparManilha(config.manilhaObjetos);
+  limparPlacar(config.placarObjetos);
+  destruirDestaque(config.destaque);
+  return { redesenhar: undefined, tweenVez: undefined };
+}
+
+export function transicionarRodada(
+  cena: Phaser.Scene,
+  objetos: Phaser.GameObjects.GameObject[],
+  callback: () => void,
+): void {
+  mostrarOverlayRodadaConcluida(cena, objetos);
+  cena.time.delayedCall(900, callback);
+}

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -1,33 +1,57 @@
+import type { Scene } from 'phaser';
 import type { Rodada } from '@/core/Rodada';
 import type { MaoJogador } from '@/types/estado-rodada';
 import type { DecisorHumano } from '../DecisorHumano';
 import { obterDpr, escalar } from '../escala';
+import { criarFundoInterativo } from '../input/input-humano';
 import type { EstadoDestaque } from '../renderers/destaque-renderer';
 import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
 import { calcularPosicoes } from '../renderers/posicoes-mao';
 
-interface ConfigDesenharMaos {
-  cena: Phaser.Scene;
-  maos: MaoJogador[];
+interface ConfigMaosJogo {
+  cena: Scene;
   rodada: Rodada;
+  maos: MaoJogador[];
   decisorHumano: DecisorHumano;
   destaque: EstadoDestaque;
   objetos: Phaser.GameObjects.GameObject[];
-  labels: Phaser.GameObjects.Text[];
 }
 
-export function desenharMaosJogo(config: ConfigDesenharMaos): ('horizontal' | 'vertical')[] {
-  const posicoes = calcularPosicoes({
-    largura: config.cena.cameras.main.width,
-    altura: config.cena.cameras.main.height,
-    margem: escalar(60, config.cena),
-    margemInferior: escalar(80, config.cena),
-    espacamentoCartas: escalar(40, config.cena),
-    alturaCarta: escalar(75, config.cena),
-    dpr: obterDpr(config.cena),
-  });
+export function desenharMaosJogo(config: ConfigMaosJogo): {
+  labels: Phaser.GameObjects.Text[];
+  direcoes: ('horizontal' | 'vertical')[];
+} {
+  const labels: Phaser.GameObjects.Text[] = [];
+  const posicoes = calcularPosicoesMaos(config.cena);
   config.maos.forEach((mao, i) => {
-    desenharMaoNaCena({ ...config, mao, posicao: posicoes[i] });
+    desenharMaoNaCena({
+      cena: config.cena,
+      mao,
+      posicao: posicoes[i],
+      rodada: config.rodada,
+      decisorHumano: config.decisorHumano,
+      destaque: config.destaque,
+      objetos: config.objetos,
+      labels,
+    });
   });
-  return posicoes.map((p) => p.mao.direcao);
+  criarFundoInterativo({
+    cena: config.cena,
+    objetos: config.objetos,
+    decisorHumano: config.decisorHumano,
+    destaque: config.destaque,
+  });
+  return { labels, direcoes: posicoes.map((p) => p.mao.direcao) };
+}
+
+function calcularPosicoesMaos(cena: Scene): ReturnType<typeof calcularPosicoes> {
+  return calcularPosicoes({
+    largura: cena.cameras.main.width,
+    altura: cena.cameras.main.height,
+    margem: escalar(60, cena),
+    margemInferior: escalar(80, cena),
+    espacamentoCartas: escalar(40, cena),
+    alturaCarta: escalar(75, cena),
+    dpr: obterDpr(cena),
+  });
 }

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -11,6 +11,7 @@ interface ConfigDeclaracoes {
   objetos: Phaser.GameObjects.GameObject[];
   decisorHumano: DecisorDeclaracaoHumano;
   atualizarIndicadorVez: () => void;
+  atualizarPlacar: () => void;
   iniciarTurnos: () => Promise<void>;
 }
 
@@ -33,6 +34,7 @@ export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<v
     const declarou = await tentarDeclarar(rodada);
     if (!declarou) return;
     limparObjetosDeclaracao(config.objetos);
+    config.atualizarPlacar();
     config.atualizarIndicadorVez();
   }
   if (rodada.estado.fase === 'aguardandoJogada') {


### PR DESCRIPTION
## Resumo

- Renderiza placar persistente com jogador, declarado, feito e pontos.
- Atualiza o placar durante declarações e ao receber `PONTUACAO_APLICADA`.
- Destaca pontuação negativa em vermelho.

## Validação

- `pnpm lint` (passa com avisos existentes de `console`)
- `pnpm typecheck`
- `pnpm build`
- push hook: `pnpm typecheck` e `pnpm test`

Closes #113