### PR TITLE
refactor: eliminar hack EstadoPrivado nos testes (C5)

### DIFF
--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -1,8 +1,7 @@
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, EstadoMutavel, EstadoRodada, FaseRodada } from '@/types/estado-rodada';
 import { criarBaralho, distribuir, embaralhar } from './Baralho';
-import { obterProximoValor } from './Carta';
-import type { Carta } from './Carta';
+import { obterProximoValor, type Carta } from './Carta';
 import { criarMaosRodada } from './criar-maos-rodada';
 import type { DecisoresRodada } from './decisores-rodada';
 import {
@@ -50,6 +49,10 @@ export class Rodada {
   }
   get estado(): EstadoRodada {
     return criarSnapshotEstadoRodada(this._estado);
+  }
+  /** @testOnly Substitui o estado interno da rodada. */
+  restaurarEstado(estado: EstadoMutavel): void {
+    this._estado = estado;
   }
   distribuir(numeroCartas: number, baralhoEntrada?: Carta[]): void {
     const baralho = baralhoEntrada ?? embaralhar(criarBaralho());

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -18,9 +18,11 @@ function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
 
 function concluirRodadaComPontos(partida: Partida, pontos: Record<string, number>): void {
   const rodada = partida.iniciarProximaRodada() as Rodada;
-  const estado = (rodada as unknown as { _estado: EstadoMutavel })._estado;
-  estado.fase = 'rodadaConcluida';
-  estado.pontos = pontos;
+  rodada.restaurarEstado({
+    ...rodada.estado,
+    fase: 'rodadaConcluida',
+    pontos,
+  } as EstadoMutavel);
 }
 
 function criarPartidaComEmissor() {

--- a/tests/core/Rodada.manilha.test.ts
+++ b/tests/core/Rodada.manilha.test.ts
@@ -4,7 +4,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import { estadoEmJogo } from '@/types/estado-rodada';
-import { criarCarta, criarJogador, criarDecisorPrimeiraCarta } from './rodada-fixtures';
+import { criarCarta, criarJogador, criarDecisorPrimeiraCarta, criarRodadaComMao } from './rodada-fixtures';
 
 describe('Rodada — carta virada removida', () => {
   it('deve remover carta virada do baralho e não distribuir', () => {
@@ -66,13 +66,13 @@ describe('Rodada — manilha vence não-manilha', () => {
       ['j1', criarDecisorPrimeiraCarta()],
       ['j2', criarDecisorPrimeiraCarta()],
     ]);
-    const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
-    const estadoPrivado = rodada as unknown as {
-      _estado: { fase: 'aguardandoJogada'; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-    };
-    estadoPrivado._estado.maos = [{ cartas: [criarCarta('3', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
-    estadoPrivado._estado.manilha = '4';
-    estadoPrivado._estado.fase = 'aguardandoJogada';
+    const rodada = criarRodadaComMao({
+      jogadores,
+      decisores,
+      emissor,
+      maos: [[criarCarta('3', '♦')], [criarCarta('4', '♣')]],
+      manilha: '4',
+    });
     await rodada.jogarTurno();
     await rodada.jogarTurno();
     expect(estadoEmJogo(rodada.estado).vazas['j2']).toBe(1);
@@ -87,13 +87,13 @@ describe('Rodada — desempate de manilhas', () => {
       ['j1', criarDecisorPrimeiraCarta()],
       ['j2', criarDecisorPrimeiraCarta()],
     ]);
-    const rodada = new Rodada(jogadores, emissor, { jogada: decisores, declaracao: new Map() });
-    const estadoPrivado = rodada as unknown as {
-      _estado: { fase: 'aguardandoJogada'; manilha: Carta['valor']; maos: { cartas: Carta[] }[] };
-    };
-    estadoPrivado._estado.maos = [{ cartas: [criarCarta('4', '♦')] }, { cartas: [criarCarta('4', '♣')] }];
-    estadoPrivado._estado.manilha = '4';
-    estadoPrivado._estado.fase = 'aguardandoJogada';
+    const rodada = criarRodadaComMao({
+      jogadores,
+      decisores,
+      emissor,
+      maos: [[criarCarta('4', '♦')], [criarCarta('4', '♣')]],
+      manilha: '4',
+    });
     await rodada.jogarTurno();
     await rodada.jogarTurno();
     expect(estadoEmJogo(rodada.estado).vazas['j2']).toBe(1);

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -49,34 +49,36 @@ export function criarRodada(config: {
     declaracao: config.decisoresDeclaracao ?? new Map<string, DecisorDeclaracao>(),
   });
   rodada.distribuir(config.cartasPorRodada ?? 1);
-  const privado = rodada as unknown as EstadoPrivado;
-  privado._estado.fase = 'aguardandoJogada';
-  privado._estado.declaracoes = {};
+  rodada.restaurarEstado({
+    ...rodada.estado,
+    fase: 'aguardandoJogada',
+    declaracoes: {},
+  } as EstadoMutavel);
   return rodada;
-}
-
-interface EstadoPrivado {
-  _estado: EstadoMutavel;
 }
 
 function pontosIniciais(jogadores: Jogador[]): Record<string, number> {
   return Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos]));
 }
 
-function preencherEstadoComMao(estado: EstadoMutavel, config: ConfigRodadaComMao): void {
-  estado.maos = config.jogadores.map((jogador, i) => ({
-    jogador,
-    cartas: config.maos[i] ?? [],
-    visivel: jogador.id === 'humano',
-  }));
-  estado.fase = config.fase ?? 'aguardandoJogada';
-  estado.jogadorAtual = config.jogadorAtual ?? 0;
-  estado.turno = config.turno ?? 1;
-  estado.cartasPorRodada = config.cartasPorRodada ?? 4;
-  estado.manilha = config.manilha ?? '3';
-  estado.declaracoes = config.declaracoes ?? {};
-  estado.pontos = config.pontos ?? pontosIniciais(config.jogadores);
-  estado.vazas = config.vazas ?? {};
+function criarEstadoComMao(config: ConfigRodadaComMao): EstadoMutavel {
+  return {
+    maos: config.jogadores.map((jogador, i) => ({
+      jogador,
+      cartas: config.maos[i] ?? [],
+      visivel: jogador.id === 'humano',
+    })),
+    fase: config.fase ?? 'aguardandoJogada',
+    jogadorAtual: config.jogadorAtual ?? 0,
+    turno: config.turno ?? 1,
+    cartasPorRodada: config.cartasPorRodada ?? 4,
+    manilha: config.manilha ?? '3',
+    declaracoes: config.declaracoes ?? {},
+    pontos: config.pontos ?? pontosIniciais(config.jogadores),
+    vazas: config.vazas ?? {},
+    mesa: [],
+    cartaVirada: null,
+  };
 }
 
 interface ConfigRodadaComMao {
@@ -99,8 +101,7 @@ export function criarRodadaComMao(config: ConfigRodadaComMao): Rodada {
     jogada: config.decisores,
     declaracao: new Map<string, DecisorDeclaracao>(),
   });
-  const privado = rodada as unknown as EstadoPrivado;
-  preencherEstadoComMao(privado._estado, config);
+  rodada.restaurarEstado(criarEstadoComMao(config));
   return rodada;
 }
 


### PR DESCRIPTION
## C5 — Eliminar hack `EstadoPrivado` nos testes

### Problema

Testes faziam `rodada as unknown as { _estado: EstadoMutavel }` para hackear estado privado da `Rodada`. Se `_estado` fosse renomeado, os testes compilavam mas quebravam silenciosamente em runtime.

### Solução

- **`Rodada.restaurarEstado(estado: EstadoMutavel)`** — método `@testOnly` com tipagem explícita. Se `EstadoMutavel` mudar de forma, todos os callers quebram em tempo de compilação.
- Removida interface `EstadoPrivado` dos fixtures.
- `preencherEstadoComMao` → `criarEstadoComMao` — função pura que retorna `EstadoMutavel` em vez de mutar estado privado.
- `Rodada.manilha.test.ts` — usa `criarRodadaComMao` com parâmetro `manilha` em vez de hackear `_estado`.
- `Partida.test.ts` — `concluirRodadaComPontos` usa `restaurarEstado`.

### Resultado

- **Zero** ocorrências de `as unknown` ou `_estado` nos testes.
- 531 testes passando.
- Lint e typecheck limpos.
- `Rodada.ts` com 200 linhas (limite do projeto).

### Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `src/core/Rodada.ts` | +`restaurarEstado()`, consolida imports de Carta |
| `tests/core/rodada-fixtures.ts` | Remove `EstadoPrivado`, usa `restaurarEstado`, `criarEstadoComMao` |
| `tests/core/Rodada.manilha.test.ts` | Usa `criarRodadaComMao` em vez de hack |
| `tests/core/Partida.test.ts` | `concluirRodadaComPontos` usa `restaurarEstado` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure and fixtures for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->