### PR TITLE
refactor(core): tipa DecisorJogada e deduplica criarEventoBase

### DIFF
--- a/src/adapters/bots/BotDeterministico.ts
+++ b/src/adapters/bots/BotDeterministico.ts
@@ -1,6 +1,7 @@
 import type { Carta } from '@/core/Carta';
 import { compararValor, compararNaipe } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import type { EstadoRodada } from '@/types/estado-rodada';
 
 function ehMenor(a: Carta, b: Carta): boolean {
   if (a.valor !== b.valor) {
@@ -10,7 +11,7 @@ function ehMenor(a: Carta, b: Carta): boolean {
 }
 
 export class BotDeterministico implements DecisorJogada {
-  decidirJogada(mao: Carta[], _estado: unknown): Promise<Carta> {
+  decidirJogada(mao: Carta[], _estado: EstadoRodada): Promise<Carta> {
     if (mao.length === 0) {
       return Promise.reject(new Error('Mão vazia'));
     }

--- a/src/adapters/phaser/DecisorHumano.ts
+++ b/src/adapters/phaser/DecisorHumano.ts
@@ -1,11 +1,12 @@
 import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import type { EstadoRodada } from '@/types/estado-rodada';
 
 export class DecisorHumano implements DecisorJogada {
   private resolver?: (carta: Carta) => void;
   private cartaSelecionada?: Carta;
 
-  decidirJogada(_mao: Carta[], _estado: unknown): Promise<Carta> {
+  decidirJogada(_mao: Carta[], _estado: EstadoRodada): Promise<Carta> {
     return new Promise((resolve) => {
       this.resolver = resolve;
     });

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -1,6 +1,7 @@
 import type { Jogador } from '@/types/entidades';
 import type { EstadoPartida } from '@/types/estado-partida';
 import type { EventoDominio } from '@/types/eventos-dominio';
+import { criarEventoBase } from './eventos-rodada';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 import { Rodada } from './Rodada';
@@ -12,10 +13,6 @@ interface EmissorPartida {
 interface DecisoresPartida {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
-}
-
-function eventoBase() {
-  return { id: crypto.randomUUID(), timestamp: Date.now() };
 }
 
 export class Partida {
@@ -126,12 +123,12 @@ export class Partida {
   }
 
   private emitirJogadorEliminado(jogador: Jogador): void {
-    this.emissor.emit({ ...eventoBase(), tipo: 'JOGADOR_ELIMINADO', jogador });
+    this.emissor.emit({ ...criarEventoBase(), tipo: 'JOGADOR_ELIMINADO', jogador });
   }
 
   private emitirRodadaIniciada(cartasPorRodada: number): void {
     this.emissor.emit({
-      ...eventoBase(),
+      ...criarEventoBase(),
       tipo: 'RODADA_INICIADA',
       numeroRodada: this.numeroRodada,
       cartasPorRodada,
@@ -154,7 +151,7 @@ export class Partida {
 
   private emitirJogoEncerrado(): void {
     this.emissor.emit({
-      ...eventoBase(),
+      ...criarEventoBase(),
       tipo: 'JOGO_ENCERRADO',
       classificacao: [...this.jogadores, ...this.eliminados].sort((a, b) => b.pontos - a.pontos),
     });

--- a/src/core/eventos-rodada.ts
+++ b/src/core/eventos-rodada.ts
@@ -12,32 +12,32 @@ interface CartaJogadaConfig {
   posicaoMesa: number;
 }
 
-function base() {
+export function criarEventoBase() {
   return { id: crypto.randomUUID(), timestamp: Date.now() };
 }
 
 export function emitirManilhaVirada(emissor: EmissorRodada, cartaVirada: Carta, manilha: Valor): void {
-  emissor.emit({ ...base(), tipo: 'MANILHA_VIRADA', cartaVirada, manilha });
+  emissor.emit({ ...criarEventoBase(), tipo: 'MANILHA_VIRADA', cartaVirada, manilha });
 }
 
 export function emitirDeclaracaoFeita(emissor: EmissorRodada, jogadorId: string, declarado: number): void {
-  emissor.emit({ ...base(), tipo: 'DECLARACAO_FEITA', jogadorId, declarado });
+  emissor.emit({ ...criarEventoBase(), tipo: 'DECLARACAO_FEITA', jogadorId, declarado });
 }
 
 export function emitirCartaJogada(emissor: EmissorRodada, config: CartaJogadaConfig): void {
-  emissor.emit({ ...base(), tipo: 'CARTA_JOGADA', ...config });
+  emissor.emit({ ...criarEventoBase(), tipo: 'CARTA_JOGADA', ...config });
 }
 
 export function emitirTurnoGanho(emissor: EmissorRodada, jogadorId: string, cartas: Carta[]): void {
-  emissor.emit({ ...base(), tipo: 'TURNO_GANHO', jogadorId, cartas });
+  emissor.emit({ ...criarEventoBase(), tipo: 'TURNO_GANHO', jogadorId, cartas });
 }
 
 export function emitirTurnoEmpatado(emissor: EmissorRodada, ultimoEmpatadoId: string, cartas: Carta[]): void {
-  emissor.emit({ ...base(), tipo: 'TURNO_EMPATADO', ultimoEmpatadoId, cartas });
+  emissor.emit({ ...criarEventoBase(), tipo: 'TURNO_EMPATADO', ultimoEmpatadoId, cartas });
 }
 
 export function emitirRodadaEncerrada(emissor: EmissorRodada, placar: Record<string, number>): void {
-  emissor.emit({ ...base(), tipo: 'RODADA_ENCERRADA', placar, proximaRodada: null });
+  emissor.emit({ ...criarEventoBase(), tipo: 'RODADA_ENCERRADA', placar, proximaRodada: null });
 }
 
 export function emitirPontuacaoAplicada(
@@ -45,5 +45,5 @@ export function emitirPontuacaoAplicada(
   placar: Record<string, number>,
   penalidades: Record<string, number>,
 ): void {
-  emissor.emit({ ...base(), tipo: 'PONTUACAO_APLICADA', placar, penalidades });
+  emissor.emit({ ...criarEventoBase(), tipo: 'PONTUACAO_APLICADA', placar, penalidades });
 }

--- a/src/core/portas/DecisorJogada.ts
+++ b/src/core/portas/DecisorJogada.ts
@@ -1,5 +1,6 @@
 import type { Carta } from '@/core/Carta';
+import type { EstadoRodada } from '@/types/estado-rodada';
 
 export interface DecisorJogada {
-  decidirJogada(mao: Carta[], estado: unknown): Promise<Carta>;
+  decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta>;
 }

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -16,19 +16,19 @@ export function criarJogador(id: string, nome: string): Jogador {
 }
 
 export function criarDecisor(carta: Carta): DecisorJogada {
-  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>().mockResolvedValue(carta);
+  const mock = vi.fn<(mao: Carta[], estado: EstadoRodada) => Promise<Carta>>().mockResolvedValue(carta);
   return { decidirJogada: mock };
 }
 
 export function criarDecisorPrimeiraCarta(): DecisorJogada {
-  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>();
+  const mock = vi.fn<(mao: Carta[], estado: EstadoRodada) => Promise<Carta>>();
   mock.mockImplementation((mao: Carta[]) => Promise.resolve(mao[0]));
   return { decidirJogada: mock };
 }
 
 export function criarDecisorSequencia(cartas: Carta[]): DecisorJogada {
   let indice = 0;
-  const mock = vi.fn<(mao: Carta[], estado: unknown) => Promise<Carta>>();
+  const mock = vi.fn<(mao: Carta[], estado: EstadoRodada) => Promise<Carta>>();
   mock.mockImplementation(() => {
     const carta = cartas[indice];
     indice += 1;


### PR DESCRIPTION
## O que muda

Dois quick wins de consistência:

### C3 — Tipar `DecisorJogada.estado` como `EstadoRodada`
- `DecisorDeclaracao.declarar()` já recebia `EstadoRodada`, mas `DecisorJogada.decidirJogada()` recebia `unknown`
- Porta, adapters (BotDeterministico, DecisorHumano) e fixtures atualizados

### C4 — Deduplicar `eventoBase()`/`base()`
- `Partida.ts` tinha `eventoBase()` e `eventos-rodada.ts` tinha `base()` — idênticas
- Consolidadas em `criarEventoBase()` exportada de `eventos-rodada.ts`, consumida por ambos