### PR TITLE
feat: registra cartas reveladas na rodada

### DIFF
--- a/src/core/RegistroCartasReveladas.ts
+++ b/src/core/RegistroCartasReveladas.ts
@@ -1,0 +1,31 @@
+import type { Carta } from './Carta';
+import { cartaVence } from './comparador-carta';
+
+export class RegistroCartasReveladas {
+  private cartas: Carta[] = [];
+
+  registrar(carta: Carta): void {
+    if (this.foiRevelada(carta)) return;
+    this.cartas = [...this.cartas, { ...carta }];
+  }
+
+  cartasReveladas(): Carta[] {
+    return this.cartas.map((carta) => ({ ...carta }));
+  }
+
+  foiRevelada(carta: Carta): boolean {
+    return this.cartas.some((revelada) => cartasIguais(revelada, carta));
+  }
+
+  cartasSuperioresReveladas(carta: Carta, manilha: Carta['valor']): Carta[] {
+    return this.cartasReveladas().filter((revelada) => cartaVence(revelada, carta, manilha));
+  }
+
+  reiniciar(): void {
+    this.cartas = [];
+  }
+}
+
+function cartasIguais(a: Carta, b: Carta): boolean {
+  return a.valor === b.valor && a.naipe === b.naipe;
+}

--- a/src/core/Rodada.ts
+++ b/src/core/Rodada.ts
@@ -4,6 +4,7 @@ import { criarBaralho, distribuir, embaralhar } from './Baralho';
 import { obterProximoValor, type Carta } from './Carta';
 import { criarMaosRodada } from './criar-maos-rodada';
 import type { DecisoresRodada } from './decisores-rodada';
