### PR TITLE
refactor(core): tipa estado da rodada por fase

### DIFF
--- a/src/adapters/phaser/input/input-humano.ts
+++ b/src/adapters/phaser/input/input-humano.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Carta } from '@/core/Carta';
 import type { Rodada } from '@/core/Rodada';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import type { DecisorHumano } from '../DecisorHumano';
 import { destacarCarta, removerDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 
@@ -64,7 +65,8 @@ function aoClicarCarta(config: ConfigClicarCarta): void {
   if (rodada.estado.fase !== 'aguardandoJogada' && rodada.estado.fase !== 'processandoTurno') {
     return;
   }
-  if (rodada.estado.maos[rodada.estado.jogadorAtual].jogador.id !== 'humano') {
+  const emJogo = estadoEmJogo(rodada.estado);
+  if (emJogo.maos[emJogo.jogadorAtual].jogador.id !== 'humano') {
     return;
   }
   if (destaque.container === container) {

--- a/src/adapters/phaser/renderers/mao-scene-renderer.ts
+++ b/src/adapters/phaser/renderers/mao-scene-renderer.ts
@@ -22,7 +22,9 @@ export interface ConfigDesenharMao {
 
 export function desenharMaoNaCena(config: ConfigDesenharMao): void {
   const { cena, mao, posicao, rodada, decisorHumano, destaque, objetos, labels } = config;
-  const vazas = estadoEmJogo(rodada.estado).vazas[mao.jogador.id] ?? 0;
+  const estado = rodada.estado;
+  if (estado.fase === 'distribuindo') return;
+  const vazas = estadoEmJogo(estado).vazas[mao.jogador.id] ?? 0;
   const texto = formatarLabelJogador(mao.jogador.nome, vazas, posicao.mao.direcao);
   const label = renderizarLabel({
     cena,

--- a/src/adapters/phaser/renderers/mao-scene-renderer.ts
+++ b/src/adapters/phaser/renderers/mao-scene-renderer.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Rodada } from '@/core/Rodada';
 import type { MaoJogador } from '@/types/estado-rodada';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import type { DecisorHumano } from '../DecisorHumano';
 import { configurarInteracaoHumano } from '../input/input-humano';
 import type { EstadoDestaque } from './destaque-renderer';
@@ -21,7 +22,7 @@ export interface ConfigDesenharMao {
 
 export function desenharMaoNaCena(config: ConfigDesenharMao): void {
   const { cena, mao, posicao, rodada, decisorHumano, destaque, objetos, labels } = config;
-  const vazas = rodada.estado.vazas[mao.jogador.id] ?? 0;
+  const vazas = estadoEmJogo(rodada.estado).vazas[mao.jogador.id] ?? 0;
   const texto = formatarLabelJogador(mao.jogador.nome, vazas, posicao.mao.direcao);
   const label = renderizarLabel({
     cena,

--- a/src/adapters/phaser/renderers/placar-renderer.ts
+++ b/src/adapters/phaser/renderers/placar-renderer.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoRodada } from '@/types/estado-rodada';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { escalar, escalarFonte } from '../escala';
 
 interface ConfigPlacar {
@@ -49,11 +50,12 @@ export function desenharPlacar(config: ConfigPlacar): void {
 }
 
 function criarLinhas(jogadores: Jogador[], estado: EstadoRodada): LinhaPlacar[] {
+  const emJogo = estadoEmJogo(estado);
   return jogadores.map((jogador) => ({
     jogador,
-    declarado: estado.declaracoes[jogador.id] ?? null,
-    feito: estado.vazas[jogador.id] ?? 0,
-    pontos: estado.pontos[jogador.id] ?? jogador.pontos,
+    declarado: emJogo.declaracoes[jogador.id] ?? null,
+    feito: emJogo.vazas[jogador.id] ?? 0,
+    pontos: emJogo.pontos[jogador.id] ?? jogador.pontos,
   }));
 }
 

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -1,6 +1,7 @@
 import { Scene } from 'phaser';
 import { Partida } from '@/core/Partida';
 import { Rodada } from '@/core/Rodada';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import { DecisorHumano } from '../DecisorHumano';
 import { fabricarPartida } from '../factories/rodada-factory';
@@ -8,16 +9,15 @@ import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento'
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 import { desenharIndicadorRodada } from '../renderers/indicador-rodada-renderer';
 import { limparObjetos } from '../renderers/limpar-objetos';
-import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
 import { renderizarMesa } from '../renderers/mesa-renderer';
 import { desenharPlacar } from '../renderers/placar-renderer';
 import { animarRecolhimentoTurno, atualizarIndicadorVez } from '../renderers/turno-renderer';
+import { atualizarManilhaDaCena } from './atualizar-manilha-cena';
 import { aoEncerrarCena, desativarResize, transicionarRodada } from './ciclo-vida-cena';
 import { desenharMaosJogo } from './desenhar-maos-jogo';
 import { mostrarFimJogoDaCena } from './fim-jogo-scene';
 import { iniciarDeclaracaoDaCena, iniciarTurnosDaCena } from './fluxo-jogo-scene';
 import { JOGADORES } from './jogadores';
-
 export class JogoScene extends Scene {
   objetos: Phaser.GameObjects.GameObject[] = [];
   private redesenhar?: ResizeDebouncer;
@@ -69,7 +69,7 @@ export class JogoScene extends Scene {
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
       turnoAnteriorRef: { valor: this.turnoAnterior },
-      jogadores: rodada.estado.maos.map((m) => m.jogador),
+      jogadores: estadoEmJogo(rodada.estado).maos.map((m) => m.jogador),
       getVencedorTurno: () => this.vencedorTurno,
       animarRecolhimento: this.animarRecolhimentoTurno.bind(this),
       atualizarIndicadorVez: this.atualizarIndicadorVez.bind(this),
@@ -109,16 +109,11 @@ export class JogoScene extends Scene {
     this.iniciarFluxoDeclaracao();
   }
   private atualizarManilha(): void {
-    limparManilha(this.manilhaObjetos);
-    const estado = this.partida?.estado;
-    if (!estado) return;
-    const { cartaVirada, manilha } = estado;
-    if (!cartaVirada) return;
-    desenharManilha({ cena: this, cartaVirada, manilha, objetos: this.manilhaObjetos });
+    atualizarManilhaDaCena(this, this.partida, this.manilhaObjetos);
   }
   private atualizarIndicadorRodada(): void {
     const estado = this.partida?.estado;
-    if (!estado?.numeroRodada) return;
+    if (!estado || estado.fase === 'distribuindo' || !estado.numeroRodada) return;
     desenharIndicadorRodada({
       cena: this,
       numeroRodada: estado.numeroRodada,
@@ -128,7 +123,7 @@ export class JogoScene extends Scene {
   }
   private atualizarPlacar(): void {
     const estado = this.partida?.estado;
-    if (!estado) return;
+    if (!estado || estado.fase === 'distribuindo') return;
     const jogadores = estado.maos.map((m) => m.jogador);
     desenharPlacar({ cena: this, jogadores, estado, objetos: this.placarObjetos });
   }
@@ -140,7 +135,7 @@ export class JogoScene extends Scene {
     this.atualizarPlacar();
     limparObjetos(this.mesaObjetos);
     const estado = this.partida?.estado;
-    if (!estado) return;
+    if (!estado || estado.fase === 'distribuindo') return;
     this.desenharMaos(estado.maos);
     limparObjetos(this.mesaObjetos);
     const cartas = estado.mesa.map((m) => m.carta);
@@ -186,7 +181,7 @@ export class JogoScene extends Scene {
   }
   private animarRecolhimentoTurno(): void {
     const rodada = this.partida?.rodadaAtual;
-    const jogadoresAtuais = rodada?.estado.maos.map((m) => m.jogador) ?? [];
+    const jogadoresAtuais = rodada ? estadoEmJogo(rodada.estado).maos.map((m) => m.jogador) : [];
     const objetosParaAnimar = this.mesaObjetos.filter((obj) => obj.active);
     this.mesaObjetos = [];
     animarRecolhimentoTurno({

--- a/src/adapters/phaser/scenes/atualizar-manilha-cena.ts
+++ b/src/adapters/phaser/scenes/atualizar-manilha-cena.ts
@@ -1,0 +1,17 @@
+import type { Scene } from 'phaser';
+import type { Partida } from '@/core/Partida';
+import { estadoEmJogo } from '@/types/estado-rodada';
+import { desenharManilha, limparManilha } from '../renderers/manilha-renderer';
+
+export function atualizarManilhaDaCena(
+  cena: Scene,
+  partida: Partida | undefined,
+  objetos: Phaser.GameObjects.GameObject[],
+): void {
+  limparManilha(objetos);
+  const estado = partida?.estado;
+  if (!estado || estado.fase === 'distribuindo') return;
+  const { cartaVirada, manilha } = estadoEmJogo(estado);
+  if (!cartaVirada) return;
+  desenharManilha({ cena, cartaVirada, manilha, objetos });
+}

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -1,5 +1,6 @@
 import type { Rodada } from '@/core/Rodada';
 import type { Jogador } from '@/types/entidades';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import type { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import { desenharBotoesDeclaracao, limparObjetosDeclaracao } from '../renderers/declaracao-renderer';
 import { atualizarLabelVencedor } from '../renderers/label-jogador';
@@ -44,7 +45,8 @@ export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<v
 
 async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void> {
   const { cena, rodada } = config;
-  const maoAtual = rodada.estado.maos[rodada.estado.jogadorAtual];
+  const emJogo = estadoEmJogo(rodada.estado);
+  const maoAtual = emJogo.maos[emJogo.jogadorAtual];
   if (maoAtual.jogador.id !== 'humano') {
     await esperar(cena, 400);
     return;
@@ -52,7 +54,7 @@ async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void>
   limparObjetosDeclaracao(config.objetos);
   desenharBotoesDeclaracao({
     cena,
-    maximo: rodada.estado.cartasPorRodada,
+    maximo: emJogo.cartasPorRodada,
     objetos: config.objetos,
     onSelecionar: (valor: number) => {
       config.decisorHumano.confirmar(valor);
@@ -72,21 +74,23 @@ export async function iniciarProcessamentoTurno(config: ConfigTurnos): Promise<v
 }
 
 async function aguardarBotAtual(config: ConfigTurnos): Promise<void> {
-  const maoAtual = config.rodada.estado.maos[config.rodada.estado.jogadorAtual];
+  const emJogo = estadoEmJogo(config.rodada.estado);
+  const maoAtual = emJogo.maos[emJogo.jogadorAtual];
   if (maoAtual.jogador.id !== 'humano') await esperar(config.cena, 500);
 }
 
 async function atualizarFimDeTurno(config: ConfigTurnos): Promise<void> {
   const { rodada, turnoAnteriorRef } = config;
-  if (rodada.estado.turno <= turnoAnteriorRef.valor) return;
-  turnoAnteriorRef.valor = rodada.estado.turno;
+  const emJogo = estadoEmJogo(rodada.estado);
+  if (emJogo.turno <= turnoAnteriorRef.valor) return;
+  turnoAnteriorRef.valor = emJogo.turno;
   const vencedorId = config.getVencedorTurno();
   config.animarRecolhimento();
   await esperar(config.cena, 800);
   atualizarLabelVencedor({
     vencedorId,
     jogadores: config.jogadores,
-    vazas: rodada.estado.vazas,
+    vazas: emJogo.vazas,
     labels: config.getLabels(),
     direcoes: config.getDirecoesLabels(),
   });

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -38,8 +38,9 @@ export class Partida {
 
   get estado(): EstadoPartida {
     if (!this.rodada) return this.estadoInicial();
+    const estadoRodada = this.rodada.estado;
     return {
-      ...this.rodada.estado,
+      ...estadoRodada,
       numeroRodada: this.numeroRodada,
       jogadoresAtivos: this.jogadoresAtivos(),
       embaralhadorId: this.embaralhadorAtual().id,
@@ -69,14 +70,6 @@ export class Partida {
     return {
       fase: 'distribuindo',
       jogadorAtual: 0,
-      mesa: [],
-      maos: [],
-      vazas: {},
-      turno: 1,
-      cartasPorRodada: 0,
-      manilha: '3',
-      cartaVirada: null,
-      declaracoes: {},
       pontos: Object.fromEntries(this.jogadores.map((jogador) => [jogador.id, jogador.pontos])),
       numeroRodada: this.numeroRodada,
       jogadoresAtivos: this.jogadoresAtivos(),

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -1,8 +1,9 @@
 import type { Jogador } from '@/types/entidades';
-import type { EstadoRodada, FaseRodada } from '@/types/estado-rodada';
+import type { EstadoEmJogo, EstadoMutavel, EstadoRodada, FaseRodada } from '@/types/estado-rodada';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
 import { obterProximoValor } from './Carta';
 import type { Carta } from './Carta';
+import { criarMaosRodada } from './criar-maos-rodada';
 import type { DecisoresRodada } from './decisores-rodada';
 import {
   emitirCartaJogada,
@@ -14,21 +15,18 @@ import {
   emitirTurnoGanho,
   type EmissorRodada,
 } from './eventos-rodada';
-import { MaquinaFases } from './maquina-fases';
+import { validarTransicaoFase } from './maquina-fases';
 import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 import { calcularResultadoTurno } from './resultado-turno';
-
 export class Rodada {
-  private _estado: EstadoRodada;
+  private _estado: EstadoMutavel;
   private decisores: Map<string, DecisorJogada>;
   private decisoresDeclaracao: Map<string, DecisorDeclaracao>;
   private emissor: EmissorRodada;
   private jogadores: Jogador[];
   private numeroRodada: number;
-  private fases = new MaquinaFases();
-
   constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
     this.decisores = decisores.jogada;
@@ -49,38 +47,30 @@ export class Rodada {
       pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos])),
     };
   }
-
   get estado(): EstadoRodada {
+    if (this._estado.fase === 'distribuindo') {
+      return {
+        fase: 'distribuindo',
+        jogadorAtual: this._estado.jogadorAtual,
+        pontos: this._estado.pontos,
+      };
+    }
     return this._estado;
   }
-
   distribuir(numeroCartas: number, baralhoEntrada?: Carta[]): void {
     const baralho = baralhoEntrada ?? embaralhar(criarBaralho());
     const precisaDistribuir = numeroCartas * this.jogadores.length;
     const cartaVirada = baralho.length > precisaDistribuir ? baralho[0] : null;
     const baralhoRestante = cartaVirada ? baralho.slice(1) : baralho;
     const manilha = cartaVirada ? obterProximoValor(cartaVirada.valor) : '3';
-
     const cartas = distribuir(baralhoRestante, numeroCartas, this.jogadores.length);
-    const primeiraRodada = this.numeroRodada === 1;
-    this._estado.maos = this.jogadores.map((jogador, i) => ({
-      jogador,
-      cartas: cartas[i],
-      visivel: primeiraRodada ? jogador.id !== 'humano' : jogador.id === 'humano',
-    }));
-    this._estado.cartasPorRodada = numeroCartas;
-    this._estado.manilha = manilha;
-    this._estado.cartaVirada = cartaVirada;
-    this._estado.declaracoes = {};
+    this.atualizarEstadoDistribuido({ numeroCartas, cartaVirada, manilha, cartas });
     this.transitarFase('aguardandoDeclaracao');
-
     if (cartaVirada) emitirManilhaVirada(this.emissor, cartaVirada, manilha);
   }
-
   async declarar(): Promise<void> {
-    if (!this.fases.eh('aguardandoDeclaracao')) {
-      throw new Error(`Não é possível declarar na fase ${this.fases.atual}`);
-    }
+    const estado = this.estado;
+    if (estado.fase !== 'aguardandoDeclaracao') throw new Error(`Não é possível declarar na fase ${estado.fase}`);
     this.transitarFase('processandoDeclaracao');
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisoresDeclaracao.get(jogador.id);
@@ -89,39 +79,19 @@ export class Rodada {
       throw new Error(`Decisor de declaração não encontrado para jogador ${jogador.id}`);
     }
     try {
-      const declaracao = await decisor.declarar(this._estado, this._estado.maos[this._estado.jogadorAtual].cartas);
+      const declaracao = await decisor.declarar(estado, this._estado.maos[this._estado.jogadorAtual].cartas);
       this.validarDeclaracao(declaracao);
       this._estado.declaracoes[jogador.id] = declaracao;
       emitirDeclaracaoFeita(this.emissor, jogador.id, declaracao);
       this.avancarDeclaracao();
     } catch (erro) {
-      if (this.fases.eh('processandoDeclaracao')) this.transitarFase('aguardandoDeclaracao');
+      if (this._estado.fase === 'processandoDeclaracao') this.transitarFase('aguardandoDeclaracao');
       throw erro;
     }
   }
-
-  private validarDeclaracao(declaracao: number): void {
-    const maximo = this._estado.cartasPorRodada;
-    if (!Number.isInteger(declaracao) || declaracao < 0 || declaracao > maximo) {
-      throw new Error(`Declaração inválida: ${String(declaracao)}`);
-    }
-  }
-
-  private avancarDeclaracao(): void {
-    const totalDeclaracoes = Object.keys(this._estado.declaracoes).length;
-    if (totalDeclaracoes === this.jogadores.length) {
-      this.transitarFase('aguardandoJogada');
-      this._estado.jogadorAtual = 0;
-    } else {
-      this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
-      this.transitarFase('aguardandoDeclaracao');
-    }
-  }
-
   async jogarTurno(): Promise<void> {
-    if (!this.fases.eh('aguardandoJogada')) {
-      throw new Error(`Não é possível jogar na fase ${this.fases.atual}`);
-    }
+    const estado = this.estado;
+    if (estado.fase !== 'aguardandoJogada') throw new Error(`Não é possível jogar na fase ${estado.fase}`);
     this.transitarFase('processandoTurno');
     const jogador = this.jogadores[this._estado.jogadorAtual];
     const decisor = this.decisores.get(jogador.id);
@@ -130,28 +100,48 @@ export class Rodada {
       throw new Error(`Decisor não encontrado para jogador ${jogador.id}`);
     }
     try {
-      await this.executarJogada(jogador, decisor);
+      await this.executarJogada(jogador, decisor, estado);
     } catch (erro) {
-      if (this.fases.eh('processandoTurno')) this.transitarFase('aguardandoJogada');
+      if (this._estado.fase === 'processandoTurno') this.transitarFase('aguardandoJogada');
       throw erro;
     }
   }
-
-  private async executarJogada(jogador: Jogador, decisor: DecisorJogada): Promise<void> {
+  private atualizarEstadoDistribuido(config: DistribuicaoConfig): void {
+    this._estado.maos = criarMaosRodada(this.jogadores, config.cartas, this.numeroRodada === 1);
+    this._estado.cartasPorRodada = config.numeroCartas;
+    this._estado.manilha = config.manilha;
+    this._estado.cartaVirada = config.cartaVirada;
+    this._estado.declaracoes = {};
+    this._estado.mesa = [];
+    this._estado.vazas = {};
+    this._estado.turno = 1;
+  }
+  private validarDeclaracao(declaracao: number): void {
+    const maximo = this._estado.cartasPorRodada;
+    if (!Number.isInteger(declaracao) || declaracao < 0 || declaracao > maximo) {
+      throw new Error(`Declaração inválida: ${String(declaracao)}`);
+    }
+  }
+  private avancarDeclaracao(): void {
+    const totalDeclaracoes = Object.keys(this._estado.declaracoes).length;
+    if (totalDeclaracoes === this.jogadores.length) {
+      this.transitarFase('aguardandoJogada');
+      this._estado.jogadorAtual = 0;
+      return;
+    }
+    this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;
+    this.transitarFase('aguardandoDeclaracao');
+  }
+  private async executarJogada(jogador: Jogador, decisor: DecisorJogada, estado: EstadoEmJogo): Promise<void> {
     const mao = this._estado.maos[this._estado.jogadorAtual].cartas;
-    const carta = await decisor.decidirJogada(mao, this._estado);
+    const carta = await decisor.decidirJogada(mao, estado);
     const indiceCarta = mao.findIndex((c) => c.valor === carta.valor && c.naipe === carta.naipe);
     if (indiceCarta === -1) throw new Error(`Jogada inválida para jogador ${jogador.id}`);
     this._estado.maos[this._estado.jogadorAtual].cartas = [...mao.slice(0, indiceCarta), ...mao.slice(indiceCarta + 1)];
     this._estado.mesa.push({ jogadorId: jogador.id, carta });
-    emitirCartaJogada(this.emissor, {
-      jogadorId: jogador.id,
-      carta,
-      posicaoMesa: this._estado.mesa.length - 1,
-    });
+    emitirCartaJogada(this.emissor, { jogadorId: jogador.id, carta, posicaoMesa: this._estado.mesa.length - 1 });
     this.avancarJogador();
   }
-
   private avancarJogador(): void {
     if (this._estado.mesa.length === this.jogadores.length) {
       this.resolverTurno();
@@ -163,37 +153,51 @@ export class Rodada {
 
   private resolverTurno(): void {
     const resultado = calcularResultadoTurno(this._estado.mesa, this._estado.manilha, this.jogadores);
-    let proximoJogadorId: string;
+    const proximoJogadorId = this.processarResultadoTurno(resultado);
+    this._estado.turno += 1;
+    this._estado.mesa = [];
+    if (this._estado.turno > this._estado.cartasPorRodada) this.concluirRodada();
+    else this.iniciarProximoTurno(proximoJogadorId);
+  }
+
+  private processarResultadoTurno(resultado: ReturnType<typeof calcularResultadoTurno>): string {
     if (resultado.tipo === 'vitoria') {
       this._estado.vazas[resultado.jogador.id] = (this._estado.vazas[resultado.jogador.id] ?? 0) + 1;
       emitirTurnoGanho(this.emissor, resultado.jogador.id, this.cartasDaMesa());
-      proximoJogadorId = resultado.jogador.id;
-    } else {
-      emitirTurnoEmpatado(this.emissor, resultado.ultimoEmpatado.id, this.cartasDaMesa());
-      proximoJogadorId = resultado.ultimoEmpatado.id;
+      return resultado.jogador.id;
     }
-    this._estado.turno += 1;
-    this._estado.mesa = [];
-    if (this._estado.turno > this._estado.cartasPorRodada) {
-      this.transitarFase('rodadaConcluida');
-      const pontos = aplicarPontuacao(
-        this._estado,
-        this.jogadores.map((j) => j.id),
-      );
-      emitirPontuacaoAplicada(this.emissor, pontos.pontos, pontos.penalidades);
-      emitirRodadaEncerrada(this.emissor, { ...this._estado.vazas });
-    } else {
-      this.transitarFase('aguardandoJogada');
-      this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === proximoJogadorId);
-    }
+    emitirTurnoEmpatado(this.emissor, resultado.ultimoEmpatado.id, this.cartasDaMesa());
+    return resultado.ultimoEmpatado.id;
+  }
+
+  private concluirRodada(): void {
+    this.transitarFase('rodadaConcluida');
+    const pontos = aplicarPontuacao(
+      this._estado,
+      this.jogadores.map((j) => j.id),
+    );
+    emitirPontuacaoAplicada(this.emissor, pontos.pontos, pontos.penalidades);
+    emitirRodadaEncerrada(this.emissor, { ...this._estado.vazas });
+  }
+
+  private iniciarProximoTurno(proximoJogadorId: string): void {
+    this.transitarFase('aguardandoJogada');
+    this._estado.jogadorAtual = this.jogadores.findIndex((j) => j.id === proximoJogadorId);
   }
 
   private transitarFase(novaFase: FaseRodada): void {
-    this.fases.transitar(novaFase);
+    validarTransicaoFase(this._estado.fase, novaFase);
     this._estado.fase = novaFase;
   }
 
   private cartasDaMesa(): Carta[] {
     return this._estado.mesa.map((m) => m.carta);
   }
+}
+
+interface DistribuicaoConfig {
+  numeroCartas: number;
+  cartaVirada: Carta | null;
+  manilha: Carta['valor'];
+  cartas: Carta[][];
 }

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -20,6 +20,7 @@ import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 import { calcularResultadoTurno } from './resultado-turno';
+import { criarSnapshotEstadoRodada } from './snapshot-estado-rodada';
 export class Rodada {
   private _estado: EstadoMutavel;
   private decisores: Map<string, DecisorJogada>;
@@ -48,14 +49,7 @@ export class Rodada {
     };
   }
   get estado(): EstadoRodada {
-    if (this._estado.fase === 'distribuindo') {
-      return {
-        fase: 'distribuindo',
-        jogadorAtual: this._estado.jogadorAtual,
-        pontos: this._estado.pontos,
-      };
-    }
-    return this._estado;
+    return criarSnapshotEstadoRodada(this._estado);
   }
   distribuir(numeroCartas: number, baralhoEntrada?: Carta[]): void {
     const baralho = baralhoEntrada ?? embaralhar(criarBaralho());

--- a/src/core/criar-maos-rodada.ts
+++ b/src/core/criar-maos-rodada.ts
@@ -1,0 +1,11 @@
+import type { Jogador } from '@/types/entidades';
+import type { MaoJogador } from '@/types/estado-rodada';
+import type { Carta } from './Carta';
+
+export function criarMaosRodada(jogadores: Jogador[], cartas: Carta[][], primeiraRodada: boolean): MaoJogador[] {
+  return jogadores.map((jogador, i) => ({
+    jogador,
+    cartas: cartas[i],
+    visivel: primeiraRodada ? jogador.id !== 'humano' : jogador.id === 'humano',
+  }));
+}

--- a/src/core/maquina-fases.ts
+++ b/src/core/maquina-fases.ts
@@ -7,7 +7,6 @@ const TRANSICOES_VALIDAS: Record<FaseRodada, FaseRodada[]> = {
   aguardandoJogada: ['processandoTurno'],
   processandoTurno: ['aguardandoJogada', 'rodadaConcluida'],
   rodadaConcluida: [],
-  turnoConcluido: [],
 };
 
 export function validarTransicaoFase(faseAtual: FaseRodada, novaFase: FaseRodada): void {

--- a/src/core/maquina-fases.ts
+++ b/src/core/maquina-fases.ts
@@ -7,33 +7,12 @@ const TRANSICOES_VALIDAS: Record<FaseRodada, FaseRodada[]> = {
   aguardandoJogada: ['processandoTurno'],
   processandoTurno: ['aguardandoJogada', 'rodadaConcluida'],
   rodadaConcluida: [],
+  turnoConcluido: [],
 };
 
-export class MaquinaFases {
-  private fase: FaseRodada;
-
-  constructor(faseInicial: FaseRodada = 'distribuindo') {
-    this.fase = faseInicial;
-  }
-
-  get atual(): FaseRodada {
-    return this.fase;
-  }
-
-  eh(fase: FaseRodada): boolean {
-    return this.fase === fase;
-  }
-
-  transitar(novaFase: FaseRodada): void {
-    const validas = TRANSICOES_VALIDAS[this.fase];
-    if (!validas.includes(novaFase)) {
-      throw new Error(`Transição inválida: ${this.fase} → ${novaFase}`);
-    }
-    this.fase = novaFase;
-  }
-
-  /** Define a fase sem validação. Uso interno para restauração de estado. */
-  definir(fase: FaseRodada): void {
-    this.fase = fase;
+export function validarTransicaoFase(faseAtual: FaseRodada, novaFase: FaseRodada): void {
+  const validas = TRANSICOES_VALIDAS[faseAtual];
+  if (!validas.includes(novaFase)) {
+    throw new Error(`Transição inválida: ${faseAtual} → ${novaFase}`);
   }
 }

--- a/src/core/snapshot-estado-rodada.ts
+++ b/src/core/snapshot-estado-rodada.ts
@@ -1,0 +1,37 @@
+import type { EstadoMutavel, EstadoRodada, MaoJogador, MesaItem } from '@/types/estado-rodada';
+import type { Carta } from './Carta';
+
+export function criarSnapshotEstadoRodada(estado: EstadoMutavel): EstadoRodada {
+  if (estado.fase === 'distribuindo') {
+    return { fase: 'distribuindo', jogadorAtual: estado.jogadorAtual, pontos: { ...estado.pontos } };
+  }
+  return {
+    ...estado,
+    pontos: { ...estado.pontos },
+    declaracoes: { ...estado.declaracoes },
+    vazas: { ...estado.vazas },
+    cartaVirada: clonarCartaOuNula(estado.cartaVirada),
+    maos: estado.maos.map(clonarMao),
+    mesa: estado.mesa.map(clonarMesaItem),
+  };
+}
+
+function clonarMao(mao: MaoJogador): MaoJogador {
+  return {
+    jogador: { ...mao.jogador },
+    cartas: mao.cartas.map(clonarCarta),
+    visivel: mao.visivel,
+  };
+}
+
+function clonarMesaItem(item: MesaItem): MesaItem {
+  return { jogadorId: item.jogadorId, carta: clonarCarta(item.carta) };
+}
+
+function clonarCartaOuNula(carta: Carta | null): Carta | null {
+  return carta ? clonarCarta(carta) : null;
+}
+
+function clonarCarta(carta: Carta): Carta {
+  return { ...carta };
+}

--- a/src/types/estado-partida.ts
+++ b/src/types/estado-partida.ts
@@ -1,8 +1,10 @@
 import type { EstadoRodada } from './estado-rodada';
 
-export interface EstadoPartida extends EstadoRodada {
+type CamposPartida = {
   numeroRodada: number;
   jogadoresAtivos: string[];
   embaralhadorId: string;
   jogoEncerrado: boolean;
-}
+};
+
+export type EstadoPartida = EstadoRodada & CamposPartida;

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -1,13 +1,15 @@
 import type { Carta, Valor } from '@/core/Carta';
 import type { Jogador } from './entidades';
 
-export type FaseRodada =
-  | 'distribuindo'
+export type FaseComCartas =
   | 'aguardandoDeclaracao'
   | 'processandoDeclaracao'
   | 'aguardandoJogada'
   | 'processandoTurno'
+  | 'turnoConcluido'
   | 'rodadaConcluida';
+
+export type FaseRodada = 'distribuindo' | FaseComCartas;
 
 export interface MaoJogador {
   jogador: Jogador;
@@ -20,16 +22,49 @@ export interface MesaItem {
   carta: Carta;
 }
 
-export interface EstadoRodada {
-  fase: FaseRodada;
+export interface EstadoDistribuindo {
+  fase: 'distribuindo';
   jogadorAtual: number;
-  mesa: MesaItem[];
+  pontos: Record<string, number>;
+}
+
+interface EstadoComCartasBase {
+  jogadorAtual: number;
+  pontos: Record<string, number>;
   maos: MaoJogador[];
-  vazas: Record<string, number>;
-  turno: number;
   cartasPorRodada: number;
   manilha: Valor;
   cartaVirada: Carta | null;
   declaracoes: Record<string, number>;
-  pontos: Record<string, number>;
+  mesa: MesaItem[];
+  vazas: Record<string, number>;
+  turno: number;
+}
+
+export type EstadoAguardandoDeclaracao = EstadoComCartasBase & { fase: 'aguardandoDeclaracao' };
+export type EstadoProcessandoDeclaracao = EstadoComCartasBase & { fase: 'processandoDeclaracao' };
+export type EstadoAguardandoJogada = EstadoComCartasBase & { fase: 'aguardandoJogada' };
+export type EstadoProcessandoTurno = EstadoComCartasBase & { fase: 'processandoTurno' };
+export type EstadoTurnoConcluido = EstadoComCartasBase & { fase: 'turnoConcluido' };
+export type EstadoRodadaConcluida = EstadoComCartasBase & { fase: 'rodadaConcluida' };
+
+export type EstadoEmJogo =
+  | EstadoAguardandoDeclaracao
+  | EstadoProcessandoDeclaracao
+  | EstadoAguardandoJogada
+  | EstadoProcessandoTurno
+  | EstadoTurnoConcluido
+  | EstadoRodadaConcluida;
+
+export type EstadoRodada = EstadoDistribuindo | EstadoEmJogo;
+
+export interface EstadoMutavel extends Omit<EstadoComCartasBase, 'fase'> {
+  fase: FaseRodada;
+}
+
+export function estadoEmJogo(estado: EstadoRodada): EstadoEmJogo {
+  if (estado.fase === 'distribuindo') {
+    throw new Error('Estado não deveria estar em distribuindo');
+  }
+  return estado;
 }

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -6,7 +6,6 @@ export type FaseComCartas =
   | 'processandoDeclaracao'
   | 'aguardandoJogada'
   | 'processandoTurno'
-  | 'turnoConcluido'
   | 'rodadaConcluida';
 
 export type FaseRodada = 'distribuindo' | FaseComCartas;
@@ -45,7 +44,6 @@ export type EstadoAguardandoDeclaracao = EstadoComCartasBase & { fase: 'aguardan
 export type EstadoProcessandoDeclaracao = EstadoComCartasBase & { fase: 'processandoDeclaracao' };
 export type EstadoAguardandoJogada = EstadoComCartasBase & { fase: 'aguardandoJogada' };
 export type EstadoProcessandoTurno = EstadoComCartasBase & { fase: 'processandoTurno' };
-export type EstadoTurnoConcluido = EstadoComCartasBase & { fase: 'turnoConcluido' };
 export type EstadoRodadaConcluida = EstadoComCartasBase & { fase: 'rodadaConcluida' };
 
 export type EstadoEmJogo =
@@ -53,7 +51,6 @@ export type EstadoEmJogo =
   | EstadoProcessandoDeclaracao
   | EstadoAguardandoJogada
   | EstadoProcessandoTurno
-  | EstadoTurnoConcluido
   | EstadoRodadaConcluida;
 
 export type EstadoRodada = EstadoDistribuindo | EstadoEmJogo;

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -3,6 +3,7 @@ import { Partida } from '@/core/Partida';
 import type { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
+import type { EstadoMutavel } from '@/types/estado-rodada';
 import { estadoEmJogo } from '@/types/estado-rodada';
 import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarDecisorPrimeiraCarta, jogadoresPadrao } from './rodada-fixtures';
@@ -17,8 +18,9 @@ function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
 
 function concluirRodadaComPontos(partida: Partida, pontos: Record<string, number>): void {
   const rodada = partida.iniciarProximaRodada() as Rodada;
-  rodada.estado.fase = 'rodadaConcluida';
-  rodada.estado.pontos = pontos;
+  const estado = (rodada as unknown as { _estado: EstadoMutavel })._estado;
+  estado.fase = 'rodadaConcluida';
+  estado.pontos = pontos;
 }
 
 function criarPartidaComEmissor() {

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -3,6 +3,7 @@ import { Partida } from '@/core/Partida';
 import type { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarDecisorPrimeiraCarta, jogadoresPadrao } from './rodada-fixtures';
 
@@ -34,7 +35,7 @@ describe('Partida — contagem de cartas', () => {
     const cartasPorRodada: number[] = [];
     for (let i = 0; i < 15; i++) {
       partida.iniciarProximaRodada();
-      cartasPorRodada.push(partida.estado.cartasPorRodada);
+      cartasPorRodada.push(estadoEmJogo(partida.estado).cartasPorRodada);
     }
     expect(cartasPorRodada).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 13]);
   });
@@ -57,12 +58,12 @@ describe('Partida — estado público', () => {
     ];
     const partida = criarPartida(jogadores);
     partida.iniciarProximaRodada();
-    expect(partida.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+    expect(estadoEmJogo(partida.estado).maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
       ['humano', false],
       ['bot1', true],
     ]);
     partida.iniciarProximaRodada();
-    expect(partida.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+    expect(estadoEmJogo(partida.estado).maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
       ['humano', true],
       ['bot1', false],
     ]);
@@ -104,7 +105,7 @@ describe('Partida — eliminação', () => {
     concluirRodadaComPontos(partida, { j1: 0, j2: 4, j3: 5, j4: 5 });
     partida.iniciarProximaRodada();
     expect(partida.estado.jogadoresAtivos).toEqual(['j2', 'j3', 'j4']);
-    expect(partida.estado.maos.map((mao) => mao.jogador.id)).toEqual(['j2', 'j3', 'j4']);
+    expect(estadoEmJogo(partida.estado).maos.map((mao) => mao.jogador.id)).toEqual(['j2', 'j3', 'j4']);
   });
 
   it('deve eliminar jogador com pontos negativos', () => {
@@ -120,7 +121,7 @@ describe('Partida — eliminação', () => {
     concluirRodadaComPontos(partida, { j1: 0, j2: 4, j3: 5, j4: 5 });
     partida.iniciarProximaRodada();
     expect(partida.estado.numeroRodada).toBe(1);
-    expect(partida.estado.cartasPorRodada).toBe(1);
+    expect(estadoEmJogo(partida.estado).cartasPorRodada).toBe(1);
   });
 
   it('deve continuar a contagem quando ninguém é eliminado', () => {

--- a/tests/core/Rodada.declaracao.test.ts
+++ b/tests/core/Rodada.declaracao.test.ts
@@ -43,7 +43,9 @@ describe('Rodada — declaração — decisor', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(mockDecisor.declarar).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockDecisor.declarar).toHaveBeenCalledWith(rodada.estado, expect.any(Array));
+    const estadoRecebido = vi.mocked(mockDecisor.declarar).mock.calls[0][0];
+    expect(estadoRecebido).toMatchObject({ fase: 'aguardandoDeclaracao', jogadorAtual: 0 });
+    expect(estadoEmJogo(estadoRecebido).declaracoes).toEqual({});
   });
 });
 

--- a/tests/core/Rodada.declaracao.test.ts
+++ b/tests/core/Rodada.declaracao.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { criarJogador, jogadoresPadrao } from './rodada-fixtures';
 
 function criarDecisorDeclaracao(valor: number): DecisorDeclaracao {
@@ -17,8 +18,8 @@ describe('Rodada — declaração — transições', () => {
     rodada.distribuir(1);
     expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
     expect(rodada.estado.jogadorAtual).toBe(0);
-    expect(rodada.estado.cartasPorRodada).toBe(1);
-    expect(rodada.estado.declaracoes).toEqual({});
+    expect(estadoEmJogo(rodada.estado).cartasPorRodada).toBe(1);
+    expect(estadoEmJogo(rodada.estado).declaracoes).toEqual({});
   });
 
   it('deve rejeitar jogarTurno na fase aguardandoDeclaracao', async () => {
@@ -58,7 +59,7 @@ describe('Rodada — declaração — estado', () => {
     rodada.distribuir(3);
     await rodada.declarar();
     await rodada.declarar();
-    expect(rodada.estado.declaracoes).toEqual({ j1: 2, j2: 0 });
+    expect(estadoEmJogo(rodada.estado).declaracoes).toEqual({ j1: 2, j2: 0 });
   });
 });
 
@@ -132,7 +133,7 @@ describe('Rodada — declaração — valor zero', () => {
     const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: decisoresDeclaracao });
     rodada.distribuir(3);
     await rodada.declarar();
-    expect(rodada.estado.declaracoes['j1']).toBe(0);
+    expect(estadoEmJogo(rodada.estado).declaracoes['j1']).toBe(0);
   });
 });
 
@@ -173,7 +174,7 @@ describe('Rodada — declaração — valores invalidos', () => {
     rodada.distribuir(2);
     await expect(rodada.declarar()).rejects.toThrow('Declaração inválida');
     expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
-    expect(rodada.estado.declaracoes).toEqual({});
+    expect(estadoEmJogo(rodada.estado).declaracoes).toEqual({});
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/tests/core/Rodada.empate.test.ts
+++ b/tests/core/Rodada.empate.test.ts
@@ -3,6 +3,7 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta, criarJogador, criarDecisorPrimeiraCarta, criarRodadaComMao } from './rodada-fixtures';
 
 function criarRodadaEmpate(maos: Carta[][], manilha: Carta['valor'] = '3') {
@@ -36,7 +37,7 @@ describe('Rodada — empate entre não-manilhas do mesmo valor', () => {
     emissor.on('TURNO_EMPATADO', handler);
     await jogarTurnos(rodada, 4);
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(rodada.estado.vazas).toEqual({});
+    expect(estadoEmJogo(rodada.estado).vazas).toEqual({});
   });
 
   it('não deve incrementar vaza para nenhum jogador no empate', async () => {
@@ -47,10 +48,10 @@ describe('Rodada — empate entre não-manilhas do mesmo valor', () => {
       [criarCarta('4', '♦')],
     ]);
     await jogarTurnos(rodada, 4);
-    expect(rodada.estado.vazas['j1']).toBeUndefined();
-    expect(rodada.estado.vazas['j2']).toBeUndefined();
-    expect(rodada.estado.vazas['j3']).toBeUndefined();
-    expect(rodada.estado.vazas['j4']).toBeUndefined();
+    expect(estadoEmJogo(rodada.estado).vazas['j1']).toBeUndefined();
+    expect(estadoEmJogo(rodada.estado).vazas['j2']).toBeUndefined();
+    expect(estadoEmJogo(rodada.estado).vazas['j3']).toBeUndefined();
+    expect(estadoEmJogo(rodada.estado).vazas['j4']).toBeUndefined();
   });
 });
 
@@ -64,7 +65,7 @@ describe('Rodada — empate e próximo turno', () => {
     ]);
     await jogarTurnos(rodada, 4);
     expect(rodada.estado.jogadorAtual).toBe(1); // j2 foi o último empatado
-    expect(rodada.estado.turno).toBe(2);
+    expect(estadoEmJogo(rodada.estado).turno).toBe(2);
   });
 
   it('deve fazer o último empatado iniciar quando o naipe maior é jogado por último', async () => {
@@ -76,7 +77,7 @@ describe('Rodada — empate e próximo turno', () => {
     ]);
     await jogarTurnos(rodada, 4);
     expect(rodada.estado.jogadorAtual).toBe(1); // j2 foi o último empatado
-    expect(rodada.estado.turno).toBe(2);
+    expect(estadoEmJogo(rodada.estado).turno).toBe(2);
   });
 });
 
@@ -87,7 +88,7 @@ describe('Rodada — manilha vs não-manilha não é empate', () => {
       '4',
     );
     await jogarTurnos(rodada, 4);
-    expect(rodada.estado.vazas['j2']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j2']).toBe(1);
   });
 });
 
@@ -98,6 +99,6 @@ describe('Rodada — desempate entre manilhas por naipe', () => {
       '4',
     );
     await jogarTurnos(rodada, 4);
-    expect(rodada.estado.vazas['j4']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j4']).toBe(1);
   });
 });

--- a/tests/core/Rodada.manilha.test.ts
+++ b/tests/core/Rodada.manilha.test.ts
@@ -3,7 +3,7 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
-import type { FaseRodada } from '@/types/estado-rodada';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta, criarJogador, criarDecisorPrimeiraCarta } from './rodada-fixtures';
 
 describe('Rodada — carta virada removida', () => {
@@ -19,11 +19,11 @@ describe('Rodada — carta virada removida', () => {
     ];
     const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
     rodada.distribuir(2, baralho);
-    const todasCartas = rodada.estado.maos.flatMap((m) => m.cartas);
+    const todasCartas = estadoEmJogo(rodada.estado).maos.flatMap((m) => m.cartas);
     expect(todasCartas).toHaveLength(4);
     expect(todasCartas).not.toContainEqual(criarCarta('A', '♣'));
-    expect(rodada.estado.cartaVirada).toEqual(criarCarta('A', '♣'));
-    expect(rodada.estado.manilha).toBe('2');
+    expect(estadoEmJogo(rodada.estado).cartaVirada).toEqual(criarCarta('A', '♣'));
+    expect(estadoEmJogo(rodada.estado).manilha).toBe('2');
   });
 });
 
@@ -53,8 +53,8 @@ describe('Rodada — sem carta para virar', () => {
     const jogadores = [criarJogador('j1', 'J1')];
     const rodada = new Rodada(jogadores, emissor, { jogada: new Map(), declaracao: new Map() });
     rodada.distribuir(0, []);
-    expect(rodada.estado.manilha).toBe('3');
-    expect(rodada.estado.cartaVirada).toBeNull();
+    expect(estadoEmJogo(rodada.estado).manilha).toBe('3');
+    expect(estadoEmJogo(rodada.estado).cartaVirada).toBeNull();
   });
 });
 
@@ -68,16 +68,14 @@ describe('Rodada — manilha vence não-manilha', () => {
     ]);
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
-      _estado: { fase: FaseRodada; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-      fases: { definir(fase: FaseRodada): void };
+      _estado: { fase: 'aguardandoJogada'; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('3', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';
     estadoPrivado._estado.fase = 'aguardandoJogada';
-    estadoPrivado.fases.definir('aguardandoJogada');
     await rodada.jogarTurno();
     await rodada.jogarTurno();
-    expect(rodada.estado.vazas['j2']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j2']).toBe(1);
   });
 });
 
@@ -91,15 +89,13 @@ describe('Rodada — desempate de manilhas', () => {
     ]);
     const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
     const estadoPrivado = rodada as unknown as {
-      _estado: { fase: FaseRodada; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-      fases: { definir(fase: FaseRodada): void };
+      _estado: { fase: 'aguardandoJogada'; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
     };
     estadoPrivado._estado.maos = [{ cartas: [criarCarta('4', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
     estadoPrivado._estado.manilha = '4';
     estadoPrivado._estado.fase = 'aguardandoJogada';
-    estadoPrivado.fases.definir('aguardandoJogada');
     await rodada.jogarTurno();
     await rodada.jogarTurno();
-    expect(rodada.estado.vazas['j2']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j2']).toBe(1);
   });
 });

--- a/tests/core/Rodada.mesa.test.ts
+++ b/tests/core/Rodada.mesa.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import {
   criarCarta,
   criarJogador,
@@ -18,11 +19,13 @@ describe('Rodada — mesa remoção', () => {
       ['j2', criarDecisorPrimeiraCarta()],
     ]);
     const rodada = criarRodada({ jogadores, decisores, emissor });
-    const cartaEsperada = rodada.estado.maos[0].cartas[0];
-    const maoAntes = rodada.estado.maos[0].cartas.length;
+    const cartaEsperada = estadoEmJogo(rodada.estado).maos[0].cartas[0];
+    const maoAntes = estadoEmJogo(rodada.estado).maos[0].cartas.length;
     await rodada.jogarTurno();
-    expect(rodada.estado.maos[0].cartas).toHaveLength(maoAntes - 1);
-    expect(rodada.estado.mesa).toContainEqual(expect.objectContaining({ carta: cartaEsperada, jogadorId: 'j1' }));
+    expect(estadoEmJogo(rodada.estado).maos[0].cartas).toHaveLength(maoAntes - 1);
+    expect(estadoEmJogo(rodada.estado).mesa).toContainEqual(
+      expect.objectContaining({ carta: cartaEsperada, jogadorId: 'j1' }),
+    );
   });
 });
 
@@ -42,8 +45,8 @@ describe('Rodada — mesa referência', () => {
       cartasPorRodada: 2,
     });
     await rodada.jogarTurno();
-    expect(rodada.estado.maos[0].cartas).toHaveLength(0);
-    expect(rodada.estado.mesa).toContainEqual(
+    expect(estadoEmJogo(rodada.estado).maos[0].cartas).toHaveLength(0);
+    expect(estadoEmJogo(rodada.estado).mesa).toContainEqual(
       expect.objectContaining({ carta: criarCarta('4', '♣'), jogadorId: 'j1' }),
     );
   });

--- a/tests/core/Rodada.rodada.test.ts
+++ b/tests/core/Rodada.rodada.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Carta } from '@/core/Carta';
 import { createEmissorEventos } from '@/store/emissor-eventos';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import {
   criarCarta,
   criarDecisorPrimeiraCarta,
@@ -42,7 +43,7 @@ describe('Rodada — cálculo de vencedor', () => {
   it('deve definir maior valor como vencedor do turno', async () => {
     const { rodada } = rodadaComMaoFixa(MAO_CURTA);
     await jogarTurnos(rodada, 4);
-    expect(rodada.estado.vazas['j1']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j1']).toBe(1);
   });
 
   it('deve desempatar pelo naipe quando valores são iguais (manilhas)', async () => {
@@ -57,7 +58,7 @@ describe('Rodada — cálculo de vencedor', () => {
       manilha: '4',
     });
     await jogarTurnos(rodada, 4);
-    expect(rodada.estado.vazas['j4']).toBe(1);
+    expect(estadoEmJogo(rodada.estado).vazas['j4']).toBe(1);
   });
 });
 
@@ -81,7 +82,7 @@ describe('Rodada — vazas e rodada', () => {
   it('deve acumular 4 vazas após 4 turnos', async () => {
     const { rodada } = rodadaComMaoFixa(MAO_LONGA, 4);
     await jogarTurnos(rodada, 16);
-    expect(rodada.estado.vazas).toEqual({ j1: 1, j2: 1, j3: 1, j4: 1 });
+    expect(estadoEmJogo(rodada.estado).vazas).toEqual({ j1: 1, j2: 1, j3: 1, j4: 1 });
   });
 
   it('deve transitar para rodadaConcluida após o último turno', async () => {

--- a/tests/core/Rodada.test.ts
+++ b/tests/core/Rodada.test.ts
@@ -5,6 +5,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
+import { estadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta, criarJogador, criarDecisor, criarRodada } from './rodada-fixtures';
 
 function jogadoresComHumano(): Jogador[] {
@@ -32,7 +33,7 @@ describe('Rodada — transições', () => {
     rodada.distribuir(1);
     expect(rodada.estado.fase).toBe('aguardandoDeclaracao');
     expect(rodada.estado.jogadorAtual).toBe(0);
-    expect(rodada.estado.cartasPorRodada).toBe(1);
+    expect(estadoEmJogo(rodada.estado).cartasPorRodada).toBe(1);
   });
 });
 
@@ -40,7 +41,7 @@ describe('Rodada — visibilidade', () => {
   it('deve ocultar a mão do humano e mostrar as mãos dos bots na primeira rodada', () => {
     const rodada = criarRodadaVisibilidade(1);
     rodada.distribuir(1);
-    expect(rodada.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+    expect(estadoEmJogo(rodada.estado).maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
       ['humano', false],
       ['bot1', true],
       ['bot2', true],
@@ -50,7 +51,7 @@ describe('Rodada — visibilidade', () => {
   it('deve mostrar a mão do humano e ocultar as mãos dos bots depois da primeira rodada', () => {
     const rodada = criarRodadaVisibilidade(2);
     rodada.distribuir(2);
-    expect(rodada.estado.maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
+    expect(estadoEmJogo(rodada.estado).maos.map((mao) => [mao.jogador.id, mao.visivel])).toEqual([
       ['humano', true],
       ['bot1', false],
       ['bot2', false],
@@ -73,8 +74,8 @@ describe('Rodada — informação dos decisores', () => {
     const chamadas = vi.mocked(declarar).mock.calls;
     expect(chamadas).toHaveLength(1);
     const chamada = chamadas[0];
-    expect(chamada[0].maos[0].visivel).toBe(false);
-    expect(chamada[1]).toEqual(rodada.estado.maos[0].cartas);
+    expect(estadoEmJogo(chamada[0]).maos[0].visivel).toBe(false);
+    expect(chamada[1]).toEqual(estadoEmJogo(rodada.estado).maos[0].cartas);
   });
 });
 
@@ -94,7 +95,7 @@ describe('Rodada — avanço de jogadorAtual', () => {
     }
     await rodada.jogarTurno();
     expect(rodada.estado.fase).toBe('aguardandoJogada');
-    expect(rodada.estado.turno).toBe(2);
+    expect(estadoEmJogo(rodada.estado).turno).toBe(2);
   });
 });
 
@@ -132,7 +133,7 @@ describe('Rodada — eventos', () => {
       ['j1', { decidirJogada: (mao: Carta[]) => Promise.resolve(mao[0]) }],
     ]);
     const rodada = criarRodada({ jogadores, decisores, emissor });
-    const cartaEsperada = rodada.estado.maos[0].cartas[0];
+    const cartaEsperada = estadoEmJogo(rodada.estado).maos[0].cartas[0];
     await rodada.jogarTurno();
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(

--- a/tests/core/maquina-fases.test.ts
+++ b/tests/core/maquina-fases.test.ts
@@ -1,31 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { MaquinaFases } from '@/core/maquina-fases';
+import { validarTransicaoFase } from '@/core/maquina-fases';
 
-describe('MaquinaFases — construção', () => {
-  it('deve iniciar na fase distribuindo por padrão', () => {
-    const maquina = new MaquinaFases();
-    expect(maquina.atual).toBe('distribuindo');
-  });
-
-  it('deve permitir iniciar em qualquer fase', () => {
-    const maquina = new MaquinaFases('aguardandoJogada');
-    expect(maquina.atual).toBe('aguardandoJogada');
-  });
-});
-
-describe('MaquinaFases — consulta', () => {
-  it('deve retornar true quando a fase atual corresponde', () => {
-    const maquina = new MaquinaFases('aguardandoJogada');
-    expect(maquina.eh('aguardandoJogada')).toBe(true);
-  });
-
-  it('deve retornar false quando a fase atual não corresponde', () => {
-    const maquina = new MaquinaFases('aguardandoJogada');
-    expect(maquina.eh('aguardandoDeclaracao')).toBe(false);
-  });
-});
-
-describe('MaquinaFases — transições válidas', () => {
+describe('validarTransicaoFase — transições válidas', () => {
   it.each([
     ['distribuindo', 'aguardandoDeclaracao'],
     ['aguardandoDeclaracao', 'processandoDeclaracao'],
@@ -34,31 +10,22 @@ describe('MaquinaFases — transições válidas', () => {
     ['aguardandoJogada', 'processandoTurno'],
     ['processandoTurno', 'aguardandoJogada'],
     ['processandoTurno', 'rodadaConcluida'],
-  ] as const)('deve transitar de %s para %s', (de, para) => {
-    const maquina = new MaquinaFases(de);
-    maquina.transitar(para);
-    expect(maquina.atual).toBe(para);
+  ] as const)('deve permitir transição de %s para %s', (de, para) => {
+    expect(() => {
+      validarTransicaoFase(de, para);
+    }).not.toThrow();
   });
 });
 
-describe('MaquinaFases — transições inválidas', () => {
+describe('validarTransicaoFase — transições inválidas', () => {
   it.each([
     ['distribuindo', 'aguardandoJogada'],
     ['aguardandoJogada', 'aguardandoDeclaracao'],
     ['rodadaConcluida', 'distribuindo'],
     ['aguardandoDeclaracao', 'rodadaConcluida'],
   ] as const)('deve rejeitar transição de %s para %s', (de, para) => {
-    const maquina = new MaquinaFases(de);
     expect(() => {
-      maquina.transitar(para);
+      validarTransicaoFase(de, para);
     }).toThrow('Transição inválida');
-  });
-});
-
-describe('MaquinaFases — definir', () => {
-  it('deve definir a fase sem validação', () => {
-    const maquina = new MaquinaFases('distribuindo');
-    maquina.definir('rodadaConcluida');
-    expect(maquina.atual).toBe('rodadaConcluida');
   });
 });

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -5,7 +5,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
-import type { EstadoRodada, FaseRodada } from '@/types/estado-rodada';
+import type { EstadoMutavel, EstadoRodada, FaseComCartas } from '@/types/estado-rodada';
 
 export function criarCarta(valor: Carta['valor'], naipe: Carta['naipe']): Carta {
   return { valor, naipe };
@@ -52,32 +52,24 @@ export function criarRodada(config: {
   const privado = rodada as unknown as EstadoPrivado;
   privado._estado.fase = 'aguardandoJogada';
   privado._estado.declaracoes = {};
-  privado.fases.definir('aguardandoJogada');
   return rodada;
 }
 
 interface EstadoPrivado {
-  _estado: EstadoRodada;
-  fases: { definir(fase: FaseRodada): void };
+  _estado: EstadoMutavel;
 }
 
 function pontosIniciais(jogadores: Jogador[]): Record<string, number> {
   return Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos]));
 }
 
-function preencherEstadoComMao(
-  estado: EstadoRodada,
-  config: ConfigRodadaComMao,
-  fases: { definir(fase: FaseRodada): void },
-): void {
+function preencherEstadoComMao(estado: EstadoMutavel, config: ConfigRodadaComMao): void {
   estado.maos = config.jogadores.map((jogador, i) => ({
     jogador,
     cartas: config.maos[i] ?? [],
     visivel: jogador.id === 'humano',
   }));
-  const fase = config.fase ?? 'aguardandoJogada';
-  estado.fase = fase;
-  fases.definir(fase);
+  estado.fase = config.fase ?? 'aguardandoJogada';
   estado.jogadorAtual = config.jogadorAtual ?? 0;
   estado.turno = config.turno ?? 1;
   estado.cartasPorRodada = config.cartasPorRodada ?? 4;
@@ -93,7 +85,7 @@ interface ConfigRodadaComMao {
   emissor: ReturnType<typeof createEmissorEventos>;
   maos: Carta[][];
   jogadorAtual?: number;
-  fase?: EstadoRodada['fase'];
+  fase?: FaseComCartas;
   turno?: number;
   cartasPorRodada?: number;
   manilha?: Carta['valor'];
@@ -108,7 +100,7 @@ export function criarRodadaComMao(config: ConfigRodadaComMao): Rodada {
     declaracao: new Map<string, DecisorDeclaracao>(),
   });
   const privado = rodada as unknown as EstadoPrivado;
-  preencherEstadoComMao(privado._estado, config, privado.fases);
+  preencherEstadoComMao(privado._estado, config);
   return rodada;
 }
 


### PR DESCRIPTION
## Resumo

- transforma `EstadoRodada` em union discriminada por `fase`
- faz `EstadoPartida` compor a union com campos da partida
- substitui `MaquinaFases` com estado por validação pura de transição
- atualiza core/adapters para narrowings explícitos de estado pós-distribuição
- extrai helpers pequenos para criação de mãos e atualização de manilha na cena

## Validação

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `npx vitest run` (531 testes)
- [x] `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal game state management and phase transition logic to improve code maintainability and consistency across the game engine.

---

*No user-facing feature changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->