### PR TITLE
feat: adiciona eliminação de jogadores

### DIFF
--- a/src/adapters/phaser/renderers/turno-renderer.ts
+++ b/src/adapters/phaser/renderers/turno-renderer.ts
@@ -39,8 +39,8 @@ export function animarRecolhimentoTurno(config: ConfigAnimarTurno): void {
   const { cena, labels, jogadores, vencedorId, mesaObjetos } = config;
   if (vencedorId) {
     const indice = jogadores.findIndex((j) => j.id === vencedorId);
-    if (indice >= 0) {
-      const label = labels[indice];
+    const label = labels[indice];
+    if (indice >= 0 && label.active) {
       cena.tweens.add({
         targets: label,
         scale: 1.4,
@@ -51,6 +51,7 @@ export function animarRecolhimentoTurno(config: ConfigAnimarTurno): void {
     }
   }
   mesaObjetos.forEach((obj) => {
+    if (!obj.active) return;
     cena.tweens.add({
       targets: obj,
       alpha: 0,

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -34,7 +34,6 @@ export class JogoScene extends Scene {
   private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
   private indicadorRodadaObjetos: Phaser.GameObjects.GameObject[] = [];
   private placarObjetos: Phaser.GameObjects.GameObject[] = [];
-
   constructor() {
     super({ key: 'JogoScene' });
   }
@@ -62,13 +61,14 @@ export class JogoScene extends Scene {
   private async iniciarFluxoTurno(): Promise<void> {
     const rodada = this.partida?.rodadaAtual;
     if (!rodada) return;
+    const jogadoresAtuais = rodada.estado.maos.map((m) => m.jogador);
     await iniciarProcessamentoTurno({
       cena: this,
       rodada,
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
       turnoAnteriorRef: { valor: this.turnoAnterior },
-      jogadores: JOGADORES,
+      jogadores: jogadoresAtuais,
       getVencedorTurno: () => this.vencedorTurno,
       animarRecolhimento: this.animarRecolhimentoTurno.bind(this),
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
@@ -122,7 +122,8 @@ export class JogoScene extends Scene {
   private atualizarPlacar(): void {
     const estado = this.partida?.estado;
     if (!estado) return;
-    desenharPlacar({ cena: this, jogadores: JOGADORES, estado, objetos: this.placarObjetos });
+    const jogadores = estado.maos.map((m) => m.jogador);
+    desenharPlacar({ cena: this, jogadores, estado, objetos: this.placarObjetos });
   }
   private redesenharTela = (): void => {
     destruirDestaque(this.destaque);
@@ -134,7 +135,9 @@ export class JogoScene extends Scene {
     const estado = this.partida?.estado;
     if (!estado) return;
     this.desenharMaos(estado.maos);
-    this.atualizarMesa();
+    limparObjetos(this.mesaObjetos);
+    const cartas = estado.mesa.map((m) => m.carta);
+    renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos });
     this.atualizarIndicadorVez();
   };
   private desenharMaos(maos: Parameters<typeof desenharMaosJogo>[0]['maos']): void {
@@ -151,7 +154,7 @@ export class JogoScene extends Scene {
     this.direcoesLabels = resultado.direcoes;
   }
   private aoEncerrar = (): void => {
-    const resultado = aoEncerrarCena({
+    const r = aoEncerrarCena({
       cena: this,
       redesenhar: this.redesenhar,
       tweenVez: this.tweenVez,
@@ -162,16 +165,9 @@ export class JogoScene extends Scene {
       placarObjetos: this.placarObjetos,
       destaque: this.destaque,
     });
-    this.redesenhar = resultado.redesenhar;
-    this.tweenVez = resultado.tweenVez;
+    this.redesenhar = r.redesenhar;
+    this.tweenVez = r.tweenVez;
   };
-  private atualizarMesa(): void {
-    limparObjetos(this.mesaObjetos);
-    const estado = this.partida?.estado;
-    if (!estado) return;
-    const cartas = estado.mesa.map((m) => m.carta);
-    renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos });
-  }
   private atualizarIndicadorVez(): void {
     const estado = this.partida?.estado;
     if (!estado) return;
@@ -183,15 +179,18 @@ export class JogoScene extends Scene {
     });
   }
   private animarRecolhimentoTurno(): void {
+    const rodada = this.partida?.rodadaAtual;
+    const jogadoresAtuais = rodada?.estado.maos.map((m) => m.jogador) ?? [];
+    const objetosParaAnimar = this.mesaObjetos.filter((obj) => obj.active);
+    this.mesaObjetos = [];
     animarRecolhimentoTurno({
       cena: this,
       labels: this.labels,
-      jogadores: JOGADORES,
+      jogadores: jogadoresAtuais,
       vencedorId: this.vencedorTurno,
-      mesaObjetos: this.mesaObjetos,
+      mesaObjetos: objetosParaAnimar,
     });
     this.vencedorTurno = undefined;
-    this.mesaObjetos = [];
   }
   private aoEncerrarRodada(): void {
     transicionarRodada(this, this.objetos, this.iniciarNovaRodada.bind(this));

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -25,6 +25,8 @@ export class Partida {
   private numeroRodada = 0;
   private rodada?: Rodada;
   private embaralhadorIndice: number;
+  private jogoEncerrado = false;
+  private eliminados: Jogador[] = [];
 
   constructor(jogadores: Jogador[], emissor: EmissorPartida, decisores: DecisoresPartida) {
     this.jogadores = jogadores;
@@ -44,12 +46,14 @@ export class Partida {
       numeroRodada: this.numeroRodada,
       jogadoresAtivos: this.jogadoresAtivos(),
       embaralhadorId: this.embaralhadorAtual().id,
+      jogoEncerrado: this.jogoEncerrado,
     };
   }
 
-  iniciarProximaRodada(): Rodada {
-    this.atualizarPontos();
-    this.numeroRodada += 1;
+  iniciarProximaRodada(): Rodada | undefined {
+    const teveEliminacao = this.atualizarPontosEEliminar();
+    if (this.encerrarSeNecessario()) return undefined;
+    this.numeroRodada = teveEliminacao ? 1 : this.numeroRodada + 1;
     if (this.numeroRodada > 1) this.rotacionarEmbaralhador();
     this.rodada = new Rodada(this.jogadores, this.emissor, { ...this.decisores, numeroRodada: this.numeroRodada });
     const cartasPorRodada = Math.min(this.numeroRodada, 13);
@@ -80,15 +84,49 @@ export class Partida {
       numeroRodada: this.numeroRodada,
       jogadoresAtivos: this.jogadoresAtivos(),
       embaralhadorId: this.embaralhadorAtual().id,
+      jogoEncerrado: this.jogoEncerrado,
     };
   }
 
-  private atualizarPontos(): void {
-    if (!this.rodada) return;
+  private atualizarPontosEEliminar(): boolean {
+    if (!this.rodada) return false;
     this.jogadores = this.jogadores.map((jogador) => ({
       ...jogador,
       pontos: this.rodada?.estado.pontos[jogador.id] ?? jogador.pontos,
     }));
+    return this.eliminarJogadoresSemPontos();
+  }
+
+  private eliminarJogadoresSemPontos(): boolean {
+    const eliminados = this.jogadores.filter((jogador) => jogador.pontos <= 0);
+    if (eliminados.length === 0) return false;
+    this.eliminados = [...this.eliminados, ...eliminados];
+    this.jogadores = this.jogadores.filter((jogador) => jogador.pontos > 0);
+    this.ajustarEmbaralhadorAposEliminacao();
+    eliminados.forEach((jogador) => {
+      this.emitirJogadorEliminado(jogador);
+    });
+    return true;
+  }
+
+  private ajustarEmbaralhadorAposEliminacao(): void {
+    if (this.jogadores.length === 0) {
+      this.embaralhadorIndice = 0;
+      return;
+    }
+    this.embaralhadorIndice %= this.jogadores.length;
+  }
+
+  private encerrarSeNecessario(): boolean {
+    if (this.jogadores.length !== 1) return false;
+    this.jogoEncerrado = true;
+    this.rodada = undefined;
+    this.emitirJogoEncerrado();
+    return true;
+  }
+
+  private emitirJogadorEliminado(jogador: Jogador): void {
+    this.emissor.emit({ ...eventoBase(), tipo: 'JOGADOR_ELIMINADO', jogador });
   }
 
   private emitirRodadaIniciada(cartasPorRodada: number): void {
@@ -112,5 +150,13 @@ export class Partida {
 
   private jogadoresAtivos(): string[] {
     return this.jogadores.map((jogador) => jogador.id);
+  }
+
+  private emitirJogoEncerrado(): void {
+    this.emissor.emit({
+      ...eventoBase(),
+      tipo: 'JOGO_ENCERRADO',
+      classificacao: [...this.jogadores, ...this.eliminados].sort((a, b) => b.pontos - a.pontos),
+    });
   }
 }

--- a/src/types/estado-partida.ts
+++ b/src/types/estado-partida.ts
@@ -4,4 +4,5 @@ export interface EstadoPartida extends EstadoRodada {
   numeroRodada: number;
   jogadoresAtivos: string[];
   embaralhadorId: string;
+  jogoEncerrado: boolean;
 }

--- a/src/types/evento-map.ts
+++ b/src/types/evento-map.ts
@@ -3,6 +3,7 @@ import type {
   CartaJogada,
   JogoEncerrado,
   JogoIniciado,
+  JogadorEliminado,
   ManilhaVirada,
   PontuacaoAplicada,
   RodadaIniciada,
@@ -24,6 +25,7 @@ export interface EventoMap {
   RODADA_ENCERRADA: RodadaEncerrada;
   RODADA_INICIADA: RodadaIniciada;
   PONTUACAO_APLICADA: PontuacaoAplicada;
+  JOGADOR_ELIMINADO: JogadorEliminado;
   JOGO_ENCERRADO: JogoEncerrado;
   // --- Eventos de input ---
   TOQUE_CARTA: ToqueCarta;

--- a/src/types/eventos-dominio.ts
+++ b/src/types/eventos-dominio.ts
@@ -63,6 +63,11 @@ export interface PontuacaoAplicada extends EventoBase {
   penalidades: Record<string, number>;
 }
 
+export interface JogadorEliminado extends EventoBase {
+  tipo: 'JOGADOR_ELIMINADO';
+  jogador: Jogador;
+}
+
 export interface JogoEncerrado extends EventoBase {
   tipo: 'JOGO_ENCERRADO';
   classificacao: Jogador[];
@@ -78,4 +83,5 @@ export type EventoDominio =
   | RodadaEncerrada
   | RodadaIniciada
   | PontuacaoAplicada
+  | JogadorEliminado
   | JogoEncerrado;

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Partida } from '@/core/Partida';
+import type { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
+import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarDecisorPrimeiraCarta, jogadoresPadrao } from './rodada-fixtures';
 
 function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
@@ -10,6 +12,20 @@ function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
     jogada: decisoresJogada,
     declaracao: new Map(),
   });
+}
+
+function concluirRodadaComPontos(partida: Partida, pontos: Record<string, number>): void {
+  const rodada = partida.iniciarProximaRodada() as Rodada;
+  rodada.estado.fase = 'rodadaConcluida';
+  rodada.estado.pontos = pontos;
+}
+
+function criarPartidaComEmissor() {
+  const emissor = createEmissorEventos();
+  const jogadores = jogadoresPadrao();
+  const decisoresJogada = new Map(jogadores.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+  const partida = new Partida(jogadores, emissor, { jogada: decisoresJogada, declaracao: new Map() });
+  return { emissor, partida };
 }
 
 describe('Partida — contagem de cartas', () => {
@@ -67,12 +83,9 @@ describe('Partida — embaralhador', () => {
 
 describe('Partida — eventos', () => {
   it('deve emitir RODADA_INICIADA no início de cada rodada', () => {
-    const emissor = createEmissorEventos();
+    const { emissor, partida } = criarPartidaComEmissor();
     const handler = vi.fn<(ev: unknown) => void>();
     emissor.on('RODADA_INICIADA', handler);
-    const jogadores = jogadoresPadrao();
-    const decisoresJogada = new Map(jogadores.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
-    const partida = new Partida(jogadores, emissor, { jogada: decisoresJogada, declaracao: new Map() });
     partida.iniciarProximaRodada();
     expect(handler).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -82,5 +95,74 @@ describe('Partida — eventos', () => {
         jogadoresAtivos: ['j1', 'j2', 'j3', 'j4'],
       }),
     );
+  });
+});
+
+describe('Partida — eliminação', () => {
+  it('deve eliminar jogador com 0 pontos', () => {
+    const partida = criarPartida();
+    concluirRodadaComPontos(partida, { j1: 0, j2: 4, j3: 5, j4: 5 });
+    partida.iniciarProximaRodada();
+    expect(partida.estado.jogadoresAtivos).toEqual(['j2', 'j3', 'j4']);
+    expect(partida.estado.maos.map((mao) => mao.jogador.id)).toEqual(['j2', 'j3', 'j4']);
+  });
+
+  it('deve eliminar jogador com pontos negativos', () => {
+    const partida = criarPartida();
+    concluirRodadaComPontos(partida, { j1: -1, j2: 4, j3: 5, j4: 5 });
+    partida.iniciarProximaRodada();
+    expect(partida.estado.jogadoresAtivos).toEqual(['j2', 'j3', 'j4']);
+  });
+
+  it('deve reiniciar a contagem em 1 após eliminação', () => {
+    const partida = criarPartida();
+    partida.iniciarProximaRodada();
+    concluirRodadaComPontos(partida, { j1: 0, j2: 4, j3: 5, j4: 5 });
+    partida.iniciarProximaRodada();
+    expect(partida.estado.numeroRodada).toBe(1);
+    expect(partida.estado.cartasPorRodada).toBe(1);
+  });
+
+  it('deve continuar a contagem quando ninguém é eliminado', () => {
+    const partida = criarPartida();
+    concluirRodadaComPontos(partida, { j1: 4, j2: 4, j3: 5, j4: 5 });
+    partida.iniciarProximaRodada();
+    expect(partida.estado.numeroRodada).toBe(2);
+  });
+});
+
+describe('Partida — eventos de eliminação', () => {
+  it('deve emitir JOGADOR_ELIMINADO por jogador eliminado', () => {
+    const { emissor, partida } = criarPartidaComEmissor();
+    const handler = vi.fn<(ev: unknown) => void>();
+    emissor.on('JOGADOR_ELIMINADO', handler);
+    concluirRodadaComPontos(partida, { j1: 0, j2: -1, j3: 5, j4: 5 });
+    partida.iniciarProximaRodada();
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, expect.objectContaining({ tipo: 'JOGADOR_ELIMINADO' }));
+  });
+});
+
+describe('Partida — encerramento', () => {
+  it('deve encerrar quando sobra 1 sobrevivente', () => {
+    const partida = criarPartida();
+    concluirRodadaComPontos(partida, { j1: 2, j2: 0, j3: -1, j4: 0 });
+    const proximaRodada = partida.iniciarProximaRodada();
+    expect(proximaRodada).toBeUndefined();
+    expect(partida.estado.jogoEncerrado).toBe(true);
+    expect(partida.estado.jogadoresAtivos).toEqual(['j1']);
+  });
+
+  it('deve emitir JOGO_ENCERRADO com classificação final', () => {
+    const { emissor, partida } = criarPartidaComEmissor();
+    const handler = vi.fn<(ev: EventoDominio) => void>();
+    emissor.on('JOGO_ENCERRADO', handler);
+    concluirRodadaComPontos(partida, { j1: 2, j2: 0, j3: -1, j4: 0 });
+    partida.iniciarProximaRodada();
+    expect(handler).toHaveBeenCalledTimes(1);
+    const evento = handler.mock.calls[0][0];
+    expect(evento).toMatchObject({ tipo: 'JOGO_ENCERRADO' });
+    if (evento.tipo !== 'JOGO_ENCERRADO') throw new Error('Evento JOGO_ENCERRADO não emitido');
+    expect(evento.classificacao[0]).toMatchObject({ id: 'j1', pontos: 2 });
   });
 });


### PR DESCRIPTION
## Resumo

- Adiciona eliminação de jogadores com pontos <= 0 ao avançar rodada
- Emite `JOGADOR_ELIMINADO` por jogador e `JOGO_ENCERRADO` com classificação final
- Reinicia a contagem da próxima rodada em 1 após eliminação

## Validação

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (passou com warnings preexistentes de `console` em `src/adapters/phaser/scenes/jogo-scene-loop.ts`)
- `pnpm build`

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Player elimination system: Players with points at or below zero are now automatically eliminated from the game.
  * Game ending condition: The game automatically concludes when only one player remains, displaying final standings.
  * Elimination event notifications: Players receive event notifications when other players are eliminated.

* **Bug Fixes**
  * Improved animation validation to prevent unnecessary visual tweens on inactive game objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->