### PR TITLE
fix: atualiza painel após turno resolvido

### DIFF
--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -136,6 +136,7 @@ export class JogoController {
       getVencedorTurno: () => this.vencedorTurno,
       animarRecolhimento: this.deps.animarRecolhimentoTurno,
       atualizarIndicadorVez: this.deps.atualizarIndicadorVez,
+      atualizarPainel: this.deps.atualizarPainel,
     });
   }
 }

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -30,6 +30,7 @@ interface ConfigTurnos {
   getVencedorTurno: () => string | undefined;
   animarRecolhimento: () => void;
   atualizarIndicadorVez: () => void;
+  atualizarPainel: () => void;
 }
 
 export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<void> {
@@ -94,6 +95,7 @@ async function atualizarFimDeTurno(config: ConfigTurnos): Promise<void> {
   const vencedorId = config.getVencedorTurno();
   config.animarRecolhimento();
   await esperar(config.cena, 800);
+  config.atualizarPainel();
   atualizarLabelVencedor({
     vencedorId,
     jogadores: config.jogadores,


### PR DESCRIPTION
## Resumo
- Atualiza o painel depois da animação de recolhimento do turno
- Garante que a coluna F (feito/vazas) reflita o estado real antes do próximo turno

Closes #140

## Testes
- pnpm typecheck
- pnpm lint
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed panel UI updates during turn finalization to ensure game state is properly reflected on screen.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->