+import { criarEstadoInicialRodada } from './estado-inicial-rodada';
 import {
   emitirCartaJogada,
   emitirDeclaracaoFeita,
@@ -18,6 +19,8 @@ import { validarTransicaoFase } from './maquina-fases';
 import { aplicarPontuacao } from './pontuacao';
 import type { DecisorDeclaracao } from './portas/DecisorDeclaracao';
 import type { DecisorJogada } from './portas/DecisorJogada';
+import { registrarCartasVisiveis } from './registrar-cartas-visiveis';
+import { RegistroCartasReveladas } from './RegistroCartasReveladas';
 import { calcularResultadoTurno } from './resultado-turno';
 import { criarSnapshotEstadoRodada } from './snapshot-estado-rodada';
 export class Rodada {
@@ -28,6 +31,7 @@ export class Rodada {
   private jogadores: Jogador[];
   private numeroRodada: number;
   private jogadorInicialIndice: number;
+  private registro = new RegistroCartasReveladas();
   constructor(jogadores: Jogador[], emissor: EmissorRodada, decisores: DecisoresRodada) {
     this.jogadores = jogadores;
     this.decisores = decisores.jogada;
@@ -35,19 +39,7 @@ export class Rodada {
     this.emissor = emissor;
     this.numeroRodada = decisores.numeroRodada ?? 1;
     this.jogadorInicialIndice = decisores.jogadorInicialIndice ?? 0;
-    this._estado = {
-      fase: 'distribuindo',
-      jogadorAtual: this.jogadorInicialIndice,
-      mesa: [],
-      maos: [],
-      vazas: {},
-      turno: 1,
-      cartasPorRodada: 0,
-      manilha: '3',
-      cartaVirada: null,
-      declaracoes: {},
-      pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos])),
-    };
+    this._estado = criarEstadoInicialRodada(jogadores, this.jogadorInicialIndice);
   }
   get estado(): EstadoRodada {
     return criarSnapshotEstadoRodada(this._estado);
@@ -106,12 +98,15 @@ export class Rodada {
     }
   }
   private atualizarEstadoDistribuido(config: DistribuicaoConfig): void {
+    this.registro.reiniciar();
     this._estado.maos = criarMaosRodada(this.jogadores, config.cartas, this.numeroRodada === 1);
+    registrarCartasVisiveis(this.registro, this._estado.maos);
     this._estado.cartasPorRodada = config.numeroCartas;
     this._estado.manilha = config.manilha;
     this._estado.cartaVirada = config.cartaVirada;
     this._estado.declaracoes = {};
     this._estado.mesa = [];
+    this.atualizarCartasReveladas();
     this._estado.vazas = {};
     this._estado.turno = 1;
     this._estado.jogadorAtual = this.jogadorInicialIndice;
@@ -139,8 +134,14 @@ export class Rodada {
     if (indiceCarta === -1) throw new Error(`Jogada inválida para jogador ${jogador.id}`);
     this._estado.maos[this._estado.jogadorAtual].cartas = [...mao.slice(0, indiceCarta), ...mao.slice(indiceCarta + 1)];
     this._estado.mesa.push({ jogadorId: jogador.id, carta });
+    this.registro.registrar(carta);
+    this.atualizarCartasReveladas();
     emitirCartaJogada(this.emissor, { jogadorId: jogador.id, carta, posicaoMesa: this._estado.mesa.length - 1 });
     this.avancarJogador();
+  }
+
+  private atualizarCartasReveladas(): void {
+    this._estado.cartasReveladas = this.registro.cartasReveladas();
   }
   private avancarJogador(): void {
     if (this._estado.mesa.length === this.jogadores.length) {

--- a/src/core/estado-inicial-rodada.ts
+++ b/src/core/estado-inicial-rodada.ts
@@ -1,0 +1,19 @@
+import type { Jogador } from '@/types/entidades';
+import type { EstadoMutavel } from '@/types/estado-rodada';
+
+export function criarEstadoInicialRodada(jogadores: Jogador[], jogadorInicial: number): EstadoMutavel {
+  return {
+    fase: 'distribuindo',
+    jogadorAtual: jogadorInicial,
+    mesa: [],
+    cartasReveladas: [],
+    maos: [],
+    vazas: {},
+    turno: 1,
+    cartasPorRodada: 0,
+    manilha: '3',
+    cartaVirada: null,
+    declaracoes: {},
+    pontos: Object.fromEntries(jogadores.map((jogador) => [jogador.id, jogador.pontos])),
+  };
+}

--- a/src/core/registrar-cartas-visiveis.ts
+++ b/src/core/registrar-cartas-visiveis.ts
@@ -1,0 +1,9 @@
+import type { MaoJogador } from '@/types/estado-rodada';
+import type { RegistroCartasReveladas } from './RegistroCartasReveladas';
+
+export function registrarCartasVisiveis(registro: RegistroCartasReveladas, maos: MaoJogador[]): void {
+  for (const mao of maos) {
+    if (!mao.visivel) continue;
+    for (const carta of mao.cartas) registro.registrar(carta);
+  }
+}

--- a/src/core/snapshot-estado-rodada.ts
+++ b/src/core/snapshot-estado-rodada.ts
@@ -13,6 +13,7 @@ export function criarSnapshotEstadoRodada(estado: EstadoMutavel): EstadoRodada {
     cartaVirada: clonarCartaOuNula(estado.cartaVirada),
     maos: estado.maos.map(clonarMao),
     mesa: estado.mesa.map(clonarMesaItem),
+    cartasReveladas: estado.cartasReveladas.map(clonarCarta),
   };
 }
 

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -36,6 +36,7 @@ interface EstadoComCartasBase {
   cartaVirada: Carta | null;
   declaracoes: Record<string, number>;
   mesa: MesaItem[];
+  cartasReveladas: Carta[];
   vazas: Record<string, number>;
   turno: number;
 }

--- a/tests/core/RegistroCartasReveladas.test.ts
+++ b/tests/core/RegistroCartasReveladas.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { RegistroCartasReveladas } from '@/core/RegistroCartasReveladas';
+import { criarCarta } from './rodada-fixtures';
+
+describe('RegistroCartasReveladas', () => {
+  it('deve registrar carta revelada legalmente', () => {
+    const registro = new RegistroCartasReveladas();
+    const carta = criarCarta('A', '♣');
+    registro.registrar(carta);
+    expect(registro.cartasReveladas()).toEqual([carta]);
+  });
+
+  it('deve indicar que carta não registrada não foi revelada', () => {
+    const registro = new RegistroCartasReveladas();
+    registro.registrar(criarCarta('A', '♣'));
+    expect(registro.foiRevelada(criarCarta('K', '♥'))).toBe(false);
+  });
+
+  it('deve retornar apenas cartas reveladas que batem a consulta', () => {
+    const registro = new RegistroCartasReveladas();
+    registro.registrar(criarCarta('A', '♣'));
+    registro.registrar(criarCarta('4', '♥'));
+    registro.registrar(criarCarta('K', '♦'));
+    expect(registro.cartasSuperioresReveladas(criarCarta('K', '♣'), '4')).toEqual([
+      criarCarta('A', '♣'),
+      criarCarta('4', '♥'),
+    ]);
+  });
+
+  it('deve limpar cartas reveladas ao reiniciar', () => {
+    const registro = new RegistroCartasReveladas();
+    registro.registrar(criarCarta('A', '♣'));
+    registro.reiniciar();
+    expect(registro.cartasReveladas()).toEqual([]);
+  });
+});

--- a/tests/core/Rodada.registro-cartas-reveladas.test.ts
+++ b/tests/core/Rodada.registro-cartas-reveladas.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Carta } from '@/core/Carta';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
+import { criarCarta, criarDecisorPrimeiraCarta, criarRodadaComMao, jogadoresPadrao } from './rodada-fixtures';
+
+const MAOS_FIXAS: Carta[][] = [
+  [criarCarta('A', '♣')],
+  [criarCarta('K', '♥')],
+  [criarCarta('Q', '♠')],
+  [criarCarta('J', '♦')],
+];
+
+function decisoresPrimeiraCarta(): Map<string, DecisorJogada> {
+  return new Map(jogadoresPadrao().map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+}
+
+function criarRodadaRegistro(decisores = decisoresPrimeiraCarta()) {
+  return criarRodadaComMao({
+    jogadores: jogadoresPadrao(),
+    decisores,
+    emissor: createEmissorEventos(),
+    maos: MAOS_FIXAS,
+  });
+}
+
+describe('Rodada — registro de cartas reveladas', () => {
+  it('deve registrar carta jogada na mesa', async () => {
+    const rodada = criarRodadaRegistro();
+    await rodada.jogarTurno();
+    expect(estadoEmJogo(rodada.estado).cartasReveladas).toEqual([criarCarta('A', '♣')]);
+  });
+
+  it('deve acumular cartas reveladas ao longo de múltiplos turnos', async () => {
+    const rodada = criarRodadaRegistro();
+    await rodada.jogarTurno();
+    await rodada.jogarTurno();
+    expect(estadoEmJogo(rodada.estado).cartasReveladas).toEqual([criarCarta('A', '♣'), criarCarta('K', '♥')]);
+  });
+
+  it('deve iniciar sem cartas reveladas ao distribuir rodada comum', () => {
+    const rodada = criarRodadaRegistro();
+    expect(estadoEmJogo(rodada.estado).cartasReveladas).toEqual([]);
+  });
+});
+
+describe('Rodada — decisores com cartas reveladas', () => {
+  it('deve passar cartas reveladas no snapshot recebido pelo decisor', async () => {
+    const decidirJogada = vi.fn<(mao: Carta[], estado: EstadoRodada) => Promise<Carta>>();
+    decidirJogada.mockResolvedValue(criarCarta('K', '♥'));
+    const rodada = criarRodadaRegistro(
+      new Map<string, DecisorJogada>([
+        ['j1', criarDecisorPrimeiraCarta()],
+        ['j2', { decidirJogada }],
+        ['j3', criarDecisorPrimeiraCarta()],
+        ['j4', criarDecisorPrimeiraCarta()],
+      ]),
+    );
+    await rodada.jogarTurno();
+    await rodada.jogarTurno();
+    expect(estadoEmJogo(decidirJogada.mock.calls[0][1]).cartasReveladas).toEqual([criarCarta('A', '♣')]);
+  });
+});

--- a/tests/core/rodada-fixtures.ts
+++ b/tests/core/rodada-fixtures.ts
@@ -77,6 +77,7 @@ function criarEstadoComMao(config: ConfigRodadaComMao): EstadoMutavel {
     pontos: config.pontos ?? pontosIniciais(config.jogadores),
     vazas: config.vazas ?? {},
     mesa: [],
+    cartasReveladas: [],
     cartaVirada: null,
   };
 }


### PR DESCRIPTION
## Resumo

- Adiciona `RegistroCartasReveladas` no core com consultas de cartas conhecidas e superiores reveladas.
- Integra o registro ao fluxo de distribuição/jogada da `Rodada` e expõe `cartasReveladas` no snapshot passado aos decisores.
- Cobre registro isolado, acumulação por turnos e snapshot para decisores com Vitest.

## Validação

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #153