### PR TITLE
feat: adiciona tela de fim de jogo

### DIFF
--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -16,6 +16,7 @@ export interface CallbacksRodada {
   onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
   onRodadaIniciada?: () => void;
   onPontuacaoAplicada?: () => void;
+  onJogoEncerrado?: (classificacao: Jogador[]) => void;
 }
 
 function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, callbacks: CallbacksRodada): void {
@@ -28,6 +29,7 @@ function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, ca
   emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
   emissor.on('PONTUACAO_APLICADA', () => callbacks.onPontuacaoAplicada?.());
   emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
+  emissor.on('JOGO_ENCERRADO', (evento) => callbacks.onJogoEncerrado?.(evento.classificacao));
 }
 
 function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao }): {

--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -1,0 +1,125 @@
+import type { Scene } from 'phaser';
+import type { Jogador } from '@/types/entidades';
+import { escalar, escalarFonte } from '../escala';
+import { limparObjetos } from './limpar-objetos';
+
+interface ConfigFimJogo {
+  cena: Scene;
+  classificacao: Jogador[];
+  objetos: Phaser.GameObjects.GameObject[];
+  onReiniciar: () => void;
+}
+
+interface LinhaRanking {
+  jogador: Jogador;
+  indice: number;
+}
+
+export function desenharFimJogo(config: ConfigFimJogo): void {
+  limparObjetos(config.objetos);
+  desenharFundo(config);
+  desenharTitulo(config.cena, config.objetos);
+  config.classificacao.forEach((jogador, indice) => {
+    desenharLinha({ cena: config.cena, objetos: config.objetos, jogador, indice });
+  });
+  desenharBotao(config);
+}
+
+function desenharFundo(config: ConfigFimJogo): void {
+  const { cena, objetos } = config;
+  const fundo = cena.add.rectangle(0, 0, cena.cameras.main.width, cena.cameras.main.height, 0x050816, 0.94);
+  fundo.setOrigin(0).setDepth(100);
+  fundo.setAlpha(0);
+  cena.tweens.add({ targets: fundo, alpha: 1, duration: 350, ease: 'Sine.easeOut' });
+  objetos.push(fundo);
+}
+
+function desenharTitulo(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): void {
+  const y = cena.cameras.main.height * 0.18;
+  const titulo = cena.add
+    .text(cena.cameras.main.centerX, y, 'Fim de jogo', {
+      fontSize: escalarFonte(34, cena),
+      fontStyle: 'bold',
+      color: '#ffffff',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5)
+    .setDepth(102);
+  objetos.push(titulo);
+}
+
+function desenharLinha(config: LinhaRanking & { cena: Scene; objetos: Phaser.GameObjects.GameObject[] }): void {
+  const { cena, objetos, jogador, indice } = config;
+  const largura = Math.min(escalar(360, cena), cena.cameras.main.width - escalar(32, cena));
+  const altura = escalar(indice === 0 ? 54 : 44, cena);
+  const x = cena.cameras.main.centerX;
+  const y = cena.cameras.main.height * 0.32 + indice * escalar(54, cena);
+  const cor = indice === 0 ? 0x4ecca3 : 0x16213e;
+  const fundo = cena.add.rectangle(x, y, largura, altura, cor, indice === 0 ? 0.95 : 0.82);
+  fundo.setStrokeStyle(escalar(1, cena), indice === 0 ? 0xfacc15 : 0xffffff, indice === 0 ? 0.8 : 0.18);
+  fundo.setDepth(101);
+  objetos.push(fundo);
+  desenharTextoLinha(cena, objetos, { jogador, indice, x, y, largura });
+  if (indice === 0) animarVencedor(cena, fundo);
+}
+
+function desenharTextoLinha(
+  cena: Scene,
+  objetos: Phaser.GameObjects.GameObject[],
+  config: LinhaRanking & { x: number; y: number; largura: number },
+): void {
+  const medalha = config.indice === 0 ? '* ' : '';
+  const texto = `${medalha}${String(config.indice + 1)}. ${config.jogador.nome}`;
+  const nome = cena.add
+    .text(config.x - config.largura / 2 + escalar(18, cena), config.y, texto, {
+      fontSize: escalarFonte(config.indice === 0 ? 19 : 16, cena),
+      fontStyle: config.indice === 0 ? 'bold' : 'normal',
+      color: config.indice === 0 ? '#0b1020' : '#ffffff',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0, 0.5)
+    .setDepth(102);
+  const pontos = cena.add
+    .text(config.x + config.largura / 2 - escalar(18, cena), config.y, `${String(config.jogador.pontos)} pts`, {
+      fontSize: escalarFonte(16, cena),
+      fontStyle: 'bold',
+      color: config.indice === 0 ? '#0b1020' : '#dbeafe',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(1, 0.5)
+    .setDepth(102);
+  objetos.push(nome, pontos);
+}
+
+function animarVencedor(cena: Scene, alvo: Phaser.GameObjects.Rectangle): void {
+  cena.tweens.add({
+    targets: alvo,
+    scaleX: 1.03,
+    scaleY: 1.03,
+    duration: 700,
+    yoyo: true,
+    repeat: -1,
+    ease: 'Sine.easeInOut',
+  });
+}
+
+function desenharBotao(config: ConfigFimJogo): void {
+  const { cena, objetos } = config;
+  const largura = escalar(220, cena);
+  const altura = escalar(52, cena);
+  const x = cena.cameras.main.centerX;
+  const y = cena.cameras.main.height * 0.78;
+  const botao = cena.add.rectangle(x, y, largura, altura, 0xfacc15, 1).setDepth(102);
+  const texto = cena.add
+    .text(x, y, 'Jogar novamente', {
+      fontSize: escalarFonte(18, cena),
+      fontStyle: 'bold',
+      color: '#111827',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5)
+    .setDepth(103);
+  const zona = cena.add.zone(x, y, largura, altura).setInteractive({ useHandCursor: true }).setDepth(104);
+  zona.on('pointerdown', config.onReiniciar);
+  objetos.push(botao, texto, zona);
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -14,26 +14,28 @@ import { desenharPlacar } from '../renderers/placar-renderer';
 import { animarRecolhimentoTurno, atualizarIndicadorVez } from '../renderers/turno-renderer';
 import { aoEncerrarCena, transicionarRodada } from './ciclo-vida-cena';
 import { desenharMaosJogo } from './desenhar-maos-jogo';
+import { mostrarFimJogoDaCena } from './fim-jogo-scene';
+import { iniciarDeclaracaoDaCena, iniciarTurnosDaCena } from './fluxo-jogo-scene';
 import { JOGADORES } from './jogadores';
-import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
 
 export class JogoScene extends Scene {
-  private objetos: Phaser.GameObjects.GameObject[] = [];
+  objetos: Phaser.GameObjects.GameObject[] = [];
   private redesenhar?: ResizeDebouncer;
   private decisorHumano = new DecisorHumano();
   private decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
-  private mesaObjetos: Phaser.GameObjects.GameObject[] = [];
-  private objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
-  private destaque: EstadoDestaque = {};
+  mesaObjetos: Phaser.GameObjects.GameObject[] = [];
+  objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
+  destaque: EstadoDestaque = {};
   private partida?: Partida;
   private labels: Phaser.GameObjects.Text[] = [];
   private direcoesLabels: ('horizontal' | 'vertical')[] = [];
   private tweenVez?: Phaser.Tweens.Tween;
   private turnoAnterior = 1;
   private vencedorTurno?: string;
-  private manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
-  private indicadorRodadaObjetos: Phaser.GameObjects.GameObject[] = [];
-  private placarObjetos: Phaser.GameObjects.GameObject[] = [];
+  manilhaObjetos: Phaser.GameObjects.GameObject[] = [];
+  indicadorRodadaObjetos: Phaser.GameObjects.GameObject[] = [];
+  placarObjetos: Phaser.GameObjects.GameObject[] = [];
+  fimJogoObjetos: Phaser.GameObjects.GameObject[] = [];
   constructor() {
     super({ key: 'JogoScene' });
   }
@@ -48,7 +50,7 @@ export class JogoScene extends Scene {
   private iniciarFluxoDeclaracao(): void {
     const rodada = this.partida?.rodadaAtual;
     if (!rodada) return;
-    void processarDeclaracoes({
+    iniciarDeclaracaoDaCena({
       cena: this,
       rodada,
       objetos: this.objetosDeclaracao,
@@ -56,19 +58,18 @@ export class JogoScene extends Scene {
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
       atualizarPlacar: this.atualizarPlacar.bind(this),
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),
-    }).catch(() => undefined);
+    });
   }
   private async iniciarFluxoTurno(): Promise<void> {
     const rodada = this.partida?.rodadaAtual;
     if (!rodada) return;
-    const jogadoresAtuais = rodada.estado.maos.map((m) => m.jogador);
-    await iniciarProcessamentoTurno({
+    await iniciarTurnosDaCena({
       cena: this,
       rodada,
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
       turnoAnteriorRef: { valor: this.turnoAnterior },
-      jogadores: jogadoresAtuais,
+      jogadores: rodada.estado.maos.map((m) => m.jogador),
       getVencedorTurno: () => this.vencedorTurno,
       animarRecolhimento: this.animarRecolhimentoTurno.bind(this),
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
@@ -86,18 +87,23 @@ export class JogoScene extends Scene {
         onTurnoEmpatado: () => {
           this.vencedorTurno = undefined;
         },
-        onRodadaEncerrada: this.aoEncerrarRodada.bind(this),
+        onRodadaEncerrada: () => {
+          transicionarRodada(this, this.objetos, this.iniciarNovaRodada.bind(this));
+        },
         onManilhaVirada: this.atualizarManilha.bind(this),
         onRodadaIniciada: this.atualizarIndicadorRodada.bind(this),
         onPontuacaoAplicada: this.atualizarPlacar.bind(this),
+        onJogoEncerrado: (classificacao) => {
+          mostrarFimJogoDaCena(this, classificacao);
+        },
       },
     );
   }
   private iniciarNovaRodada(): void {
     this.turnoAnterior = 1;
     this.vencedorTurno = undefined;
-    this.partida?.iniciarProximaRodada();
-    this.atualizarManilha();
+    const rodada = this.partida?.iniciarProximaRodada();
+    if (!rodada) return;
     this.redesenharTela();
     this.iniciarFluxoDeclaracao();
   }
@@ -154,7 +160,7 @@ export class JogoScene extends Scene {
     this.direcoesLabels = resultado.direcoes;
   }
   private aoEncerrar = (): void => {
-    const r = aoEncerrarCena({
+    aoEncerrarCena({
       cena: this,
       redesenhar: this.redesenhar,
       tweenVez: this.tweenVez,
@@ -163,10 +169,9 @@ export class JogoScene extends Scene {
       indicadorRodadaObjetos: this.indicadorRodadaObjetos,
       manilhaObjetos: this.manilhaObjetos,
       placarObjetos: this.placarObjetos,
+      fimJogoObjetos: this.fimJogoObjetos,
       destaque: this.destaque,
     });
-    this.redesenhar = r.redesenhar;
-    this.tweenVez = r.tweenVez;
   };
   private atualizarIndicadorVez(): void {
     const estado = this.partida?.estado;
@@ -191,8 +196,5 @@ export class JogoScene extends Scene {
       mesaObjetos: objetosParaAnimar,
     });
     this.vencedorTurno = undefined;
-  }
-  private aoEncerrarRodada(): void {
-    transicionarRodada(this, this.objetos, this.iniciarNovaRodada.bind(this));
   }
 }

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -12,7 +12,7 @@ import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
 import { desenharPlacar } from '../renderers/placar-renderer';
 import { animarRecolhimentoTurno, atualizarIndicadorVez } from '../renderers/turno-renderer';
-import { aoEncerrarCena, transicionarRodada } from './ciclo-vida-cena';
+import { aoEncerrarCena, desativarResize, transicionarRodada } from './ciclo-vida-cena';
 import { desenharMaosJogo } from './desenhar-maos-jogo';
 import { mostrarFimJogoDaCena } from './fim-jogo-scene';
 import { iniciarDeclaracaoDaCena, iniciarTurnosDaCena } from './fluxo-jogo-scene';
@@ -94,6 +94,7 @@ export class JogoScene extends Scene {
         onRodadaIniciada: this.atualizarIndicadorRodada.bind(this),
         onPontuacaoAplicada: this.atualizarPlacar.bind(this),
         onJogoEncerrado: (classificacao) => {
+          desativarResize(this, this.redesenhar);
           mostrarFimJogoDaCena(this, classificacao);
         },
       },

--- a/src/adapters/phaser/scenes/ciclo-vida-cena.ts
+++ b/src/adapters/phaser/scenes/ciclo-vida-cena.ts
@@ -14,6 +14,7 @@ interface ConfigEncerramento {
   indicadorRodadaObjetos: Phaser.GameObjects.GameObject[];
   manilhaObjetos: Phaser.GameObjects.GameObject[];
   placarObjetos: Phaser.GameObjects.GameObject[];
+  fimJogoObjetos: Phaser.GameObjects.GameObject[];
   destaque: EstadoDestaque;
 }
 
@@ -32,6 +33,7 @@ export function aoEncerrarCena(config: ConfigEncerramento): {
   limparObjetos(config.indicadorRodadaObjetos);
   limparManilha(config.manilhaObjetos);
   limparPlacar(config.placarObjetos);
+  limparObjetos(config.fimJogoObjetos);
   destruirDestaque(config.destaque);
   return { redesenhar: undefined, tweenVez: undefined };
 }

--- a/src/adapters/phaser/scenes/ciclo-vida-cena.ts
+++ b/src/adapters/phaser/scenes/ciclo-vida-cena.ts
@@ -22,10 +22,7 @@ export function aoEncerrarCena(config: ConfigEncerramento): {
   redesenhar?: ResizeDebouncer;
   tweenVez?: Phaser.Tweens.Tween;
 } {
-  if (config.redesenhar) {
-    config.cena.scale.off('resize', config.redesenhar);
-    config.redesenhar.limpar();
-  }
+  desativarResize(config.cena, config.redesenhar);
   config.tweenVez?.stop();
   config.tweenVez?.remove();
   limparObjetos(config.objetos);
@@ -36,6 +33,12 @@ export function aoEncerrarCena(config: ConfigEncerramento): {
   limparObjetos(config.fimJogoObjetos);
   destruirDestaque(config.destaque);
   return { redesenhar: undefined, tweenVez: undefined };
+}
+
+export function desativarResize(cena: Phaser.Scene, redesenhar?: ResizeDebouncer): void {
+  if (!redesenhar) return;
+  cena.scale.off('resize', redesenhar);
+  redesenhar.limpar();
 }
 
 export function transicionarRodada(

--- a/src/adapters/phaser/scenes/fim-jogo-scene.ts
+++ b/src/adapters/phaser/scenes/fim-jogo-scene.ts
@@ -1,0 +1,57 @@
+import type { Scene } from 'phaser';
+import type { Jogador } from '@/types/entidades';
+import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
+import { desenharFimJogo } from '../renderers/fim-jogo-renderer';
+import { limparObjetos } from '../renderers/limpar-objetos';
+import { limparManilha } from '../renderers/manilha-renderer';
+import type { JogoScene } from './JogoScene';
+
+interface ConfigFimJogoScene {
+  cena: Scene;
+  classificacao: Jogador[];
+  fimJogoObjetos: Phaser.GameObjects.GameObject[];
+  objetos: Phaser.GameObjects.GameObject[];
+  mesaObjetos: Phaser.GameObjects.GameObject[];
+  objetosDeclaracao: Phaser.GameObjects.GameObject[];
+  indicadorRodadaObjetos: Phaser.GameObjects.GameObject[];
+  manilhaObjetos: Phaser.GameObjects.GameObject[];
+  placarObjetos: Phaser.GameObjects.GameObject[];
+  destaque: EstadoDestaque;
+  onReiniciar: () => void;
+}
+
+export function mostrarFimJogo(config: ConfigFimJogoScene): void {
+  limparTelaDeJogo(config);
+  desenharFimJogo({
+    cena: config.cena,
+    classificacao: config.classificacao,
+    objetos: config.fimJogoObjetos,
+    onReiniciar: config.onReiniciar,
+  });
+}
+
+export function mostrarFimJogoDaCena(cena: JogoScene, classificacao: Jogador[]): void {
+  mostrarFimJogo({
+    cena,
+    classificacao,
+    fimJogoObjetos: cena.fimJogoObjetos,
+    objetos: cena.objetos,
+    mesaObjetos: cena.mesaObjetos,
+    objetosDeclaracao: cena.objetosDeclaracao,
+    indicadorRodadaObjetos: cena.indicadorRodadaObjetos,
+    manilhaObjetos: cena.manilhaObjetos,
+    placarObjetos: cena.placarObjetos,
+    destaque: cena.destaque,
+    onReiniciar: () => cena.scene.restart(),
+  });
+}
+
+function limparTelaDeJogo(config: ConfigFimJogoScene): void {
+  limparObjetos(config.objetos);
+  limparObjetos(config.mesaObjetos);
+  limparObjetos(config.objetosDeclaracao);
+  limparObjetos(config.indicadorRodadaObjetos);
+  limparManilha(config.manilhaObjetos);
+  limparObjetos(config.placarObjetos);
+  destruirDestaque(config.destaque);
+}

--- a/src/adapters/phaser/scenes/fluxo-jogo-scene.ts
+++ b/src/adapters/phaser/scenes/fluxo-jogo-scene.ts
@@ -1,0 +1,35 @@
+import type { Rodada } from '@/core/Rodada';
+import type { Jogador } from '@/types/entidades';
+import type { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
+import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
+import type { JogoScene } from './JogoScene';
+
+interface ConfigDeclaracaoCena {
+  cena: JogoScene;
+  rodada: Rodada;
+  objetos: Phaser.GameObjects.GameObject[];
+  decisorHumano: DecisorDeclaracaoHumano;
+  atualizarIndicadorVez: () => void;
+  atualizarPlacar: () => void;
+  iniciarTurnos: () => Promise<void>;
+}
+
+interface ConfigTurnosCena {
+  cena: JogoScene;
+  rodada: Rodada;
+  getLabels: () => Phaser.GameObjects.Text[];
+  getDirecoesLabels: () => ('horizontal' | 'vertical')[];
+  turnoAnteriorRef: { valor: number };
+  jogadores: Jogador[];
+  getVencedorTurno: () => string | undefined;
+  animarRecolhimento: () => void;
+  atualizarIndicadorVez: () => void;
+}
+
+export function iniciarDeclaracaoDaCena(config: ConfigDeclaracaoCena): void {
+  void processarDeclaracoes(config).catch(() => undefined);
+}
+
+export async function iniciarTurnosDaCena(config: ConfigTurnosCena): Promise<void> {
+  await iniciarProcessamentoTurno(config);
+}


### PR DESCRIPTION
## Resumo

- conecta o evento `JOGO_ENCERRADO` no adapter Phaser
- exibe ranking final ordenado por pontos, com vencedor destacado e animação simples
- adiciona botão `Jogar novamente` reiniciando a cena

## Validação

- `pnpm lint` (avisos preexistentes de `console` em `jogo-scene-loop.ts`)
- `pnpm typecheck`
- `pnpm build`
- hook de push: `pnpm typecheck` e `pnpm test` (520 testes)

Closes #116