### PR TITLE
feat: implementa linha fria dos bots

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -1,0 +1,78 @@
+import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { calcularIndiceVencedor, cartaVence } from '@/core/comparador-carta';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
+
+export class DecisorJogadaLinhaFria implements DecisorJogada {
+  decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
+    if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
+
+    const estadoAtual = estadoEmJogo(estado);
+    const avaliadas = avaliarCartas(mao, estadoAtual.manilha, estadoAtual.cartasReveladas, estadoAtual.maos.length);
+    const jogadorId = estadoAtual.maos[estadoAtual.jogadorAtual].jogador.id;
+    const necessidade = calcularNecessidade(estadoAtual, jogadorId);
+
+    if (necessidade <= 0) return Promise.resolve(this.fugir(estadoAtual, avaliadas));
+    return Promise.resolve(this.buscarVaza(estadoAtual, avaliadas));
+  }
+
+  private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
+    const perdedoras = cartasQuePerdem(estado, avaliadas);
+    if (perdedoras.length === 0) return cartaMaisBarata(avaliadas).carta;
+    if (ehUltimoDaMesa(estado) && liderPrecisaFazer(estado)) return cartaMaisBarata(perdedoras).carta;
+    return cartaMaisCara(perdedoras).carta;
+  }
+
+  private buscarVaza(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
+    const vencedoras = cartasQueVencem(estado, avaliadas);
+    if (vencedoras.length > 0) return escolherVencedoraFria(vencedoras).carta;
+
+    const perdedoras = cartasQuePerdem(estado, avaliadas);
+    if (perdedoras.length > 0) return cartaMaisCara(perdedoras).carta;
+    return cartaMaisBarata(avaliadas).carta;
+  }
+}
+
+function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {
+  return (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
+}
+
+function cartasQueVencem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
+  const melhor = melhorCartaMesa(estado.mesa, estado.manilha);
+  if (!melhor) return [...avaliadas];
+  return avaliadas.filter((avaliada) => cartaVence(avaliada.carta, melhor, estado.manilha));
+}
+
+function cartasQuePerdem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
+  const melhor = melhorCartaMesa(estado.mesa, estado.manilha);
+  if (!melhor) return [];
+  return avaliadas.filter((avaliada) => !cartaVence(avaliada.carta, melhor, estado.manilha));
+}
+
+function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
+  if (mesa.length === 0) return null;
+  return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
+}
+
+function escolherVencedoraFria(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  const naoGarantidas = avaliadas.filter((avaliada) => avaliada.categoria !== 'garantida_agora');
+  return cartaMaisBarata(naoGarantidas.length > 0 ? naoGarantidas : avaliadas);
+}
+
+function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
+}
+
+function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => b.score - a.score)[0];
+}
+
+function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
+  return estado.mesa.length === estado.maos.length - 1;
+}
+
+function liderPrecisaFazer(estado: EstadoEmJogo): boolean {
+  const indice = calcularIndiceVencedor(estado.mesa, estado.manilha);
+  return calcularNecessidade(estado, estado.mesa[indice].jogadorId) > 0;
+}

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,5 +1,5 @@
-import { BotDeterministico } from '@/adapters/bots/BotDeterministico';
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
+import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
@@ -16,9 +16,9 @@ function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: D
 } {
   const jogada = new Map<string, DecisorJogada>([
     ['humano', decisoresHumanos.jogada],
-    ['bot1', new BotDeterministico()],
-    ['bot2', new BotDeterministico()],
-    ['bot3', new BotDeterministico()],
+    ['bot1', new DecisorJogadaLinhaFria()],
+    ['bot2', new DecisorJogadaLinhaFria()],
+    ['bot3', new DecisorJogadaLinhaFria()],
   ]);
   const declaracao = new Map<string, DecisorDeclaracao>([
     ['humano', decisoresHumanos.declaracao],

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import type { Carta } from '@/core/Carta';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+describe('DecisorJogadaLinhaFria', () => {
+  it('deve fazer a vaza quando é o último, precisa fazer e tem carta que ganha', deveFazerVazaNoFim);
+  it('deve jogar o menor prejuízo quando é o último, precisa fazer e não tem carta que ganha', deveJogarMenorPrejuizo);
+  it('deve fugir com a carta alta que ainda perde quando já cumpriu', deveFugirComCartaAlta);
+  it('deve fazer sem desperdiçar carta garantida quando ainda não é o último', devePreservarGarantida);
+  it('deve deixar outro jogador fazer quando a mesa está favorável', deveDeixarOutroFazer);
+});
+
+async function deveFazerVazaNoFim(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 } });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
+    criarCarta('3', '♦'),
+  );
+}
+
+async function deveJogarMenorPrejuizo(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 } });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
+    criarCarta('Q', '♠'),
+  );
+}
+
+async function deveFugirComCartaAlta(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 } });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
+    criarCarta('Q', '♠'),
+  );
+}
+
+async function devePreservarGarantida(): Promise<void> {
+  const estado = criarEstado(cenarioGarantida());
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('6', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
+    criarCarta('6', '♦'),
+  );
+}
+
+async function deveDeixarOutroFazer(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 1, bot: 0 }, vazas: { j1: 0, bot: 0 } });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
+    criarCarta('4', '♦'),
+  );
+}
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = criarJogadores();
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function criarJogadores(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
+}
+
+function mesaComK(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function cenarioGarantida(): Partial<EstadoEmJogo> {
+  return {
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('5', '♣') }],
+    jogadorAtual: 1,
+    declaracoes: { bot: 1 },
+    vazas: { bot: 0 },
+    manilha: '4',
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+  };
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('4', '♣'),
+    criarCarta('4', '♥'),
+    criarCarta('4', '♠'),
+    criarCarta('4', '♦'),
+  ];
+}


### PR DESCRIPTION
## Resumo

- Adiciona `DecisorJogadaLinhaFria` para decisões reativas de jogada dos bots.
- Integra o novo decisor no factory da partida no lugar do `BotDeterministico`.
- Cobre os cenários de linha fria com Vitest.

## Validação

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

Closes #155