### PR TITLE
feat: add seeded rng to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ]
   },
   "dependencies": {
-    "phaser": "3.90.0"
+    "phaser": "3.90.0",
+    "pure-rand": "6.1.0"
   },
   "devDependencies": {
     "@ai-hero/sandcastle": "^0.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       phaser:
         specifier: 3.90.0
         version: 3.90.0
+      pure-rand:
+        specifier: 6.1.0
+        version: 6.1.0
     devDependencies:
       '@ai-hero/sandcastle':
         specifier: ^0.5.10

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -3,6 +3,7 @@ import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import { RngComSeed } from '@/core/RngComSeed';
 import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
@@ -37,7 +38,8 @@ export function fabricarRodada(
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
   const decisores = criarDecisores(decisoresHumanos);
-  return new Rodada(jogadores, emissor, decisores);
+  const rng = new RngComSeed(Date.now());
+  return new Rodada(jogadores, emissor, { ...decisores, rng });
 }
 
 export function fabricarPartida(
@@ -48,5 +50,6 @@ export function fabricarPartida(
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
   const decisores = criarDecisores(decisoresHumanos);
-  return new Partida(jogadores, emissor, decisores);
+  const rng = new RngComSeed(Date.now());
+  return new Partida(jogadores, emissor, { ...decisores, rng });
 }

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -4,7 +4,6 @@ import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { RngComSeed } from '@/core/RngComSeed';
-import { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
 import { subscreverEventos, type CallbacksRodada } from './subscricao-eventos-rodada';
@@ -28,18 +27,6 @@ function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: D
     ['bot3', new DecisorDeclaracaoBot()],
   ]);
   return { jogada, declaracao };
-}
-
-export function fabricarRodada(
-  jogadores: Jogador[],
-  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
-  callbacks: CallbacksRodada,
-): Rodada {
-  const emissor = createEmissorEventos();
-  subscreverEventos(emissor, callbacks);
-  const decisores = criarDecisores(decisoresHumanos);
-  const rng = new RngComSeed(Date.now());
-  return new Rodada(jogadores, emissor, { ...decisores, rng });
 }
 
 export function fabricarPartida(

--- a/src/core/Baralho.ts
+++ b/src/core/Baralho.ts
@@ -15,7 +15,7 @@ export function criarBaralho(): Carta[] {
 }
 
 export function embaralhar(baralho: Carta[], rng?: GeradorAleatorio): Carta[] {
-  if (rng) return rng.shuffle(baralho);
+  if (rng) return rng.shuffle([...baralho]);
   return embaralharComRandomGlobal(baralho);
 }
 

--- a/src/core/Baralho.ts
+++ b/src/core/Baralho.ts
@@ -1,4 +1,5 @@
 import type { Carta, Naipe, Valor } from './Carta';
+import type { GeradorAleatorio } from './RngComSeed';
 
 const valores: Valor[] = ['3', '2', 'A', 'K', 'Q', 'J', '10', '9', '8', '7', '6', '5', '4'];
 const naipes: Naipe[] = ['♣', '♥', '♠', '♦'];
@@ -13,7 +14,12 @@ export function criarBaralho(): Carta[] {
   return baralho;
 }
 
-export function embaralhar(baralho: Carta[]): Carta[] {
+export function embaralhar(baralho: Carta[], rng?: GeradorAleatorio): Carta[] {
+  if (rng) return rng.shuffle(baralho);
+  return embaralharComRandomGlobal(baralho);
+}
+
+function embaralharComRandomGlobal(baralho: Carta[]): Carta[] {
   const copia = [...baralho];
   for (let i = copia.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -4,6 +4,8 @@ import type { EventoDominio } from '@/types/eventos-dominio';
 import { criarEventoBase } from './eventos-rodada';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
+import type { GeradorAleatorio } from './RngComSeed';
+import { RngComSeed } from './RngComSeed';
 import { Rodada } from './Rodada';
 
 interface EmissorPartida {
@@ -13,6 +15,7 @@ interface EmissorPartida {
 interface DecisoresPartida {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
+  rng?: GeradorAleatorio;
 }
 
 export class Partida {
@@ -22,6 +25,7 @@ export class Partida {
   private numeroRodada = 0;
   private rodada?: Rodada;
   private embaralhadorIndice: number;
+  private rng: GeradorAleatorio;
   private jogoEncerrado = false;
   private eliminados: Jogador[] = [];
 
@@ -29,6 +33,7 @@ export class Partida {
     this.jogadores = jogadores;
     this.emissor = emissor;
     this.decisores = decisores;
+    this.rng = decisores.rng ?? new RngComSeed(Date.now());
     this.embaralhadorIndice = this.sortearEmbaralhadorIndice();
   }
 
@@ -57,6 +62,7 @@ export class Partida {
       ...this.decisores,
       numeroRodada: this.numeroRodada,
       jogadorInicialIndice: this.primeiroJogadorIndice(),
+      rng: this.rng,
     });
     const cartasPorRodada = Math.min(this.numeroRodada, 13);
     this.rodada.distribuir(cartasPorRodada);
@@ -153,7 +159,7 @@ export class Partida {
   }
 
   private sortearEmbaralhadorIndice(): number {
-    return Math.floor(Math.random() * this.jogadores.length);
+    return this.rng.randomInt(0, this.jogadores.length - 1);
   }
 
   private embaralhadorAtual(): Jogador {

--- a/src/core/RngComSeed.ts
+++ b/src/core/RngComSeed.ts
@@ -1,0 +1,37 @@
+export interface GeradorAleatorio {
+  random(): number;
+  randomInt(min: number, max: number): number;
+  shuffle<T>(array: T[]): T[];
+}
+
+export class RngComSeed implements GeradorAleatorio {
+  private estado: number;
+
+  constructor(seed: number) {
+    this.estado = seed >>> 0;
+  }
+
+  random(): number {
+    this.estado += 0x6d2b79f5;
+    let valor = this.estado;
+    valor = Math.imul(valor ^ (valor >>> 15), valor | 1);
+    valor ^= valor + Math.imul(valor ^ (valor >>> 7), valor | 61);
+    return ((valor ^ (valor >>> 14)) >>> 0) / 4294967296;
+  }
+
+  randomInt(min: number, max: number): number {
+    if (!Number.isInteger(min) || !Number.isInteger(max) || min > max) {
+      throw new Error(`Intervalo inválido para randomInt: ${min.toString()}..${max.toString()}`);
+    }
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  shuffle<T>(array: T[]): T[] {
+    const copia = [...array];
+    for (let i = copia.length - 1; i > 0; i--) {
+      const j = this.randomInt(0, i);
+      [copia[i], copia[j]] = [copia[j], copia[i]];
+    }
+    return copia;
+  }
+}

--- a/src/core/RngComSeed.ts
+++ b/src/core/RngComSeed.ts
@@ -1,3 +1,5 @@
+import { unsafeUniformIntDistribution, xoroshiro128plus, type RandomGenerator } from 'pure-rand';
+
 export interface GeradorAleatorio {
   random(): number;
   randomInt(min: number, max: number): number;
@@ -5,25 +7,21 @@ export interface GeradorAleatorio {
 }
 
 export class RngComSeed implements GeradorAleatorio {
-  private estado: number;
+  private engine: RandomGenerator;
 
   constructor(seed: number) {
-    this.estado = seed >>> 0;
+    this.engine = xoroshiro128plus(seed);
   }
 
   random(): number {
-    this.estado += 0x6d2b79f5;
-    let valor = this.estado;
-    valor = Math.imul(valor ^ (valor >>> 15), valor | 1);
-    valor ^= valor + Math.imul(valor ^ (valor >>> 7), valor | 61);
-    return ((valor ^ (valor >>> 14)) >>> 0) / 4294967296;
+    return (this.engine.unsafeNext() >>> 0) / 4294967296;
   }
 
   randomInt(min: number, max: number): number {
     if (!Number.isInteger(min) || !Number.isInteger(max) || min > max) {
       throw new Error(`Intervalo inválido para randomInt: ${min.toString()}..${max.toString()}`);
     }
-    return Math.floor(this.random() * (max - min + 1)) + min;
+    return unsafeUniformIntDistribution(min, max, this.engine);
   }
 
   shuffle<T>(array: T[]): T[] {

--- a/src/core/RngComSeed.ts
+++ b/src/core/RngComSeed.ts
@@ -10,6 +10,9 @@ export class RngComSeed implements GeradorAleatorio {
   private engine: RandomGenerator;
 
   constructor(seed: number) {
+    if (!Number.isFinite(seed) || !Number.isInteger(seed)) {
+      throw new TypeError(`Seed inválida para RngComSeed: ${seed.toString()}`);
+    }
     this.engine = xoroshiro128plus(seed);
   }
 

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -19,6 +19,7 @@ import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
 import { calcularResultadoTurno } from './resultado-turno';
+import type { GeradorAleatorio } from './RngComSeed';
 import { criarSnapshotEstadoRodada } from './snapshot-estado-rodada';
 export class Rodada {
   private _estado: EstadoMutavel;
@@ -28,6 +29,7 @@ export class Rodada {
   private jogadores: Jogador[];
   private numeroRodada: number;
   private jogadorInicialIndice: number;
+  private rng?: GeradorAleatorio;
   constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
     this.decisores = decisores.jogada;
@@ -35,6 +37,7 @@ export class Rodada {
     this.emissor = emissor;
     this.numeroRodada = decisores.numeroRodada ?? 1;
     this.jogadorInicialIndice = decisores.jogadorInicialIndice ?? 0;
+    this.rng = decisores.rng;
     this._estado = {
       fase: 'distribuindo',
       jogadorAtual: this.jogadorInicialIndice,
@@ -57,7 +60,7 @@ export class Rodada {
     this._estado = estado;
   }
   distribuir(numeroCartas: number, baralhoEntrada?: Carta[]): void {
-    const baralho = baralhoEntrada ?? embaralhar(criarBaralho());
+    const baralho = baralhoEntrada ?? embaralhar(criarBaralho(), this.rng);
     const precisaDistribuir = numeroCartas * this.jogadores.length;
     const cartaVirada = baralho.length > precisaDistribuir ? baralho[0] : null;
     const baralhoRestante = cartaVirada ? baralho.slice(1) : baralho;

--- a/src/core/decisores-rodada.ts
+++ b/src/core/decisores-rodada.ts
@@ -1,9 +1,11 @@
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
+import type { GeradorAleatorio } from './RngComSeed';
 
 export interface DecisoresRodada {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
   numeroRodada?: number;
   jogadorInicialIndice?: number;
+  rng?: GeradorAleatorio;
 }

--- a/tests/core/Baralho.test.ts
+++ b/tests/core/Baralho.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { criarBaralho, distribuir, embaralhar } from '@/core/Baralho';
+import { RngComSeed } from '@/core/RngComSeed';
 
 describe('criarBaralho', () => {
   it('deve retornar 52 cartas', () => {
@@ -41,6 +42,15 @@ describe('embaralhar', () => {
     }
     const unicos = new Set(resultados);
     expect(unicos.size).toBeGreaterThan(1);
+  });
+
+  it('deve usar rng injetado para produzir ordem deterministica', () => {
+    const baralho = criarBaralho();
+    const primeiro = embaralhar(baralho, new RngComSeed(1337));
+    const segundo = embaralhar(baralho, new RngComSeed(1337));
+
+    expect(primeiro).toEqual(segundo);
+    expect(primeiro).not.toEqual(baralho);
   });
 });
 

--- a/tests/core/Baralho.test.ts
+++ b/tests/core/Baralho.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { criarBaralho, distribuir, embaralhar } from '@/core/Baralho';
-import { RngComSeed } from '@/core/RngComSeed';
+import { RngComSeed, type GeradorAleatorio } from '@/core/RngComSeed';
 
 describe('criarBaralho', () => {
   it('deve retornar 52 cartas', () => {
@@ -51,6 +51,22 @@ describe('embaralhar', () => {
 
     expect(primeiro).toEqual(segundo);
     expect(primeiro).not.toEqual(baralho);
+  });
+});
+
+describe('embaralhar com rng injetado', () => {
+  it('deve preservar baralho original mesmo se rng alterar array recebido', () => {
+    const baralho = criarBaralho();
+    const ordemOriginal = [...baralho];
+    const rngMutavel: GeradorAleatorio = {
+      random: () => 0,
+      randomInt: () => 0,
+      shuffle: (cartas) => cartas.reverse(),
+    };
+
+    embaralhar(baralho, rngMutavel);
+
+    expect(baralho).toEqual(ordemOriginal);
   });
 });
 

--- a/tests/core/Partida.test.ts
+++ b/tests/core/Partida.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Partida } from '@/core/Partida';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { Rodada } from '@/core/Rodada';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
@@ -13,6 +14,21 @@ function criarPartida(jogadores: Jogador[] = jogadoresPadrao()): Partida {
   return new Partida(jogadores, createEmissorEventos(), {
     jogada: decisoresJogada,
     declaracao: new Map(),
+  });
+}
+
+function criarPartidaComIndiceEmbaralhador(indice: number): Partida {
+  const jogadores = jogadoresPadrao();
+  const decisoresJogada = new Map(jogadores.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+  const rng: GeradorAleatorio = {
+    random: () => 0,
+    randomInt: () => indice,
+    shuffle: (array) => [...array],
+  };
+  return new Partida(jogadores, createEmissorEventos(), {
+    jogada: decisoresJogada,
+    declaracao: new Map(),
+    rng,
   });
 }
 
@@ -76,37 +92,31 @@ describe('Partida — estado público', () => {
 
 describe('Partida — embaralhador', () => {
   it('deve sortear o embaralhador da primeira rodada', () => {
-    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const partida = criarPartida();
+    const partida = criarPartidaComIndiceEmbaralhador(2);
     partida.iniciarProximaRodada();
     expect(partida.estado.embaralhadorId).toBe('j3');
-    random.mockRestore();
   });
 
   it('deve rotacionar o embaralhador para o jogador à direita', () => {
-    const random = vi.spyOn(Math, 'random').mockReturnValue(0.99);
-    const partida = criarPartida();
+    const partida = criarPartidaComIndiceEmbaralhador(3);
     const embaralhadores: string[] = [];
     for (let i = 0; i < 5; i++) {
       partida.iniciarProximaRodada();
       embaralhadores.push(partida.estado.embaralhadorId);
     }
     expect(embaralhadores).toEqual(['j4', 'j1', 'j2', 'j3', 'j4']);
-    random.mockRestore();
   });
 });
 
 describe('Partida — primeiro jogador', () => {
   it('deve iniciar declaracao e jogada no proximo jogador apos o embaralhador', () => {
-    const random = vi.spyOn(Math, 'random').mockReturnValue(0.99);
-    const partida = criarPartida();
+    const partida = criarPartidaComIndiceEmbaralhador(3);
     const jogadoresAtuais: number[] = [];
     for (let i = 0; i < 4; i++) {
       partida.iniciarProximaRodada();
       jogadoresAtuais.push(partida.estado.jogadorAtual);
     }
     expect(jogadoresAtuais).toEqual([0, 1, 2, 3]);
-    random.mockRestore();
   });
 });
 

--- a/tests/core/RngComSeed.test.ts
+++ b/tests/core/RngComSeed.test.ts
@@ -23,6 +23,12 @@ describe('RngComSeed', () => {
       segundo.random(),
     ]);
   });
+
+  it('deve rejeitar seed nao finita ou decimal', () => {
+    expect(() => new RngComSeed(Number.NaN)).toThrow(TypeError);
+    expect(() => new RngComSeed(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+    expect(() => new RngComSeed(13.37)).toThrow(TypeError);
+  });
 });
 
 describe('RngComSeed — utilitarios', () => {

--- a/tests/core/RngComSeed.test.ts
+++ b/tests/core/RngComSeed.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { RngComSeed } from '@/core/RngComSeed';
+
+describe('RngComSeed', () => {
+  it('deve produzir sequencia deterministica para seed fixa', () => {
+    const primeiro = new RngComSeed(1337);
+    const segundo = new RngComSeed(1337);
+
+    expect([primeiro.random(), primeiro.random(), primeiro.random()]).toEqual([
+      segundo.random(),
+      segundo.random(),
+      segundo.random(),
+    ]);
+  });
+
+  it('deve produzir sequencias diferentes para seeds diferentes', () => {
+    const primeiro = new RngComSeed(1337);
+    const segundo = new RngComSeed(42);
+
+    expect([primeiro.random(), primeiro.random(), primeiro.random()]).not.toEqual([
+      segundo.random(),
+      segundo.random(),
+      segundo.random(),
+    ]);
+  });
+});
+
+describe('RngComSeed — utilitarios', () => {
+  it('deve gerar inteiros dentro dos limites inclusivos', () => {
+    const rng = new RngComSeed(1337);
+    const valores = Array.from({ length: 100 }, () => rng.randomInt(2, 5));
+
+    expect(valores.every((valor) => Number.isInteger(valor) && valor >= 2 && valor <= 5)).toBe(true);
+  });
+
+  it('deve embaralhar de forma deterministica sem alterar o array original', () => {
+    const original = [1, 2, 3, 4, 5, 6];
+    const primeiro = new RngComSeed(1337).shuffle(original);
+    const segundo = new RngComSeed(1337).shuffle(original);
+
+    expect(primeiro).toEqual(segundo);
+    expect(primeiro).not.toEqual(original);
+    expect(original).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `RngComSeed` with deterministic `random`, inclusive `randomInt`, and Fisher-Yates `shuffle`.
- Injects the shared RNG through `Partida`/`Rodada` so dealer selection and shuffling no longer call `Math.random()` directly.
- Updates the Phaser factory to create one seeded RNG from `Date.now()` for the constructed game object.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shuffled cards are now deterministically randomized, enabling reproducible game scenarios.

* **Tests**
  * Added tests for random number generation and shuffle reproducibility.

* **Chores**
  * Updated dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->