### PR TITLE
feat(skills): adiciona skill handoff

### DIFF
--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: 'What will the next session be used for?'
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
## O que muda

Adiciona a skill `handoff` ao projeto.

### `.agents/skills/handoff/SKILL.md`

Compacta o contexto da conversa atual num documento de handoff para que outro agente possa continuar o trabalho sem perda de contexto. Referencia artefatos existentes (PRDs, plans, ADRs, issues, commits) ao invés de duplicá-los.