### PR TITLE
feat: declaração de bots com temperatura

### DIFF
--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -1,7 +1,59 @@
+import { avaliarCartas, type CategoriaCarta } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+
+export interface ParametrosDeclaracaoBot {
+  poucasBaixas: number;
+  declaracaoBaixa: number;
+}
+
+export const parametrosDeclaracaoBotPadrao: ParametrosDeclaracaoBot = {
+  poucasBaixas: 1,
+  declaracaoBaixa: 1,
+};
 
 export class DecisorDeclaracaoBot implements DecisorDeclaracao {
-  declarar(): Promise<number> {
-    return Promise.resolve(0);
+  private readonly temperatura: number;
+  private readonly rng: GeradorAleatorio;
+  private readonly parametros: ParametrosDeclaracaoBot;
+
+  constructor(temperatura: number, rng: GeradorAleatorio, parametros = parametrosDeclaracaoBotPadrao) {
+    this.temperatura = temperatura;
+    this.rng = rng;
+    this.parametros = parametros;
   }
+
+  declarar(estado: EstadoRodada, mao: Carta[]): Promise<number> {
+    if (estado.fase === 'distribuindo') return Promise.resolve(0);
+
+    const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+    const contagemSegura = contarCategorias(
+      avaliadas.map((avaliada) => avaliada.categoria),
+      ['segura', 'garantida_agora'],
+    );
+    const contagemAltas = avaliadas.filter((avaliada) => avaliada.categoria === 'alta' && this.deveContar()).length;
+    const contagemDefensiva = this.deveDeclararDefensivo(
+      avaliadas.map((avaliada) => avaliada.categoria),
+      contagemSegura + contagemAltas,
+    )
+      ? 1
+      : 0;
+
+    return Promise.resolve(Math.min(mao.length, Math.max(0, contagemSegura + contagemAltas + contagemDefensiva)));
+  }
+
+  private deveDeclararDefensivo(categorias: CategoriaCarta[], declaracao: number): boolean {
+    const baixas = contarCategorias(categorias, ['baixa']);
+    return declaracao <= this.parametros.declaracaoBaixa && baixas <= this.parametros.poucasBaixas && this.deveContar();
+  }
+
+  private deveContar(): boolean {
+    return this.rng.random() < 1 - this.temperatura;
+  }
+}
+
+function contarCategorias(categorias: CategoriaCarta[], esperadas: CategoriaCarta[]): number {
+  return categorias.filter((categoria) => esperadas.includes(categoria)).length;
 }

--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -28,7 +28,7 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
   declarar(estado: EstadoRodada, mao: Carta[]): Promise<number> {
     if (estado.fase === 'distribuindo') return Promise.resolve(0);
 
-    const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+    const avaliadas = avaliarCartas(mao, estado.manilha, cartasPublicas(estado), estado.maos.length);
     const contagemSegura = contarCategorias(
       avaliadas.map((avaliada) => avaliada.categoria),
       ['segura', 'garantida_agora'],
@@ -56,4 +56,15 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
 
 function contarCategorias(categorias: CategoriaCarta[], esperadas: CategoriaCarta[]): number {
   return categorias.filter((categoria) => esperadas.includes(categoria)).length;
+}
+
+function cartasPublicas(estado: EstadoRodada): Carta[] {
+  if (estado.fase === 'distribuindo') return [];
+
+  const cartasEmMaos = estado.maos.flatMap((mao) => mao.cartas);
+  return estado.cartasReveladas.filter((carta) => !cartasEmMaos.some((emMao) => cartasIguais(emMao, carta)));
+}
+
+function cartasIguais(a: Carta, b: Carta): boolean {
+  return a.valor === b.valor && a.naipe === b.naipe;
 }

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -3,14 +3,17 @@ import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
-import { RngComSeed } from '@/core/RngComSeed';
+import { RngComSeed, type GeradorAleatorio } from '@/core/RngComSeed';
 import { createEmissorEventos } from '@/store/emissor-eventos';
 import type { Jogador } from '@/types/entidades';
 import { subscreverEventos, type CallbacksRodada } from './subscricao-eventos-rodada';
 
 export type { CallbacksRodada } from './subscricao-eventos-rodada';
 
-function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao }): {
+function criarDecisores(
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  rng: GeradorAleatorio,
+): {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
 } {
@@ -22,9 +25,9 @@ function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: D
   ]);
   const declaracao = new Map<string, DecisorDeclaracao>([
     ['humano', decisoresHumanos.declaracao],
-    ['bot1', new DecisorDeclaracaoBot()],
-    ['bot2', new DecisorDeclaracaoBot()],
-    ['bot3', new DecisorDeclaracaoBot()],
+    ['bot1', new DecisorDeclaracaoBot(0.2, rng)],
+    ['bot2', new DecisorDeclaracaoBot(0.5, rng)],
+    ['bot3', new DecisorDeclaracaoBot(0.8, rng)],
   ]);
   return { jogada, declaracao };
 }
