### PR TITLE
fix: jogador humano sempre começa todas as rodadas

### DIFF
--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -29,7 +29,7 @@ export class Partida {
     this.jogadores = jogadores;
     this.emissor = emissor;
     this.decisores = decisores;
-    this.embaralhadorIndice = jogadores.length - 1;
+    this.embaralhadorIndice = this.sortearEmbaralhadorIndice();
   }
 
   get rodadaAtual(): Rodada | undefined {
@@ -53,7 +53,11 @@ export class Partida {
     if (this.encerrarSeNecessario()) return undefined;
     this.numeroRodada = teveEliminacao ? 1 : this.numeroRodada + 1;
     if (this.numeroRodada > 1) this.rotacionarEmbaralhador();
-    this.rodada = new Rodada(this.jogadores, this.emissor, { ...this.decisores, numeroRodada: this.numeroRodada });
+    this.rodada = new Rodada(this.jogadores, this.emissor, {
+      ...this.decisores,
+      numeroRodada: this.numeroRodada,
+      jogadorInicialIndice: this.primeiroJogadorIndice(),
+    });
     const cartasPorRodada = Math.min(this.numeroRodada, 13);
     this.rodada.distribuir(cartasPorRodada);
     this.emitirRodadaIniciada(cartasPorRodada);
@@ -132,6 +136,14 @@ export class Partida {
 
   private rotacionarEmbaralhador(): void {
     this.embaralhadorIndice = (this.embaralhadorIndice + 1) % this.jogadores.length;
+  }
+
+  private primeiroJogadorIndice(): number {
+    return (this.embaralhadorIndice + 1) % this.jogadores.length;
+  }
+
+  private sortearEmbaralhadorIndice(): number {
+    return Math.floor(Math.random() * this.jogadores.length);
   }
 
   private embaralhadorAtual(): Jogador {

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -27,15 +27,17 @@ export class Rodada {
   private emissor: EmissorRodada;
   private jogadores: Jogador[];
   private numeroRodada: number;
+  private jogadorInicialIndice: number;
   constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
     this.decisores = decisores.jogada;
     this.decisoresDeclaracao = decisores.declaracao;
     this.emissor = emissor;
     this.numeroRodada = decisores.numeroRodada ?? 1;
+    this.jogadorInicialIndice = decisores.jogadorInicialIndice ?? 0;
     this._estado = {
       fase: 'distribuindo',
-      jogadorAtual: 0,
+      jogadorAtual: this.jogadorInicialIndice,
       mesa: [],
       maos: [],
       vazas: {},
@@ -112,6 +114,7 @@ export class Rodada {
     this._estado.mesa = [];
     this._estado.vazas = {};
     this._estado.turno = 1;
+    this._estado.jogadorAtual = this.jogadorInicialIndice;
   }
   private validarDeclaracao(declaracao: number): void {
     const maximo = this._estado.cartasPorRodada;
@@ -123,7 +126,7 @@ export class Rodada {
     const totalDeclaracoes = Object.keys(this._estado.declaracoes).length;
     if (totalDeclaracoes === this.jogadores.length) {
       this.transitarFase('aguardandoJogada');
-      this._estado.jogadorAtual = 0;
+      this._estado.jogadorAtual = this.jogadorInicialIndice;
       return;
     }
     this._estado.jogadorAtual = (this._estado.jogadorAtual + 1) % this.jogadores.length;

--- a/src/core/decisores-rodada.ts
+++ b/src/core/decisores-rodada.ts
@@ -5,4 +5,5 @@ export interface DecisoresRodada {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
   numeroRodada?: number;
+  jogadorInicialIndice?: number;
 }

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -75,7 +75,16 @@ describe('Partida — estado público', () => {
 });
 
 describe('Partida — embaralhador', () => {
+  it('deve sortear o embaralhador da primeira rodada', () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const partida = criarPartida();
+    partida.iniciarProximaRodada();
+    expect(partida.estado.embaralhadorId).toBe('j3');
+    random.mockRestore();
+  });
+
   it('deve rotacionar o embaralhador para o jogador à direita', () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.99);
     const partida = criarPartida();
     const embaralhadores: string[] = [];
     for (let i = 0; i < 5; i++) {
@@ -83,6 +92,21 @@ describe('Partida — embaralhador', () => {
       embaralhadores.push(partida.estado.embaralhadorId);
     }
     expect(embaralhadores).toEqual(['j4', 'j1', 'j2', 'j3', 'j4']);
+    random.mockRestore();
+  });
+});
+
+describe('Partida — primeiro jogador', () => {
+  it('deve iniciar declaracao e jogada no proximo jogador apos o embaralhador', () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    const partida = criarPartida();
+    const jogadoresAtuais: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      partida.iniciarProximaRodada();
+      jogadoresAtuais.push(partida.estado.jogadorAtual);
+    }
+    expect(jogadoresAtuais).toEqual([0, 1, 2, 3]);
+    random.mockRestore();
   });
 });
 

--- a/tests/core/Rodada.declaracao.test.ts
+++ b/tests/core/Rodada.declaracao.test.ts
@@ -109,6 +109,32 @@ describe('Rodada — declaração — ordem', () => {
   });
 });
 
+describe('Rodada — declaração — indice inicial', () => {
+  it('deve respeitar indice inicial durante declaracao e jogada', async () => {
+    const emissor = createEmissorEventos();
+    const jogadores = [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3')];
+    const decisoresDeclaracao = new Map([
+      ['j1', criarDecisorDeclaracao(1)],
+      ['j2', criarDecisorDeclaracao(1)],
+      ['j3', criarDecisorDeclaracao(1)],
+    ]);
+    const rodada = new Rodada(jogadores, emissor, {
+      jogada: new Map(),
+      declaracao: decisoresDeclaracao,
+      jogadorInicialIndice: 1,
+    });
+    rodada.distribuir(2);
+    expect(rodada.estado.jogadorAtual).toBe(1);
+    await rodada.declarar();
+    expect(rodada.estado.jogadorAtual).toBe(2);
+    await rodada.declarar();
+    expect(rodada.estado.jogadorAtual).toBe(0);
+    await rodada.declarar();
+    expect(rodada.estado.jogadorAtual).toBe(1);
+    expect(rodada.estado.fase).toBe('aguardandoJogada');
+  });
+});
+
 describe('Rodada — declaração — transicao', () => {
   it('deve transitar para aguardandoJogada apos todos declararem', async () => {
     const emissor = createEmissorEventos();


### PR DESCRIPTION
Closes #138

## Mudanças

- **Partida**: sorteia `embaralhadorIndice` aleatoriamente no construtor (em vez de fixo no último jogador)
- **Partida → Rodada**: passa o índice do primeiro jogador (próximo ao embaralhador) para cada rodada
- **Rodada**: recebe `jogadorInicialIndice` e o utiliza para declaração e início das jogadas

## Acceptance criteria

- [x] A `Partida` sorteia aleatoriamente o embaralhador na primeira rodada
- [x] A `Rodada` recebe o índice do primeiro jogador e o utiliza para declaração e jogada
- [x] O primeiro a declarar/jogar muda a cada rodada (próximo ao embaralhador)
- [x] Testes do core atualizados e passando
- [x] Sem regressão visual (posição do humano na mesa permanece a mesma)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Shuffler assignment is now randomized for each game session instead of being fixed based on player count
  * Initial player position for each round is now configurable, enabling more flexible game flow control

* **Tests**
  * Added comprehensive test coverage for shuffler randomization behavior
  * Added tests validating initial player index configuration during round declarations and transitions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->