### PR TITLE
refactor: separar factory DI de subscrição de eventos (C6)

### DIFF
--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,36 +1,14 @@
 import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
-import type { Carta, Valor } from '@/core/Carta';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
+import { subscreverEventos, type CallbacksRodada } from './subscricao-eventos-rodada';
 
-export interface CallbacksRodada {
-  onCartaJogada: () => void;
-  onTurnoGanho: (jogadorId: string) => void;
-  onTurnoEmpatado: () => void;
-  onRodadaEncerrada: () => void;
-  onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
-  onRodadaIniciada?: () => void;
-  onPontuacaoAplicada?: () => void;
-  onJogoEncerrado?: (classificacao: Jogador[]) => void;
-}
-
-function registrarCallbacks(emissor: ReturnType<typeof createEmissorEventos>, callbacks: CallbacksRodada): void {
-  emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
-  emissor.on('TURNO_GANHO', (evento) => {
-    callbacks.onTurnoGanho(evento.jogadorId);
-  });
-  emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
-  emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
-  emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
-  emissor.on('PONTUACAO_APLICADA', () => callbacks.onPontuacaoAplicada?.());
-  emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
-  emissor.on('JOGO_ENCERRADO', (evento) => callbacks.onJogoEncerrado?.(evento.classificacao));
-}
+export type { CallbacksRodada } from './subscricao-eventos-rodada';
 
 function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao }): {
   jogada: Map<string, DecisorJogada>;
@@ -57,7 +35,7 @@ export function fabricarRodada(
   callbacks: CallbacksRodada,
 ): Rodada {
   const emissor = createEmissorEventos();
-  registrarCallbacks(emissor, callbacks);
+  subscreverEventos(emissor, callbacks);
   const decisores = criarDecisores(decisoresHumanos);
   return new Rodada(jogadores, emissor, decisores);
 }
@@ -68,7 +46,7 @@ export function fabricarPartida(
   callbacks: CallbacksRodada,
 ): Partida {
   const emissor = createEmissorEventos();
-  registrarCallbacks(emissor, callbacks);
+  subscreverEventos(emissor, callbacks);
   const decisores = criarDecisores(decisoresHumanos);
   return new Partida(jogadores, emissor, decisores);
 }

--- a/src/adapters/phaser/factories/subscricao-eventos-rodada.ts
+++ b/src/adapters/phaser/factories/subscricao-eventos-rodada.ts
@@ -1,0 +1,26 @@
+import type { Carta, Valor } from '@/core/Carta';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+
+export interface CallbacksRodada {
+  onCartaJogada: () => void;
+  onTurnoGanho: (jogadorId: string) => void;
+  onTurnoEmpatado: () => void;
+  onRodadaEncerrada: () => void;
+  onManilhaVirada?: (cartaVirada: Carta, manilha: Valor) => void;
+  onRodadaIniciada?: () => void;
+  onPontuacaoAplicada?: () => void;
+  onJogoEncerrado?: (classificacao: import('@/types/entidades').Jogador[]) => void;
+}
+
+export function subscreverEventos(emissor: ReturnType<typeof createEmissorEventos>, callbacks: CallbacksRodada): void {
+  emissor.on('CARTA_JOGADA', callbacks.onCartaJogada);
+  emissor.on('TURNO_GANHO', (evento) => {
+    callbacks.onTurnoGanho(evento.jogadorId);
+  });
+  emissor.on('TURNO_EMPATADO', callbacks.onTurnoEmpatado);
+  emissor.on('RODADA_ENCERRADA', callbacks.onRodadaEncerrada);
+  emissor.on('RODADA_INICIADA', () => callbacks.onRodadaIniciada?.());
+  emissor.on('PONTUACAO_APLICADA', () => callbacks.onPontuacaoAplicada?.());
+  emissor.on('MANILHA_VIRADA', (evento) => callbacks.onManilhaVirada?.(evento.cartaVirada, evento.manilha));
+  emissor.on('JOGO_ENCERRADO', (evento) => callbacks.onJogoEncerrado?.(evento.classificacao));
+}


### PR DESCRIPTION
## C6 — Separar factory DI de subscrição de eventos

### Problema

`rodada-factory.ts` fazia duas coisas: (1) criar Rodada/Partida com dependências injetadas e (2) subscrever eventos do emissor para orquestrar o fluxo do jogo via callbacks.

### Solução

Extraiu `subscricao-eventos-rodada.ts` com responsabilidade única:

| Arquivo | Responsabilidade |
|---------|-----------------|
| `subscricao-eventos-rodada.ts` | `CallbacksRodada` + `subscreverEventos()` — conecta emissor a callbacks |
| `rodada-factory.ts` | DI pura — `criarDecisores()`, `fabricarRodada()`, `fabricarPartida()` |

- Factory reexporta `CallbacksRodada` para manter compatibilidade com consumidores
- Nenhuma mudança em `JogoScene` ou outros adapters
- Linhas: 52 (factory) + 26 (subscrição) = 78 total (antes: 74 em 1 arquivo)

### Verificação

- 531 testes passando
- Typecheck + lint limpos
- Build OK (deploy preview para validação visual)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized event subscription logic for improved code maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->