@@ -36,7 +39,7 @@ export function fabricarPartida(
 ): Partida {
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
-  const decisores = criarDecisores(decisoresHumanos);
   const rng = new RngComSeed(Date.now());
+  const decisores = criarDecisores(decisoresHumanos, rng);
   return new Partida(jogadores, emissor, { ...decisores, rng });
 }

--- a/tests/adapters/DecisorDeclaracaoBot.test.ts
+++ b/tests/adapters/DecisorDeclaracaoBot.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
+import type { Carta } from '@/core/Carta';
+import { RngComSeed, type GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+function criarEstado(mao: Carta[]): EstadoRodada {
+  const jogador = criarJogador('bot1', 'Bot 1');
+  return {
+    fase: 'aguardandoDeclaracao',
+    jogadorAtual: 0,
+    pontos: { bot1: 5, bot2: 5, bot3: 5, bot4: 5 },
+    maos: [
+      { jogador, cartas: mao, visivel: true },
+      { jogador: criarJogador('bot2', 'Bot 2'), cartas: [], visivel: true },
+      { jogador: criarJogador('bot3', 'Bot 3'), cartas: [], visivel: true },
+      { jogador: criarJogador('bot4', 'Bot 4'), cartas: [], visivel: true },
+    ],
+    cartasPorRodada: mao.length,
+    manilha: '4',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 0,
+  };
+}
+
+function criarRng(valores: number[]): GeradorAleatorio {
+  let indice = 0;
+  return {
+    random: () => valores[indice++] ?? 0,
+    randomInt: (min: number) => min,
+    shuffle: <T>(array: T[]) => [...array],
+  };
+}
+
+describe('DecisorDeclaracaoBot', () => {
+  const maoForte = [criarCarta('4', '♣'), criarCarta('4', '♣'), criarCarta('3', '♣'), criarCarta('2', '♥')];
+
+  it('deve declarar seguras e altas para bot frio', async () => {
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0, 0]));
+
+    await expect(decisor.declarar(criarEstado(maoForte), maoForte)).resolves.toBe(4);
+  });
+
+  it('deve declarar apenas seguras para bot quente', async () => {
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0, 0]));
+
+    await expect(decisor.declarar(criarEstado(maoForte), maoForte)).resolves.toBe(2);
+  });
+
+  it('deve produzir resultado determinístico com seed fixa', async () => {
+    const mao = [...maoForte, criarCarta('K', '♦'), criarCarta('Q', '♠')];
+    const primeiro = new DecisorDeclaracaoBot(0.5, new RngComSeed(154));
+    const segundo = new DecisorDeclaracaoBot(0.5, new RngComSeed(154));
+
+    await expect(primeiro.declarar(criarEstado(mao), mao)).resolves.toBe(await segundo.declarar(criarEstado(mao), mao));
+  });
+});
+
+describe('DecisorDeclaracaoBot com limites', () => {
+  it('deve somar um defensivo quando tem poucas baixas e declaração baixa', async () => {
+    const mao = [criarCarta('3', '♣'), criarCarta('Q', '♣')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0, 0]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(2);
+  });
+
+  it('não deve exceder o número de cartas da rodada', async () => {
+    const maoForte = [criarCarta('4', '♣'), criarCarta('4', '♣'), criarCarta('3', '♣'), criarCarta('2', '♥')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0, 0, 0]));
+
+    await expect(decisor.declarar(criarEstado(maoForte), maoForte)).resolves.toBe(4);
+  });
+
+  it('não deve declarar valor negativo', async () => {
+    const mao = [criarCarta('5', '♦'), criarCarta('6', '♠')];
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(0);
+  });
+});

