### PR TITLE
[Fase 3] 1ª rodada — visibilidade invertida

### DIFF
--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -51,7 +51,7 @@ export class Partida {
     this.atualizarPontos();
     this.numeroRodada += 1;
     if (this.numeroRodada > 1) this.rotacionarEmbaralhador();
-    this.rodada = new Rodada(this.jogadores, this.emissor, this.decisores);
+    this.rodada = new Rodada(this.jogadores, this.emissor, { ...this.decisores, numeroRodada: this.numeroRodada });
     const cartasPorRodada = Math.min(this.numeroRodada, 13);
     this.rodada.distribuir(cartasPorRodada);
     this.emitirRodadaIniciada(cartasPorRodada);

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -3,7 +3,7 @@ import type { EstadoRodada } from '@/types/estado-rodada';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
 import { obterProximoValor } from './Carta';
 import type { Carta } from './Carta';
-import { calcularIndiceVencedor, cartasEmpatam } from './comparador-carta';
+import type { DecisoresRodada } from './decisores-rodada';
 import {
   emitirCartaJogada,
   emitirDeclaracaoFeita,
@@ -17,6 +17,7 @@ import {
 import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
+import { calcularResultadoTurno } from './resultado-turno';
 
 export class Rodada {
   private _estado: EstadoRodada;
@@ -24,19 +25,14 @@ export class Rodada {
   private decisoresDeclaracao: Map<string, DecisorDeclaracao>;
   private emissor: EmissorRodada;
   private jogadores: Jogador[];
+  private numeroRodada: number;
 
-  constructor(
-    jogadores: Jogador[],
-    emissor: EmissorRodada,
-    decisores: {
-      jogada: Map<string, DecisorJogada>;
-      declaracao: Map<string, DecisorDeclaracao>;
-    },
-  ) {
+  constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
     this.decisores = decisores.jogada;
     this.decisoresDeclaracao = decisores.declaracao;
     this.emissor = emissor;
+    this.numeroRodada = decisores.numeroRodada ?? 1;
     this._estado = {
       fase: 'distribuindo',
       jogadorAtual: 0,
@@ -64,10 +60,11 @@ export class Rodada {
     const manilha = cartaVirada ? obterProximoValor(cartaVirada.valor) : '3';
 
     const cartas = distribuir(baralhoRestante, numeroCartas, this.jogadores.length);
+    const primeiraRodada = this.numeroRodada === 1;
     this._estado.maos = this.jogadores.map((jogador, i) => ({
       jogador,
       cartas: cartas[i],
-      visivel: jogador.id === 'humano',
+      visivel: primeiraRodada ? jogador.id !== 'humano' : jogador.id === 'humano',
     }));
     this._estado.cartasPorRodada = numeroCartas;
     this._estado.manilha = manilha;
@@ -163,7 +160,7 @@ export class Rodada {
   }
 
   private resolverTurno(): void {
-    const resultado = this.calcularVencedorTurno();
+    const resultado = calcularResultadoTurno(this._estado.mesa, this._estado.manilha, this.jogadores);
     let proximoJogadorId: string;
     if (resultado.tipo === 'vitoria') {
       this._estado.vazas[resultado.jogador.id] = (this._estado.vazas[resultado.jogador.id] ?? 0) + 1;
@@ -187,24 +184,6 @@ export class Rodada {
       this._estado.fase = 'aguardandoJogada';
       this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === proximoJogadorId);
     }
-  }
-
-  private calcularVencedorTurno(): { tipo: 'vitoria'; jogador: Jogador } | { tipo: 'empate'; ultimoEmpatado: Jogador } {
-    const indiceMelhor = calcularIndiceVencedor(this._estado.mesa, this._estado.manilha);
-    const cartaMelhor = this._estado.mesa[indiceMelhor].carta;
-    const empatados = this._estado.mesa.filter((item, i) => {
-      return i === indiceMelhor || cartasEmpatam(item.carta, cartaMelhor, this._estado.manilha);
-    });
-    if (empatados.length > 1) {
-      const ultimoEmpatado = empatados[empatados.length - 1];
-      const jogador = this.jogadores.find((j) => j.id === ultimoEmpatado.jogadorId);
-      if (!jogador) throw new Error('Último empatado não encontrado');
-      return { tipo: 'empate', ultimoEmpatado: jogador };
-    }
-    const jogadorId = this._estado.mesa[indiceMelhor].jogadorId;
-    const vencedor = this.jogadores.find((j) => j.id === jogadorId);
-    if (!vencedor) throw new Error('Vencedor não encontrado');
-    return { tipo: 'vitoria', jogador: vencedor };
   }
 
   private cartasDaMesa(): Carta[] {

--- a/src/core/decisores-rodada.ts
+++ b/src/core/decisores-rodada.ts
@@ -1,0 +1,8 @@
+import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
+import type { DecisorJogada } from './portas/DecisorJogada';
+
+export interface DecisoresRodada {
+  jogada: Map<string, DecisorJogada>;
+  declaracao: Map<string, DecisorDeclaracao>;
+  numeroRodada?: number;
+}

--- a/src/core/resultado-turno.ts
+++ b/src/core/resultado-turno.ts
@@ -1,0 +1,22 @@
+import type { Jogador } from '@/types/entidades';
+import type { MesaItem } from '@/types/estado-rodada';
+import type { Valor } from './Carta';
+import { calcularIndiceVencedor, cartasEmpatam } from './comparador-carta';
+
+export type ResultadoTurno = { tipo: 'vitoria'; jogador: Jogador } | { tipo: 'empate'; ultimoEmpatado: Jogador };
+
+export function calcularResultadoTurno(mesa: MesaItem[], manilha: Valor, jogadores: Jogador[]): ResultadoTurno {
+  const indiceMelhor = calcularIndiceVencedor(mesa, manilha);
+  const cartaMelhor = mesa[indiceMelhor].carta;
+  const empatados = mesa.filter((item, i) => i === indiceMelhor || cartasEmpatam(item.carta, cartaMelhor, manilha));
+  if (empatados.length > 1) {
+    const ultimoEmpatado = empatados[empatados.length - 1];
+    const jogador = jogadores.find((j) => j.id === ultimoEmpatado.jogadorId);
+    if (!jogador) throw new Error('Último empatado não encontrado');
+    return { tipo: 'empate', ultimoEmpatado: jogador };
+  }
+  const jogadorId = mesa[indiceMelhor].jogadorId;
+  const vencedor = jogadores.find((j) => j.id === jogadorId);
+  if (!vencedor) throw new Error('Vencedor não encontrado');
+  return { tipo: 'vitoria', jogador: vencedor };
+}

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -33,6 +33,24 @@ describe('Partida — estado público', () => {
     expect(partida.estado.numeroRodada).toBe(2);
     expect(partida.estado.jogadoresAtivos).toEqual(jogadores.map((jogador) => jogador.id));
   });
+
+  it('deve aplicar visibilidade invertida apenas na primeira rodada', () => {
+    const jogadores = [
+      { id: 'humano', nome: 'Humano', pontos: 5 },
+      { id: 'bot1', nome: 'Bot 1', pontos: 5 },
+    ];
+    const partida = criarPartida(jogadores);
+    partida.iniciarProximaRodada();
+    expect(partida.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+      ['humano', false],
+      ['bot1', true],
+    ]);
+    partida.iniciarProximaRodada();
+    expect(partida.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+      ['humano', true],
+      ['bot1', false],
+    ]);
+  });
 });
 
 describe('Partida — embaralhador', () => {

--- a/tests/core/Rodada.test.ts
+++ b/tests/core/Rodada.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Carta } from '@/core/Carta';
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { Jogador } from '@/types/entidades';
 import { criarCarta, criarJogador, criarDecisor, criarRodada } from './rodada-fixtures';
+
+function jogadoresComHumano(): Jogador[] {
+  return [criarJogador('humano', 'Humano'), criarJogador('bot1', 'Bot 1'), criarJogador('bot2', 'Bot 2')];
+}
+
+function criarRodadaVisibilidade(numeroRodada: number): Rodada {
+  return new Rodada(jogadoresComHumano(), createEmissorEventos(), {
+    jogada: new Map(),
+    declaracao: new Map(),
+    numeroRodada,
+  });
+}
 
 describe('Rodada — transições', () => {
   it('deve iniciar na fase distribuindo e avançar para aguardandoJogada', () => {
@@ -19,6 +33,48 @@ describe('Rodada — transições', () => {
     expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
     expect(rodada.estado.jogadorAtual).toBe(0);
     expect(rodada.estado.cartasPorRodada).toBe(1);
+  });
+});
+
+describe('Rodada — visibilidade', () => {
+  it('deve ocultar a mão do humano e mostrar as mãos dos bots na primeira rodada', () => {
+    const rodada = criarRodadaVisibilidade(1);
+    rodada.distribuir(1);
+    expect(rodada.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+      ['humano', false],
+      ['bot1', true],
+      ['bot2', true],
+    ]);
+  });
+
+  it('deve mostrar a mão do humano e ocultar as mãos dos bots depois da primeira rodada', () => {
+    const rodada = criarRodadaVisibilidade(2);
+    rodada.distribuir(2);
+    expect(rodada.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+      ['humano', true],
+      ['bot1', false],
+      ['bot2', false],
+    ]);
+  });
+});
+
+describe('Rodada — informação dos decisores', () => {
+  it('deve entregar a mão completa ao decisor mesmo quando ela não está visível', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('humano', 'Humano')];
+    const declarar: DecisorDeclaracao['declarar'] = vi.fn().mockResolvedValue(0);
+    const rodada = new Rodada(jogadores, emissor, {
+      jogada: new Map(),
+      declaracao: new Map([['humano', { declarar }]]),
+      numeroRodada: 1,
+    });
+    rodada.distribuir(1);
+    await rodada.declarar();
+    const chamadas = vi.mocked(declarar).mock.calls;
+    expect(chamadas).toHaveLength(1);
+    const chamada = chamadas[0];
+    expect(chamada[0].maos[0].visivel).toBe(false);
+    expect(chamada[1]).toEqual(rodada.estado.maos[0].cartas);
   });
 });
 


### PR DESCRIPTION
## Resumo

- Inverte a visibilidade pública das mãos na primeira rodada: humano oculto, bots visíveis.
- Mantém o comportamento padrão nas rodadas seguintes: humano visível, bots ocultos.
- Garante por teste que decisores recebem a mão completa mesmo quando a mão não está visível no estado público.

## Verificações

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (sem erros; warnings de `console` preexistentes em `jogo-scene-loop.ts`)

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Round-aware hand visibility: visibility toggles by round (first round vs later rounds).
  * Improved turn-resolution logic using a consolidated outcome calculation.
* **Changes**
  * Round objects now carry the current round number into decision logic.
  * Added a typed decision container for round deciders.
* **Tests**
  * Updated and added tests covering visibility rules and turn-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->