### PR TITLE
refactor: cartas com texto nos cantos e espaçamento menor

### DIFF
--- a/src/adapters/phaser/renderers/carta-renderer.ts
+++ b/src/adapters/phaser/renderers/carta-renderer.ts
@@ -28,15 +28,41 @@ export function criarCartaFrente(config: ConfigCartaFrente): GameObjects.Contain
   frente.fillStyle(0xffffff, 1);
   frente.fillRoundedRect(rx, ry, largura, altura, raio);
 
-  const texto = cena.add
-    .text(0, 0, `${carta.valor}${carta.naipe}`, {
-      fontSize: escalarFonte(14, cena),
-      fontStyle: 'bold',
-      color: '#000000',
-    })
-    .setOrigin(0.5);
+  const cantoSuperior = criarIndiceCarta({ cena, carta, x: rx + escalar(9, cena), y: ry + escalar(13, cena) });
+  const cantoInferior = criarIndiceCarta({
+    cena,
+    carta,
+    x: rx + largura - escalar(9, cena),
+    y: ry + altura - escalar(13, cena),
+  });
+  cantoInferior.setRotation(Math.PI);
 
-  return cena.add.container(Math.round(x), Math.round(y), [frente, texto]).setSize(largura, altura);
+  return cena.add
+    .container(Math.round(x), Math.round(y), [frente, cantoSuperior, cantoInferior])
+    .setSize(largura, altura);
+}
+
+interface ConfigIndiceCarta {
+  cena: Scene;
+  carta: Carta;
+  x: number;
+  y: number;
+}
+
+function criarIndiceCarta(config: ConfigIndiceCarta): GameObjects.Container {
+  const { cena, carta, x, y } = config;
+  const estilo = {
+    fontSize: escalarFonte(14, cena),
+    fontStyle: 'bold',
+    color: obterCorNaipe(carta.naipe),
+  };
+  const valor = cena.add.text(0, -escalar(5, cena), carta.valor, estilo).setOrigin(0.5);
+  const naipe = cena.add.text(0, escalar(6, cena), carta.naipe, estilo).setOrigin(0.5);
+  return cena.add.container(x, y, [valor, naipe]);
+}
+
+function obterCorNaipe(naipe: Carta['naipe']): string {
+  return naipe === '♥' || naipe === '♦' ? '#cc0000' : '#000000';
 }
 
 export interface ConfigCartaVerso {

--- a/src/adapters/phaser/renderers/posicoes-mao.ts
+++ b/src/adapters/phaser/renderers/posicoes-mao.ts
@@ -11,13 +11,24 @@ export interface ConfigPosicoes {
   gameArea: Retangulo;
   margem: number;
   margemInferior: number;
-  espacamentoCartas: number;
+  espacamentoHorizontal: number;
+  espacamentoVertical: number;
   alturaCarta: number;
+  quantidadeCartas: number;
   dpr: number;
 }
 
 export function calcularPosicoes(config: ConfigPosicoes): PosicaoTela[] {
-  const { gameArea, margem, margemInferior, espacamentoCartas, alturaCarta, dpr } = config;
+  const {
+    gameArea,
+    margem,
+    margemInferior,
+    espacamentoHorizontal,
+    espacamentoVertical,
+    alturaCarta,
+    quantidadeCartas,
+    dpr,
+  } = config;
   const { x: ox, y: oy, largura, altura } = gameArea;
   const cx = ox + Math.round(largura / 2);
   const cy = oy + Math.round(altura / 2);
@@ -25,10 +36,10 @@ export function calcularPosicoes(config: ConfigPosicoes): PosicaoTela[] {
   const offsetLateral = Math.round(60 * dpr);
   const dl = alturaCarta / 2 + offsetBase;
   return [
-    posicaoHumano({ cx, oy, altura, margemInferior, dl, espacamento: espacamentoCartas, offsetLateral }),
-    posicaoBotEsquerda({ ox, margem, cy, dl, espacamento: espacamentoCartas, offsetLateral, offsetBase }),
-    posicaoBotTopo({ cx, oy, margem, dl, espacamento: espacamentoCartas, offsetLateral }),
-    posicaoBotDireita({ ox, largura, margem, cy, dl, espacamento: espacamentoCartas, offsetLateral, offsetBase }),
+    posicaoHumano({ cx, oy, altura, margemInferior, dl, espacamento: espacamentoHorizontal, quantidadeCartas }),
+    posicaoBotEsquerda({ ox, margem, cy, dl, espacamento: espacamentoVertical, offsetLateral, offsetBase }),
+    posicaoBotTopo({ cx, oy, margem, dl, espacamento: espacamentoHorizontal, quantidadeCartas }),
+    posicaoBotDireita({ ox, largura, margem, cy, dl, espacamento: espacamentoVertical, offsetLateral, offsetBase }),
   ];
 }
 
@@ -39,15 +50,16 @@ function posicaoHumano(cfg: {
   margemInferior: number;
   dl: number;
   espacamento: number;
-  offsetLateral: number;
+  quantidadeCartas: number;
 }): PosicaoTela {
-  const { cx, oy, altura, margemInferior, dl, espacamento, offsetLateral } = cfg;
+  const { cx, oy, altura, margemInferior, dl, espacamento, quantidadeCartas } = cfg;
   const baseY = oy + altura;
+  const inicioX = calcularInicioCentralizado(cx, quantidadeCartas, espacamento);
   return {
     labelX: cx,
     labelY: Math.round(baseY - margemInferior + dl),
     mao: {
-      x: cx - offsetLateral,
+      x: inicioX,
       y: Math.round(baseY - margemInferior),
       espacamento,
       direcao: 'horizontal',
@@ -83,14 +95,15 @@ function posicaoBotTopo(cfg: {
   margem: number;
   dl: number;
   espacamento: number;
-  offsetLateral: number;
+  quantidadeCartas: number;
 }): PosicaoTela {
-  const { cx, oy, margem, dl, espacamento, offsetLateral } = cfg;
+  const { cx, oy, margem, dl, espacamento, quantidadeCartas } = cfg;
+  const inicioX = calcularInicioCentralizado(cx, quantidadeCartas, espacamento);
   return {
     labelX: cx,
     labelY: Math.round(oy + margem - dl),
     mao: {
-      x: cx - offsetLateral,
+      x: inicioX,
       y: oy + margem,
       espacamento,
       direcao: 'horizontal',
@@ -120,4 +133,9 @@ function posicaoBotDireita(cfg: {
       direcao: 'vertical',
     },
   };
+}
+
+function calcularInicioCentralizado(cx: number, quantidadeCartas: number, espacamento: number): number {
+  const larguraMao = Math.max(0, quantidadeCartas - 1) * espacamento;
+  return Math.round(cx - larguraMao / 2);
 }

--- a/src/adapters/phaser/renderers/posicoes-mao.ts
+++ b/src/adapters/phaser/renderers/posicoes-mao.ts
@@ -14,33 +14,54 @@ export interface ConfigPosicoes {
   espacamentoHorizontal: number;
   espacamentoVertical: number;
   alturaCarta: number;
-  quantidadeCartas: number;
+  quantidadesCartas: number[];
   dpr: number;
 }
 
+interface MedidasTela {
+  cx: number;
+  oy: number;
+  altura: number;
+  dl: number;
+}
+
 export function calcularPosicoes(config: ConfigPosicoes): PosicaoTela[] {
-  const {
-    gameArea,
-    margem,
-    margemInferior,
-    espacamentoHorizontal,
-    espacamentoVertical,
-    alturaCarta,
-    quantidadeCartas,
-    dpr,
-  } = config;
-  const { x: ox, y: oy, largura, altura } = gameArea;
+  const { x: ox, y: oy, largura, altura } = config.gameArea;
   const cx = ox + Math.round(largura / 2);
   const cy = oy + Math.round(altura / 2);
-  const offsetBase = Math.round(10 * dpr);
-  const offsetLateral = Math.round(60 * dpr);
-  const dl = alturaCarta / 2 + offsetBase;
+  const offsetBase = Math.round(10 * config.dpr);
+  const offsetLateral = Math.round(60 * config.dpr);
+  const dl = config.alturaCarta / 2 + offsetBase;
+  const vertical = config.espacamentoVertical;
   return [
-    posicaoHumano({ cx, oy, altura, margemInferior, dl, espacamento: espacamentoHorizontal, quantidadeCartas }),
-    posicaoBotEsquerda({ ox, margem, cy, dl, espacamento: espacamentoVertical, offsetLateral, offsetBase }),
-    posicaoBotTopo({ cx, oy, margem, dl, espacamento: espacamentoHorizontal, quantidadeCartas }),
-    posicaoBotDireita({ ox, largura, margem, cy, dl, espacamento: espacamentoVertical, offsetLateral, offsetBase }),
+    posicaoHumano(configHumano(config, { cx, oy, altura, dl })),
+    posicaoBotEsquerda({ ox, margem: config.margem, cy, dl, espacamento: vertical, offsetLateral, offsetBase }),
+    posicaoBotTopo(configTopo(config, { cx, oy, altura, dl })),
+    posicaoBotDireita({ ox, largura, margem: config.margem, cy, dl, espacamento: vertical, offsetLateral, offsetBase }),
   ];
+}
+
+function configHumano(config: ConfigPosicoes, medidas: MedidasTela) {
+  return {
+    cx: medidas.cx,
+    oy: medidas.oy,
+    altura: medidas.altura,
+    dl: medidas.dl,
+    margemInferior: config.margemInferior,
+    espacamento: config.espacamentoHorizontal,
+    quantidadeCartas: config.quantidadesCartas[0] ?? 0,
+  };
+}
+
+function configTopo(config: ConfigPosicoes, medidas: MedidasTela) {
+  return {
+    cx: medidas.cx,
+    oy: medidas.oy,
+    dl: medidas.dl,
+    margem: config.margem,
+    espacamento: config.espacamentoHorizontal,
+    quantidadeCartas: config.quantidadesCartas[2] ?? 0,
+  };
 }
 
 function posicaoHumano(cfg: {

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -24,7 +24,7 @@ export function desenharMaosJogo(config: ConfigMaosJogo): {
   direcoes: ('horizontal' | 'vertical')[];
 } {
   const labels: Phaser.GameObjects.Text[] = [];
-  const posicoes = calcularPosicoesMaos(config.cena, config.gameArea);
+  const posicoes = calcularPosicoesMaos(config.cena, config.gameArea, config.maos[0]?.cartas.length ?? 0);
   config.maos.forEach((mao, i) => {
     desenharMaoNaCena({
       cena: config.cena,
@@ -47,13 +47,19 @@ export function desenharMaosJogo(config: ConfigMaosJogo): {
   return { labels, direcoes: posicoes.map((p) => p.mao.direcao) };
 }
 
-function calcularPosicoesMaos(cena: Scene, gameArea: Retangulo): ReturnType<typeof calcularPosicoes> {
+function calcularPosicoesMaos(
+  cena: Scene,
+  gameArea: Retangulo,
+  quantidadeCartas: number,
+): ReturnType<typeof calcularPosicoes> {
   return calcularPosicoes({
     gameArea,
     margem: escalar(60, cena),
     margemInferior: escalar(80, cena),
-    espacamentoCartas: escalar(40, cena),
+    espacamentoHorizontal: escalar(18, cena),
+    espacamentoVertical: escalar(6, cena),
     alturaCarta: escalar(75, cena),
+    quantidadeCartas,
     dpr: obterDpr(cena),
   });
 }

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -24,7 +24,8 @@ export function desenharMaosJogo(config: ConfigMaosJogo): {
   direcoes: ('horizontal' | 'vertical')[];
 } {
   const labels: Phaser.GameObjects.Text[] = [];
-  const posicoes = calcularPosicoesMaos(config.cena, config.gameArea, config.maos[0]?.cartas.length ?? 0);
+  const quantidadesCartas = config.maos.map((mao) => mao.cartas.length);
+  const posicoes = calcularPosicoesMaos(config.cena, config.gameArea, quantidadesCartas);
   config.maos.forEach((mao, i) => {
     desenharMaoNaCena({
       cena: config.cena,
@@ -50,7 +51,7 @@ export function desenharMaosJogo(config: ConfigMaosJogo): {
 function calcularPosicoesMaos(
   cena: Scene,
   gameArea: Retangulo,
-  quantidadeCartas: number,
+  quantidadesCartas: number[],
 ): ReturnType<typeof calcularPosicoes> {
   return calcularPosicoes({
     gameArea,
@@ -59,7 +60,7 @@ function calcularPosicoesMaos(
     espacamentoHorizontal: escalar(18, cena),
     espacamentoVertical: escalar(6, cena),
     alturaCarta: escalar(75, cena),
-    quantidadeCartas,
+    quantidadesCartas,
     dpr: obterDpr(cena),
   });
 }


### PR DESCRIPTION
## Resumo

As cartas nas mãos dos jogadores agora usam layout de cantos (como baralho real), permitindo empilhar mais compactamente.

### Mudanças

- **Texto nos cantos**: valor em cima, naipe embaixo nos cantos superior esquerdo e inferior direito (rotacionado 180°)
- **Cor por naipe**: vermelho para copas/ouros, preto para espadas/paus
- **Espaçamento reduzido**: horizontal de 40px → 18px, vertical (bots laterais) de 40px → 6px
- **Centralização**: mãos horizontais (humano e bot2) ficam centralizadas na gameArea

### Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `carta-renderer.ts` | Layout de cantos com `criarIndiceCarta` + `obterCorNaipe` |
| `posicoes-mao.ts` | Espaçamento horizontal/vertical separado + centralização |
| `desenhar-maos-jogo.ts` | Passa `quantidadeCartas` e novos parâmetros de espaçamento |

### Validação

- [x] Typecheck passa
- [x] Lint passa
- [x] 540 testes passam
- [x] Visual check via deploy preview

Closes #141