--- a/tests/adapters/DecisorDeclaracaoBot.test.ts
+++ b/tests/adapters/DecisorDeclaracaoBot.test.ts
@@ -5,7 +5,7 @@ import { RngComSeed, type GeradorAleatorio } from '@/core/RngComSeed';
 import type { EstadoRodada } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 
-function criarEstado(mao: Carta[]): EstadoRodada {
+function criarEstado(mao: Carta[], cartasReveladas: Carta[] = []): EstadoRodada {
   const jogador = criarJogador('bot1', 'Bot 1');
   return {
     fase: 'aguardandoDeclaracao',
@@ -13,7 +13,7 @@ function criarEstado(mao: Carta[]): EstadoRodada {
     pontos: { bot1: 5, bot2: 5, bot3: 5, bot4: 5 },
     maos: [
       { jogador, cartas: mao, visivel: true },
-      { jogador: criarJogador('bot2', 'Bot 2'), cartas: [], visivel: true },
+      { jogador: criarJogador('humano', 'Humano'), cartas: cartasReveladas, visivel: true },
       { jogador: criarJogador('bot3', 'Bot 3'), cartas: [], visivel: true },
       { jogador: criarJogador('bot4', 'Bot 4'), cartas: [], visivel: true },
     ],
@@ -22,7 +22,7 @@ function criarEstado(mao: Carta[]): EstadoRodada {
     cartaVirada: null,
     declaracoes: {},
     mesa: [],
-    cartasReveladas: [],
+    cartasReveladas,
     vazas: {},
     turno: 0,
   };
@@ -61,6 +61,19 @@ describe('DecisorDeclaracaoBot', () => {
   });
 });
 
+describe('DecisorDeclaracaoBot com cartas reveladas', () => {
+  it('não deve usar cartas visíveis da mão humana para declarar', async () => {
+    const mao = [criarCarta('Q', '♣')];
+    const cartasHumanas = criarCartasHumanasVisiveis();
+    const decisorComCartasHumanas = new DecisorDeclaracaoBot(0, criarRng([0]));
+    const decisorSemCartasHumanas = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisorComCartasHumanas.declarar(criarEstado(mao, cartasHumanas), mao)).resolves.toBe(
+      await decisorSemCartasHumanas.declarar(criarEstado(mao), mao),
+    );
+  });
+});
+
 describe('DecisorDeclaracaoBot com limites', () => {
   it('deve somar um defensivo quando tem poucas baixas e declaração baixa', async () => {
     const mao = [criarCarta('3', '♣'), criarCarta('Q', '♣')];
@@ -83,3 +96,14 @@ describe('DecisorDeclaracaoBot com limites', () => {
     await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(0);
   });
 });
+
+function criarCartasHumanasVisiveis(): Carta[] {
+  return [
+    criarCarta('4', '♣'),
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('3', '♦'),
+    criarCarta('2', '♣'),
+  ];
+}


### PR DESCRIPTION
## Resumo

- Substitui o placeholder de declaração dos bots por uma heurística baseada no avaliador de cartas.
- Usa temperatura e RNG injetado para contar cartas altas e declaração defensiva.
- Integra bots com temperaturas fixas no factory da partida.
- Adiciona cobertura Vitest para comportamento frio/quente, seed fixa, defensivo e limites.

## Verificações

- `pnpm exec vitest run tests/adapters/DecisorDeclaracaoBot.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- Hook de push: `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`
- Hook de push: `vitest run` (31 arquivos, 575 testes)

Closes #154