### PR TITLE
refactor(core): extrai MaquinaFases da Rodada

### DIFF
--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -38,9 +38,7 @@ export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<v
     config.atualizarIndicadorVez();
   }
   if (rodada.estado.fase === 'aguardandoJogada') {
-    void config.iniciarTurnos().catch((erro: unknown) => {
-      console.error('Erro nos turnos:', erro);
-    });
+    void config.iniciarTurnos().catch(() => undefined);
   }
 }
 
@@ -102,8 +100,7 @@ async function tentarDeclarar(rodada: Rodada): Promise<boolean> {
   try {
     await rodada.declarar();
     return true;
-  } catch (erro) {
-    console.error('Falha em declarar:', erro);
+  } catch {
     return false;
   }
 }
@@ -112,8 +109,7 @@ async function tentarJogarTurno(rodada: Rodada): Promise<boolean> {
   try {
     await rodada.jogarTurno();
     return true;
-  } catch (erro) {
-    console.error('Falha em jogarTurno:', erro);
+  } catch {
     return false;
   }
 }

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -85,7 +85,7 @@ export class Rodada {
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisoresDeclaracao.get(jogador.id);
     if (!decisor) {
-      this._estado.fase = 'aguardandoDeclaracao';
+      this.transitarFase('aguardandoDeclaracao');
       throw new Error(`Decisor de declaração não encontrado para jogador ${jogador.id}`);
     }
     try {
@@ -126,7 +126,7 @@ export class Rodada {
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisores.get(jogador.id);
     if (!decisor) {
-      this._estado.fase = 'aguardandoJogada';
+      this.transitarFase('aguardandoJogada');
       throw new Error(`Decisor não encontrado para jogador ${jogador.id}`);
     }
     try {

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -95,7 +95,7 @@ export class Rodada {
       emitirDeclaracaoFeita(this.emissor, jogador.id, declaracao);
       this.avancarDeclaracao();
     } catch (erro) {
-      this.transitarFase('aguardandoDeclaracao');
+      if (this.fases.eh('processandoDeclaracao')) this.transitarFase('aguardandoDeclaracao');
       throw erro;
     }
   }
@@ -132,7 +132,7 @@ export class Rodada {
     try {
       await this.executarJogada(jogador, decisor);
     } catch (erro) {
-      this.transitarFase('aguardandoJogada');
+      if (this.fases.eh('processandoTurno')) this.transitarFase('aguardandoJogada');
       throw erro;
     }
   }

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -1,5 +1,5 @@
 import type { Jogador } from '@/types/entidades';
-import type { EstadoRodada } from '@/types/estado-rodada';
+import type { EstadoRodada, FaseRodada } from '@/types/estado-rodada';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
 import { obterProximoValor } from './Carta';
 import type { Carta } from './Carta';
@@ -14,6 +14,7 @@ import {
   emitirTurnoGanho,
   type EmissorRodada,
 } from './eventos-rodada';
+import { MaquinaFases } from './maquina-fases';
 import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
@@ -26,6 +27,7 @@ export class Rodada {
   private emissor: EmissorRodada;
   private jogadores: Jogador[];
   private numeroRodada: number;
+  private fases = new MaquinaFases();
 
   constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
@@ -70,16 +72,16 @@ export class Rodada {
     this._estado.manilha = manilha;
     this._estado.cartaVirada = cartaVirada;
     this._estado.declaracoes = {};
-    this._estado.fase = 'aguardandoDeclaracao';
+    this.transitarFase('aguardandoDeclaracao');
 
     if (cartaVirada) emitirManilhaVirada(this.emissor, cartaVirada, manilha);
   }
 
   async declarar(): Promise<void> {
-    if (this._estado.fase !== 'aguardandoDeclaracao') {
-      throw new Error(`Não é possível declarar na fase ${this._estado.fase}`);
+    if (!this.fases.eh('aguardandoDeclaracao')) {
+      throw new Error(`Não é possível declarar na fase ${this.fases.atual}`);
     }
-    this._estado.fase = 'processandoDeclaracao';
+    this.transitarFase('processandoDeclaracao');
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisoresDeclaracao.get(jogador.id);
     if (!decisor) {
@@ -93,7 +95,7 @@ export class Rodada {
       emitirDeclaracaoFeita(this.emissor, jogador.id, declaracao);
       this.avancarDeclaracao();
     } catch (erro) {
-      this._estado.fase = 'aguardandoDeclaracao';
+      this.transitarFase('aguardandoDeclaracao');
       throw erro;
     }
   }
@@ -108,19 +110,19 @@ export class Rodada {
   private avancarDeclaracao(): void {
     const totalDeclaracoes = Object.keys(this._estado.declaracoes).length;
     if (totalDeclaracoes === this.jogadores.length) {
-      this._estado.fase = 'aguardandoJogada';
+      this.transitarFase('aguardandoJogada');
       this._estado.jogadorAtual = 0;
     } else {
       this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
-      this._estado.fase = 'aguardandoDeclaracao';
+      this.transitarFase('aguardandoDeclaracao');
     }
   }
 
   async jogarTurno(): Promise<void> {
-    if (this._estado.fase !== 'aguardandoJogada') {
-      throw new Error(`Não é possível jogar na fase ${this._estado.fase}`);
+    if (!this.fases.eh('aguardandoJogada')) {
+      throw new Error(`Não é possível jogar na fase ${this.fases.atual}`);
     }
-    this._estado.fase = 'processandoTurno';
+    this.transitarFase('processandoTurno');
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisores.get(jogador.id);
     if (!decisor) {
@@ -130,7 +132,7 @@ export class Rodada {
     try {
       await this.executarJogada(jogador, decisor);
     } catch (erro) {
-      this._estado.fase = 'aguardandoJogada';
+      this.transitarFase('aguardandoJogada');
       throw erro;
     }
   }
@@ -156,7 +158,7 @@ export class Rodada {
       return;
     }
     this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
-    this._estado.fase = 'aguardandoJogada';
+    this.transitarFase('aguardandoJogada');
   }
 
   private resolverTurno(): void {
@@ -173,7 +175,7 @@ export class Rodada {
     this._estado.turno += 1;
     this._estado.mesa = [];
     if (this._estado.turno > this._estado.cartasPorRodada) {
-      this._estado.fase = 'rodadaConcluida';
+      this.transitarFase('rodadaConcluida');
       const pontos = aplicarPontuacao(
         this._estado,
         this.jogadores.map((j) => j.id),
@@ -181,9 +183,14 @@ export class Rodada {
       emitirPontuacaoAplicada(this.emissor, pontos.pontos, pontos.penalidades);
       emitirRodadaEncerrada(this.emissor, { ...this._estado.vazas });
     } else {
-      this._estado.fase = 'aguardandoJogada';
+      this.transitarFase('aguardandoJogada');
       this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === proximoJogadorId);
     }
+  }
+
+  private transitarFase(novaFase: FaseRodada): void {
+    this.fases.transitar(novaFase);
+    this._estado.fase = novaFase;
   }
 
   private cartasDaMesa(): Carta[] {

--- a/src/core/maquina-fases.ts
+++ b/src/core/maquina-fases.ts
@@ -6,7 +6,6 @@ const TRANSICOES_VALIDAS: Record<FaseRodada, FaseRodada[]> = {
   processandoDeclaracao: ['aguardandoDeclaracao', 'aguardandoJogada'],
   aguardandoJogada: ['processandoTurno'],
   processandoTurno: ['aguardandoJogada', 'rodadaConcluida'],
-  turnoConcluido: [],
   rodadaConcluida: [],
 };
 

--- a/src/core/maquina-fases.ts
+++ b/src/core/maquina-fases.ts
@@ -1,0 +1,40 @@
+import type { FaseRodada } from '@/types/estado-rodada';
+
+const TRANSICOES_VALIDAS: Record<FaseRodada, FaseRodada[]> = {
+  distribuindo: ['aguardandoDeclaracao'],
+  aguardandoDeclaracao: ['processandoDeclaracao'],
+  processandoDeclaracao: ['aguardandoDeclaracao', 'aguardandoJogada'],
+  aguardandoJogada: ['processandoTurno'],
+  processandoTurno: ['aguardandoJogada', 'rodadaConcluida'],
+  turnoConcluido: [],
+  rodadaConcluida: [],
+};
+
+export class MaquinaFases {
+  private fase: FaseRodada;
+
+  constructor(faseInicial: FaseRodada = 'distribuindo') {
+    this.fase = faseInicial;
+  }
+
+  get atual(): FaseRodada {
+    return this.fase;
+  }
+
+  eh(fase: FaseRodada): boolean {
+    return this.fase === fase;
+  }
+
+  transitar(novaFase: FaseRodada): void {
+    const validas = TRANSICOES_VALIDAS[this.fase];
+    if (!validas.includes(novaFase)) {
+      throw new Error(`Transição inválida: ${this.fase} → ${novaFase}`);
+    }
+    this.fase = novaFase;
+  }
+
+  /** Define a fase sem validação. Uso interno para restauração de estado. */
+  definir(fase: FaseRodada): void {
+    this.fase = fase;
+  }
+}

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -7,7 +7,6 @@ export type FaseRodada =
   | 'processandoDeclaracao'
   | 'aguardandoJogada'
   | 'processandoTurno'
-  | 'turnoConcluido'
   | 'rodadaConcluida';
 
 export interface MaoJogador {

--- a/tests/core/Rodada.manilha.test.ts
+++ b/tests/core/Rodada.manilha.test.ts
@@ -68,10 +68,12 @@ describe('Rodada — manilha vence não-manilha', () => {
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
       _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
+      fases: { definir(fase: string): void };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('3', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';
     estadoPrivado._estado.fase = 'aguardandoJogada';
+    estadoPrivado.fases.definir('aguardandoJogada');
     await rodada.jogarTurno();
     await rodada.jogarTurno();
     expect(rodada.estado.vazas['j2']).toBe(1);
@@ -89,10 +91,12 @@ describe('Rodada — desempate de manilhas', () => {
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
       _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
+      fases: { definir(fase: string): void };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('4', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';
     estadoPrivado._estado.fase = 'aguardandoJogada';
+    estadoPrivado.fases.definir('aguardandoJogada');
     await rodada.jogarTurno();
     await rodada.jogarTurno();
     expect(rodada.estado.vazas['j2']).toBe(1);

--- a/tests/core/Rodada.manilha.test.ts
+++ b/tests/core/Rodada.manilha.test.ts
@@ -3,6 +3,7 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { FaseRodada } from '@/types/estado-rodada';
 import { criarCarta, criarJogador, criarDecisorPrimeiraCarta } from './rodada-fixtures';
 
 describe('Rodada — carta virada removida', () => {
@@ -67,8 +68,8 @@ describe('Rodada — manilha vence não-manilha', () => {
     ]);
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
-      _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-      fases: { definir(fase: string): void };
+      _estado: { fase: FaseRodada; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
+      fases: { definir(fase: FaseRodada): void };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('3', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';
@@ -90,8 +91,8 @@ describe('Rodada — desempate de manilhas', () => {
     ]);
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
-      _estado: { fase: string; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-      fases: { definir(fase: string): void };
+      _estado: { fase: FaseRodada; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
+      fases: { definir(fase: FaseRodada): void };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('4', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';

--- a/tests/core/maquina-fases.test.ts
+++ b/tests/core/maquina-fases.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { MaquinaFases } from '@/core/maquina-fases';
+
+describe('MaquinaFases — construção', () => {
+  it('deve iniciar na fase distribuindo por padrão', () => {
+    const maquina = new MaquinaFases();
+    expect(maquina.atual).toBe('distribuindo');
+  });
+
+  it('deve permitir iniciar em qualquer fase', () => {
+    const maquina = new MaquinaFases('aguardandoJogada');
+    expect(maquina.atual).toBe('aguardandoJogada');
+  });
+});
+
+describe('MaquinaFases — consulta', () => {
+  it('deve retornar true quando a fase atual corresponde', () => {
+    const maquina = new MaquinaFases('aguardandoJogada');
+    expect(maquina.eh('aguardandoJogada')).toBe(true);
+  });
+
+  it('deve retornar false quando a fase atual não corresponde', () => {
+    const maquina = new MaquinaFases('aguardandoJogada');
+    expect(maquina.eh('aguardandoDeclaracao')).toBe(false);
+  });
+});
+
+describe('MaquinaFases — transições válidas', () => {
+  it.each([
+    ['distribuindo', 'aguardandoDeclaracao'],
+    ['aguardandoDeclaracao', 'processandoDeclaracao'],
+    ['processandoDeclaracao', 'aguardandoDeclaracao'],
+    ['processandoDeclaracao', 'aguardandoJogada'],
+    ['aguardandoJogada', 'processandoTurno'],
+    ['processandoTurno', 'aguardandoJogada'],
+    ['processandoTurno', 'rodadaConcluida'],
+  ] as const)('deve transitar de %s para %s', (de, para) => {
+    const maquina = new MaquinaFases(de);
+    maquina.transitar(para);
+    expect(maquina.atual).toBe(para);
+  });
+});
+
+describe('MaquinaFases — transições inválidas', () => {
+  it.each([
+    ['distribuindo', 'aguardandoJogada'],
+    ['aguardandoJogada', 'aguardandoDeclaracao'],
+    ['rodadaConcluida', 'distribuindo'],
+    ['aguardandoDeclaracao', 'rodadaConcluida'],
+  ] as const)('deve rejeitar transição de %s para %s', (de, para) => {
+    const maquina = new MaquinaFases(de);
+    expect(() => {
+      maquina.transitar(para);
+    }).toThrow('Transição inválida');
+  });
+});
+
+describe('MaquinaFases — definir', () => {
+  it('deve definir a fase sem validação', () => {
+    const maquina = new MaquinaFases('distribuindo');
+    maquina.definir('rodadaConcluida');
+    expect(maquina.atual).toBe('rodadaConcluida');
+  });
+});

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -5,7 +5,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
-import type { EstadoRodada } from '@/types/estado-rodada';
+import type { EstadoRodada, FaseRodada } from '@/types/estado-rodada';
 
 export function criarCarta(valor: Carta['valor'], naipe: Carta['naipe']): Carta {
   return { valor, naipe };
@@ -49,27 +49,35 @@ export function criarRodada(config: {
     declaracao: config.decisoresDeclaracao ?? new Map<string, DecisorDeclaracao>(),
   });
   rodada.distribuir(config.cartasPorRodada ?? 1);
-  const estado = (rodada as unknown as EstadoPrivado)._estado;
-  estado.fase = 'aguardandoJogada';
-  estado.declaracoes = {};
+  const privado = rodada as unknown as EstadoPrivado;
+  privado._estado.fase = 'aguardandoJogada';
+  privado._estado.declaracoes = {};
+  privado.fases.definir('aguardandoJogada');
   return rodada;
 }
 
 interface EstadoPrivado {
   _estado: EstadoRodada;
+  fases: { definir(fase: FaseRodada): void };
 }
 
 function pontosIniciais(jogadores: Jogador[]): Record<string, number> {
   return Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos]));
 }
 
-function preencherEstadoComMao(estado: EstadoRodada, config: ConfigRodadaComMao): void {
+function preencherEstadoComMao(
+  estado: EstadoRodada,
+  config: ConfigRodadaComMao,
+  fases: { definir(fase: FaseRodada): void },
+): void {
   estado.maos = config.jogadores.map((jogador, i) => ({
     jogador,
     cartas: config.maos[i] ?? [],
     visivel: jogador.id === 'humano',
   }));
-  estado.fase = config.fase ?? 'aguardandoJogada';
+  const fase = config.fase ?? 'aguardandoJogada';
+  estado.fase = fase;
+  fases.definir(fase);
   estado.jogadorAtual = config.jogadorAtual ?? 0;
   estado.turno = config.turno ?? 1;
   estado.cartasPorRodada = config.cartasPorRodada ?? 4;
@@ -99,8 +107,8 @@ export function criarRodadaComMao(config: ConfigRodadaComMao): Rodada {
     jogada: config.decisores,
     declaracao: new Map<string, DecisorDeclaracao>(),
   });
-  const estado = (rodada as unknown as EstadoPrivado)._estado;
-  preencherEstadoComMao(estado, config);
+  const privado = rodada as unknown as EstadoPrivado;
+  preencherEstadoComMao(privado._estado, config, privado.fases);
   return rodada;
 }
 


### PR DESCRIPTION
## O que muda

Extrai a lógica de transição de fases da `Rodada` para um módulo dedicado `MaquinaFases`, que valida toda transição contra uma tabela declarativa antes de aplicá-la.

### Novo módulo: `MaquinaFases` (`src/core/maquina-fases.ts`)
- Tabela `TRANSICOES_VALIDAS` — grafo de fases em um único lugar
- `transitar()` — valida e aplica; lança `Error` se inválida
- `definir()` — bypass para test fixtures

### Mudanças na `Rodada`
- Todos os `this._estado.fase = 'x'` substituídos por `this.transitarFase('x')`
- Guards de fase (`if fase !==`) passaram a usar `fases.eh()`
- `transitarFase()` é o único ponto de escrita de fase (sincroniza `fases` + `_estado.fase`)

### Testes
- 12 testes novos da `MaquinaFases` (transições válidas, inválidas, consulta)
- 520 testes originais preservados sem mudança de comportamento
- Test fixtures atualizados para sincronizar a máquina ao hackear estado

### Nota

`_estado.fase` é mantido como cache para o adapter Phaser (o estado plano é o contrato atual). Resolve no futuro com `EstadoRodada` como union discriminada por fase.

## Commits

1. `feat(core): extrai MaquinaFases com tabela de transições válidas` — novo módulo + testes (TDD)
2. `refactor(core): integra MaquinaFases na Rodada` — substituição dos assignments + fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal phase management for game rounds.

* **Tests**
  * Added comprehensive tests for phase transition logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->