### PR TITLE
fix: adiciona CI=true no wrapper do cron para evitar abort do pnpm sem TTY

### DIFF
--- a/.sandcastle/rodar-cron-com-lock.sh
+++ b/.sandcastle/rodar-cron-com-lock.sh
@@ -7,6 +7,9 @@ readonly TEMPO_LIMITE="${SANDCASTLE_TIMEOUT:-30m}"
 readonly BRANCH_BASE="${SANDCASTLE_BRANCH_BASE:-main}"
 readonly DESCRITOR_LOCK=9
 
+# Impede que o pnpm aborte por falta de TTY quando precisa reinstalar deps.
+export CI=true
+
 garantir_branch_base() {
   local branch_atual
 


### PR DESCRIPTION
## Problema

O cron do Sandcastle estava falhando silenciosamente a cada 5 minutos com o erro:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

Isso acontecia porque o pnpm, ao detectar inconsistência no `node_modules` durante o `preinstall` (executado implicitamente por comandos pnpm), exigia confirmação interativa para remover o diretório. Como o cron roda sem TTY, o pnpm abortava e todo o processo do Sandcastle falhava.

## Solução

Adiciona `export CI=true` no início do script `.sandcastle/rodar-cron-com-lock.sh`. Com essa variável de ambiente, o pnpm reconhece o ambiente como não-interativo e prossegue com as operações sem pedir confirmação.

## Como testar

1. Rodar localmente com TTY desabilitado:
   ```bash
   CI=true pnpm sandcastle:cron:lock --dry-run
   ```
2. Verificar que o erro de TTY não ocorre mais.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CI pipeline stability during dependency installation in non-interactive environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->