### PR TITLE
feat: adiciona avaliador de cartas

### DIFF
--- a/src/core/avaliador-carta.ts
+++ b/src/core/avaliador-carta.ts
@@ -1,0 +1,137 @@
+import { criarBaralho } from './Baralho';
+import { ehManilha, type Carta, type Naipe, type Valor } from './Carta';
+import { cartaVence, cartasEmpatam } from './comparador-carta';
+
+export type CategoriaCarta = 'baixa' | 'média' | 'alta' | 'segura' | 'garantida_agora';
+
+export interface CartaAvaliada {
+  carta: Carta;
+  score: number;
+  categoria: CategoriaCarta;
+}
+
+export interface ParametrosAvaliacaoCarta {
+  limiarBaixa: number;
+  limiarAlta: number;
+  limiarSegura: number;
+  pesoDensidade: number;
+  baseManilha: number;
+}
+
+export const parametrosAvaliacaoPadrao: ParametrosAvaliacaoCarta = {
+  limiarBaixa: 5.6,
+  limiarAlta: 11,
+  limiarSegura: 20,
+  pesoDensidade: 3,
+  baseManilha: 14,
+};
+
+const hierarquiaValores: Record<Valor, number> = {
+  '3': 13,
+  '2': 12,
+  A: 11,
+  K: 10,
+  Q: 9,
+  J: 8,
+  '10': 7,
+  '9': 6,
+  '8': 5,
+  '7': 4,
+  '6': 3,
+  '5': 2,
+  '4': 1,
+};
+
+const offsetManilha: Record<Naipe, number> = {
+  '♣': 9,
+  '♥': 6,
+  '♠': 3,
+  '♦': 0,
+};
+
+// A issue define esta assinatura pública para consumo pelos próximos slices.
+// eslint-disable-next-line max-params
+export function avaliarCartas(
+  mao: Carta[],
+  manilha: Valor,
+  cartasReveladas: Carta[],
+  numJogadores: number,
+): CartaAvaliada[] {
+  return mao.map((carta) =>
+    avaliarCarta({ carta, manilha, cartasReveladas, numJogadores, cartasPorJogador: mao.length }),
+  );
+}
+
+interface ContextoAvaliacao {
+  carta: Carta;
+  manilha: Valor;
+  cartasReveladas: Carta[];
+  numJogadores: number;
+  cartasPorJogador: number;
+}
+
+function avaliarCarta(contexto: ContextoAvaliacao): CartaAvaliada {
+  const { carta, manilha, cartasReveladas } = contexto;
+  const score = calcularScore(carta, manilha, cartasReveladas);
+  const categoria = obterCategoria({ ...contexto, score });
+  return { carta, score, categoria };
+}
+
+function calcularScore(carta: Carta, manilha: Valor, cartasReveladas: Carta[]): number {
+  if (ehManilha(carta, manilha)) return parametrosAvaliacaoPadrao.baseManilha + offsetManilha[carta.naipe];
+
+  return hierarquiaValores[carta.valor] + contarSuperioresReveladas(carta, manilha, cartasReveladas);
+}
+
+function contarSuperioresReveladas(carta: Carta, manilha: Valor, cartasReveladas: Carta[]): number {
+  return cartasReveladas.filter((revelada) => cartaVence(revelada, carta, manilha)).length;
+}
+
+interface ContextoCategoria {
+  carta: Carta;
+  manilha: Valor;
+  cartasReveladas: Carta[];
+  numJogadores: number;
+  cartasPorJogador: number;
+  score: number;
+}
+
+function obterCategoria(contexto: ContextoCategoria): CategoriaCarta {
+  if (ehGarantidaAgora(contexto.carta, contexto.manilha, contexto.cartasReveladas)) return 'garantida_agora';
+
+  const limiares = calcularLimiares(contexto.cartasPorJogador, contexto.numJogadores);
+  if (contexto.score >= limiares.segura) return 'segura';
+  if (contexto.score >= limiares.alta) return 'alta';
+  if (contexto.score < limiares.baixa) return 'baixa';
+  return 'média';
+}
+
+function calcularLimiares(
+  cartasPorJogador: number,
+  numJogadores: number,
+): { baixa: number; alta: number; segura: number } {
+  const ajuste = (cartasPorJogador * numJogadores * parametrosAvaliacaoPadrao.pesoDensidade) / 52;
+  return {
+    baixa: parametrosAvaliacaoPadrao.limiarBaixa - ajuste,
+    alta: parametrosAvaliacaoPadrao.limiarAlta + ajuste,
+    segura: parametrosAvaliacaoPadrao.limiarSegura + ajuste,
+  };
+}
+
+function ehGarantidaAgora(carta: Carta, manilha: Valor, cartasReveladas: Carta[]): boolean {
+  if (ehManilha(carta, manilha)) return false;
+
+  return cartasVivas(carta, cartasReveladas).every(
+    (viva) => !cartaVence(viva, carta, manilha) && !cartasEmpatam(viva, carta, manilha),
+  );
+}
+
+function cartasVivas(cartaAvaliada: Carta, cartasReveladas: Carta[]): Carta[] {
+  return criarBaralho().filter(
+    (carta) => !mesmaCarta(carta, cartaAvaliada) && !cartasReveladas.some((revelada) => mesmaCarta(carta, revelada)),
+  );
+}
+
+function mesmaCarta(a: Carta, b: Carta): boolean {
+  return a.valor === b.valor && a.naipe === b.naipe;
+}

