### PR TITLE
fix: seletor de declaração vaza na tela em rodadas altas

### DIFF
--- a/src/adapters/phaser/renderers/declaracao-renderer.ts
+++ b/src/adapters/phaser/renderers/declaracao-renderer.ts
@@ -8,6 +8,8 @@ export interface ConfigDeclaracaoRenderer {
   objetos: Phaser.GameObjects.GameObject[];
   gameArea: Retangulo;
   onSelecionar: (valor: number) => void;
+  valorInicial?: number;
+  onAlterar?: (valor: number) => void;
 }
 
 interface Posicao {
@@ -40,12 +42,13 @@ export function desenharBotoesDeclaracao(config: ConfigDeclaracaoRenderer): void
 }
 
 function criarControleDeclaracao(config: ConfigDeclaracaoRenderer, centro: Posicao): Phaser.GameObjects.GameObject[] {
-  const { cena, maximo, onSelecionar, gameArea } = config;
-  let valor = 0;
+  const { cena, maximo, onSelecionar, gameArea, valorInicial = 0, onAlterar } = config;
+  let valor = valorInicial;
   const numero = criarNumero(cena, { x: centro.x, y: centro.y + escalar(4, cena) }, valor);
   const definirValor = (novoValor: number): void => {
     valor = novoValor;
     numero.setText(String(valor));
+    onAlterar?.(valor);
   };
   const diminuir = (): void => {
     definirValor(Math.max(0, valor - 1));

--- a/src/adapters/phaser/renderers/declaracao-renderer.ts
+++ b/src/adapters/phaser/renderers/declaracao-renderer.ts
@@ -10,34 +10,127 @@ export interface ConfigDeclaracaoRenderer {
   onSelecionar: (valor: number) => void;
 }
 
+interface Posicao {
+  x: number;
+  y: number;
+}
+
+interface ConfigBotao {
+  cena: Scene;
+  posicao: Posicao;
+  texto: string;
+  aoClicar: () => void;
+}
+
+interface ConfigBotaoControle {
+  cena: Scene;
+  centro: Posicao;
+  texto: '−' | '+';
+  aoClicar: () => void;
+}
+
 export function desenharBotoesDeclaracao(config: ConfigDeclaracaoRenderer): void {
-  const { cena, maximo, objetos, gameArea, onSelecionar } = config;
-  const centroX = gameArea.x + gameArea.largura / 2;
-  const centroY = gameArea.y + gameArea.altura / 2;
-  const titulo = cena.add
-    .text(centroX, centroY - escalar(30, cena), 'Declare quantas vai fazer:', {
-      fontSize: `${String(escalar(20, cena))}px`,
+  const { gameArea, objetos } = config;
+  const centro = {
+    x: gameArea.x + gameArea.largura / 2,
+    y: gameArea.y + gameArea.altura / 2,
+  };
+
+  objetos.push(...criarControleDeclaracao(config, centro));
+}
+
+function criarControleDeclaracao(config: ConfigDeclaracaoRenderer, centro: Posicao): Phaser.GameObjects.GameObject[] {
+  const { cena, maximo, onSelecionar, gameArea } = config;
+  let valor = 0;
+  const numero = criarNumero(cena, { x: centro.x, y: centro.y + escalar(4, cena) }, valor);
+  const definirValor = (novoValor: number): void => {
+    valor = novoValor;
+    numero.setText(String(valor));
+  };
+  const diminuir = (): void => {
+    definirValor(Math.max(0, valor - 1));
+  };
+  const aumentar = (): void => {
+    definirValor(Math.min(maximo, valor + 1));
+  };
+  const confirmar = (): void => {
+    onSelecionar(valor);
+  };
+  return [
+    criarTitulo(cena, { x: centro.x, y: centro.y - escalar(34, cena) }, gameArea),
+    criarBotaoControle({ cena, centro, texto: '−', aoClicar: diminuir }),
+    numero,
+    criarBotaoControle({ cena, centro, texto: '+', aoClicar: aumentar }),
+    criarConfirmacao(cena, centro, confirmar),
+  ];
+}
+
+function criarTitulo(cena: Scene, posicao: Posicao, gameArea: Retangulo): Phaser.GameObjects.Text {
+  return cena.add
+    .text(posicao.x, posicao.y, textoTitulo(gameArea), {
+      fontSize: `${String(escalar(tamanhoTitulo(gameArea), cena))}px`,
       color: '#ffffff',
+      fontFamily: 'Arial',
+      align: 'center',
+    })
+    .setOrigin(0.5);
+}
+
+function textoTitulo(gameArea: Retangulo): string {
+  return larguraVisual(gameArea) < 420 ? 'Quantas vai\nfazer?' : 'Declare quantas vai fazer:';
+}
+
+function tamanhoTitulo(gameArea: Retangulo): number {
+  return larguraVisual(gameArea) < 420 ? 15 : 20;
+}
+
+function larguraVisual(gameArea: Retangulo): number {
+  return gameArea.largura / (window.devicePixelRatio || 1);
+}
+
+function criarNumero(cena: Scene, posicao: Posicao, valor: number): Phaser.GameObjects.Text {
+  return cena.add
+    .text(posicao.x, posicao.y, String(valor), {
+      fontSize: `${String(escalar(24, cena))}px`,
+      color: '#f1c40f',
       fontFamily: 'Arial',
     })
     .setOrigin(0.5);
-  objetos.push(titulo);
-  for (let i = 0; i <= maximo; i++) {
-    const botao = cena.add
-      .text(centroX + (i - maximo / 2) * escalar(40, cena), centroY + escalar(10, cena), String(i), {
-        fontSize: `${String(escalar(24, cena))}px`,
-        color: '#f1c40f',
-        fontFamily: 'Arial',
-        backgroundColor: '#2c3e50',
-        padding: { x: escalar(8, cena), y: escalar(4, cena) },
-      })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on('pointerdown', () => {
-        onSelecionar(i);
-      });
-    objetos.push(botao);
-  }
+}
+
+function criarBotaoControle(config: ConfigBotaoControle): Phaser.GameObjects.Text {
+  const { cena, centro, texto, aoClicar } = config;
+  const direcao = texto === '−' ? -1 : 1;
+  return criarBotao({
+    cena,
+    posicao: { x: centro.x + direcao * escalar(48, cena), y: centro.y + escalar(4, cena) },
+    texto,
+    aoClicar,
+  });
+}
+
+function criarConfirmacao(cena: Scene, centro: Posicao, aoClicar: () => void): Phaser.GameObjects.Text {
+  return criarBotao({
+    cena,
+    posicao: { x: centro.x, y: centro.y + escalar(48, cena) },
+    texto: 'Confirmar',
+    aoClicar,
+  });
+}
+
+function criarBotao(config: ConfigBotao): Phaser.GameObjects.Text {
+  const { cena, posicao, texto, aoClicar } = config;
+  return cena.add
+    .text(posicao.x, posicao.y, texto, {
+      fontSize: `${String(escalar(24, cena))}px`,
+      color: '#f1c40f',
+      fontFamily: 'Arial',
+      backgroundColor: '#2c3e50',
+      padding: { x: escalar(8, cena), y: escalar(4, cena) },
+    })
+    .setOrigin(0.5)
+    .setInteractive({ useHandCursor: true })
+    .on('pointerdown', aoClicar);
 }
 
 export function limparObjetosDeclaracao(objetos: Phaser.GameObjects.GameObject[]): void {

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -105,6 +105,7 @@ export class JogoScene extends Scene {
     this.desenharMaos(estado.maos, gameArea);
     const cartas = estado.mesa.map((m) => m.carta);
     renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos, gameArea });
+    this.controller?.redesenharDeclaracaoAtual();
     this.atualizarIndicadorVez();
   };
 

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -6,6 +6,7 @@ import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import type { DecisorHumano } from '../DecisorHumano';
 import { fabricarPartida } from '../factories/rodada-factory';
 import type { Retangulo } from '../layout';
+import { desenharBotoesDeclaracao, limparObjetosDeclaracao } from '../renderers/declaracao-renderer';
 import { JOGADORES } from './jogadores';
 import { iniciarProcessamentoTurno, processarDeclaracoes } from './jogo-scene-loop';
 
@@ -77,6 +78,26 @@ export class JogoController {
     this.iniciarFluxoDeclaracao();
   }
 
+  redesenharDeclaracaoAtual(): void {
+    const rodada = this.partida?.rodadaAtual;
+    if (!rodada) return;
+    const estado = rodada.estado;
+    if (estado.fase !== 'aguardandoDeclaracao' && estado.fase !== 'processandoDeclaracao') return;
+    const emJogo = estadoEmJogo(estado);
+    const maoAtual = emJogo.maos[emJogo.jogadorAtual];
+    if (maoAtual.jogador.id !== 'humano') return;
+    limparObjetosDeclaracao(this.deps.objetosDeclaracao);
+    desenharBotoesDeclaracao({
+      cena: this.deps.scene,
+      maximo: emJogo.cartasPorRodada,
+      objetos: this.deps.objetosDeclaracao,
+      gameArea: this.deps.getGameArea(),
+      onSelecionar: (valor) => {
+        this.decisorDeclaracaoHumano.confirmar(valor);
+      },
+    });
+  }
+
   private iniciarFluxoDeclaracao(): void {
     const rodada = this.partida?.rodadaAtual;
     if (!rodada) return;
@@ -85,7 +106,7 @@ export class JogoController {
       rodada,
       objetos: this.deps.objetosDeclaracao,
       decisorHumano: this.decisorDeclaracaoHumano,
-      gameArea: this.deps.getGameArea(),
+      getGameArea: this.deps.getGameArea,
       atualizarIndicadorVez: this.deps.atualizarIndicadorVez,
       atualizarPainel: this.deps.atualizarPainel,
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -30,6 +30,7 @@ export class JogoController {
   partida?: Partida;
   vencedorTurno?: string;
   private turnoAnterior = 1;
+  private valorDeclaracaoAtual = 0;
   private readonly decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
 
   private readonly deps: DependenciasCena;
@@ -71,6 +72,7 @@ export class JogoController {
 
   iniciarNovaRodada(): void {
     this.turnoAnterior = 1;
+    this.valorDeclaracaoAtual = 0;
     this.vencedorTurno = undefined;
     const rodada = this.partida?.iniciarProximaRodada();
     if (!rodada) return;
@@ -92,11 +94,17 @@ export class JogoController {
       maximo: emJogo.cartasPorRodada,
       objetos: this.deps.objetosDeclaracao,
       gameArea: this.deps.getGameArea(),
+      valorInicial: this.valorDeclaracaoAtual,
+      onAlterar: this.atualizarValorDeclaracao,
       onSelecionar: (valor) => {
         this.decisorDeclaracaoHumano.confirmar(valor);
       },
     });
   }
+
+  private atualizarValorDeclaracao = (valor: number): void => {
+    this.valorDeclaracaoAtual = valor;
+  };
 
   private iniciarFluxoDeclaracao(): void {
     const rodada = this.partida?.rodadaAtual;
@@ -107,6 +115,8 @@ export class JogoController {
       objetos: this.deps.objetosDeclaracao,
       decisorHumano: this.decisorDeclaracaoHumano,
       getGameArea: this.deps.getGameArea,
+      getValorDeclaracao: () => this.valorDeclaracaoAtual,
+      onAlterarDeclaracao: this.atualizarValorDeclaracao,
       atualizarIndicadorVez: this.deps.atualizarIndicadorVez,
       atualizarPainel: this.deps.atualizarPainel,
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -13,6 +13,8 @@ interface ConfigDeclaracoes {
   objetos: Phaser.GameObjects.GameObject[];
   decisorHumano: DecisorDeclaracaoHumano;
   getGameArea: () => Retangulo;
+  getValorDeclaracao: () => number;
+  onAlterarDeclaracao: (valor: number) => void;
   atualizarIndicadorVez: () => void;
   atualizarPainel: () => void;
   iniciarTurnos: () => Promise<void>;
@@ -59,6 +61,8 @@ async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void>
     maximo: emJogo.cartasPorRodada,
     objetos: config.objetos,
     gameArea: config.getGameArea(),
+    valorInicial: config.getValorDeclaracao(),
+    onAlterar: config.onAlterarDeclaracao,
     onSelecionar: (valor: number) => {
       config.decisorHumano.confirmar(valor);
     },

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -12,7 +12,7 @@ interface ConfigDeclaracoes {
   rodada: Rodada;
   objetos: Phaser.GameObjects.GameObject[];
   decisorHumano: DecisorDeclaracaoHumano;
-  gameArea: Retangulo;
+  getGameArea: () => Retangulo;
   atualizarIndicadorVez: () => void;
   atualizarPainel: () => void;
   iniciarTurnos: () => Promise<void>;
@@ -58,7 +58,7 @@ async function prepararDeclaracaoAtual(config: ConfigDeclaracoes): Promise<void>
     cena,
     maximo: emJogo.cartasPorRodada,
     objetos: config.objetos,
-    gameArea: config.gameArea,
+    gameArea: config.getGameArea(),
     onSelecionar: (valor: number) => {
       config.decisorHumano.confirmar(valor);
     },


### PR DESCRIPTION
## O que mudou

Substitui os botões 0..N lado a lado por um **contador com −/+ e botão Confirmar**, resolvendo o vazamento em rodadas altas (rodada 13 = 14 botões × 40px = 560px).

### Mudanças

- **`declaracao-renderer.ts`**: layout reescrito com contador centralizado (−, número, +) e botão "Confirmar" abaixo. Título adapta para mobile (`"Quantas vai\nfazer?"` em telas < 420px CSS).
- **`jogo-scene-loop.ts`**: `gameArea` fixo → `getGameArea()` dinâmico, evitando coordenadas desatualizadas no resize.
- **`jogo-controller.ts`**: adicionado `redesenharDeclaracaoAtual()` para redesenhar o seletor quando a tela muda de orientação.
- **`JogoScene.ts`**: `redesenharTela` chama `redesenharDeclaracaoAtual()` no resize.

### Screenshots

| Desktop | Mobile |
|---------|--------|
| Layout normal, centralizado | Texto adaptado em 2 linhas |

### Acceptance criteria

- [x] O seletor de declaração usa contador com −/+ em vez de botões 0..N lado a lado
- [x] Botão "Confirmar" explícito abaixo do contador
- [x] Valor inicial é 0; − e + ignoram nos limites (0 e N)
- [x] Layout centralizado e funcional em paisagem e retrato
- [x] Visual verificado via deploy preview

Closes #139