--- a/tests/core/avaliador-carta.test.ts
+++ b/tests/core/avaliador-carta.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { avaliarCartas, parametrosAvaliacaoPadrao } from '@/core/avaliador-carta';
+import { criarCarta } from './rodada-fixtures';
+
+describe('avaliador-carta', () => {
+  it('deve classificar 4 de ouros como baixa', () => {
+    const [avaliada] = avaliarCartas([criarCarta('4', '♦')], '5', [], 4);
+
+    expect(avaliada.categoria).toBe('baixa');
+  });
+
+  it('deve classificar 3 de paus não-manilha como alta', () => {
+    const [avaliada] = avaliarCartas([criarCarta('3', '♣')], '4', [], 4);
+
+    expect(avaliada.categoria).toBe('alta');
+  });
+
+  it('deve classificar manilha de paus como segura', () => {
+    const [avaliada] = avaliarCartas([criarCarta('4', '♣')], '4', [], 4);
+
+    expect(avaliada.categoria).toBe('segura');
+  });
+
+  it('deve classificar manilha de ouros como alta', () => {
+    const [avaliada] = avaliarCartas([criarCarta('4', '♦')], '4', [], 4);
+
+    expect(avaliada.categoria).toBe('alta');
+  });
+});
+
+describe('avaliador-carta com ajustes', () => {
+  it('deve subir categoria quando cartas superiores foram reveladas', () => {
+    const carta = criarCarta('K', '♥');
+    const semReveladas = avaliarCartas([carta], '4', [], 4);
+    const comReveladas = avaliarCartas(
+      [carta],
+      '4',
+      [criarCarta('3', '♣'), criarCarta('3', '♥'), criarCarta('2', '♠'), criarCarta('A', '♦')],
+      4,
+    );
+
+    expect(semReveladas[0].categoria).toBe('média');
+    expect(comReveladas[0].categoria).toBe('alta');
+  });
+});
+
+describe('avaliador-carta com densidade', () => {
+  it('deve mover limiares com densidade alta sem reduzir o score', () => {
+    const carta = criarCarta('8', '♠');
+    const poucaDensidade = avaliarCartas([carta], '4', [], 2);
+    const maoDensa = [
+      carta,
+      criarCarta('7', '♣'),
+      criarCarta('7', '♥'),
+      criarCarta('7', '♠'),
+      criarCarta('7', '♦'),
+      criarCarta('6', '♣'),
+      criarCarta('6', '♥'),
+      criarCarta('6', '♠'),
+      criarCarta('6', '♦'),
+      criarCarta('5', '♣'),
+      criarCarta('5', '♥'),
+      criarCarta('5', '♠'),
+      criarCarta('5', '♦'),
+    ];
+    const altaDensidade = avaliarCartas(maoDensa, '4', [], 8);
+
+    expect(poucaDensidade[0].score).toBe(altaDensidade[0].score);
+    expect(poucaDensidade[0].categoria).toBe('baixa');
+    expect(altaDensidade[0].categoria).toBe('média');
+  });
+});
+
+describe('avaliador-carta contextual', () => {
+  it('deve marcar 3 como garantida agora quando todos os 3s e manilhas foram revelados', () => {
+    const reveladas = [
+      criarCarta('3', '♣'),
+      criarCarta('3', '♥'),
+      criarCarta('3', '♠'),
+      criarCarta('4', '♣'),
+      criarCarta('4', '♥'),
+      criarCarta('4', '♠'),
+      criarCarta('4', '♦'),
+    ];
+
+    const [avaliada] = avaliarCartas([criarCarta('3', '♦')], '4', reveladas, 4);
+
+    expect(avaliada.categoria).toBe('garantida_agora');
+  });
+});
+
+describe('parametrosAvaliacaoPadrao', () => {
+  it('deve exportar parâmetros padrão editáveis separadamente', () => {
+    expect(typeof parametrosAvaliacaoPadrao.baseManilha).toBe('number');
+    expect(typeof parametrosAvaliacaoPadrao.limiarAlta).toBe('number');
+    expect(typeof parametrosAvaliacaoPadrao.limiarBaixa).toBe('number');
+    expect(typeof parametrosAvaliacaoPadrao.limiarSegura).toBe('number');
+    expect(typeof parametrosAvaliacaoPadrao.pesoDensidade).toBe('number');
+  });
+});


### PR DESCRIPTION
## Resumo

- Adiciona avaliador puro de cartas no core com score, categorias semânticas e parâmetros padrão exportados.
- Implementa faixa separada para manilhas, ajustes por cartas superiores reveladas, densidade nos limiares e categoria contextual `garantida_agora`.
- Cobre os cenários de classificação e contexto com Vitest.

## Validação

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Closes #152