### PR TITLE
feat: adicionar linha quente aos bots

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -1,0 +1,182 @@
+import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { calcularIndiceVencedor, cartasEmpatam, cartaVence } from '@/core/comparador-carta';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
+import { DecisorJogadaLinhaFria } from './DecisorJogadaLinhaFria';
+
+interface ConfigLinhaQuente {
+  temperatura: number;
+  rng: Pick<GeradorAleatorio, 'random'>;
+  liderBaixa?: number;
+  liderAlta?: number;
+}
+
+export class DecisorJogadaLinhaQuente implements DecisorJogada {
+  private readonly fria = new DecisorJogadaLinhaFria();
+  private readonly temperatura: number;
+  private readonly rng: Pick<GeradorAleatorio, 'random'>;
+  private readonly liderBaixa: number;
+  private readonly liderAlta: number;
+
+  constructor(config: ConfigLinhaQuente) {
+    this.temperatura = config.temperatura;
+    this.rng = config.rng;
+    this.liderBaixa = config.liderBaixa ?? 8;
+    this.liderAlta = config.liderAlta ?? 11;
+  }
+
+  async decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
+    if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
+
+    const estadoAtual = estadoEmJogo(estado);
+    const contexto = criarContexto(estadoAtual, mao);
+    const empate = escolherEmpate(estadoAtual, contexto, this.liderAlta);
+    if (empate) return empate.carta;
+
+    const travessia = escolherTravessia(estadoAtual, contexto);
+    if (travessia) return travessia.carta;
+
+    if (!podeBifurcar(estadoAtual, contexto, this.liderBaixa)) return this.fria.decidirJogada(mao, estado);
+    if (this.rng.random() >= this.temperatura) return this.fria.decidirJogada(mao, estado);
+    return escolherPressao(contexto).carta;
+  }
+}
+
+interface ContextoJogada {
+  jogadorId: string;
+  necessidade: number;
+  folga: number;
+  avaliadas: CartaAvaliada[];
+  vencedoras: CartaAvaliada[];
+  perdedoras: CartaAvaliada[];
+  lider: CartaAvaliada | null;
+}
+
+function criarContexto(estado: EstadoEmJogo, mao: Carta[]): ContextoJogada {
+  const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
+  const necessidade = calcularNecessidade(estado, jogadorId);
+  const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+  const lider = avaliarLider(estado);
+  return {
+    jogadorId,
+    necessidade,
+    folga: mao.length - necessidade,
+    avaliadas,
+    vencedoras: lider ? avaliadas.filter((a) => cartaVence(a.carta, lider.carta, estado.manilha)) : [...avaliadas],
+    perdedoras: lider ? avaliadas.filter((a) => !cartaVence(a.carta, lider.carta, estado.manilha)) : [],
+    lider,
+  };
+}
+
+function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaixa: number): boolean {
+  return (
+    contexto.necessidade > 0 &&
+    contexto.vencedoras.length > 0 &&
+    mesaPodePunir(estado, contexto, liderBaixa) &&
+    temSegurancaParaDepois(contexto) &&
+    temPressaoAgora(contexto) &&
+    temAlvo(estado, contexto.jogadorId)
+  );
+}
+
+function mesaPodePunir(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaixa: number): boolean {
+  return Boolean(
+    contexto.lider &&
+    contexto.lider.score <= liderBaixa &&
+    estado.mesa.some((item) => jogadorNaoQuerVaza(estado, item)),
+  );
+}
+
+function temSegurancaParaDepois(contexto: ContextoJogada): boolean {
+  return contexto.necessidade <= 1 && contexto.folga >= 1 && contexto.avaliadas.some(ehSeguraOuGarantida);
+}
+
+function temPressaoAgora(contexto: ContextoJogada): boolean {
+  return cartasDeFuga(contexto).length > 0 || vencedorasBaratasSemGarantida(contexto).length > 0;
+}
+
+function escolherPressao(contexto: ContextoJogada): CartaAvaliada {
+  const fuga = cartasDeFuga(contexto);
+  if (fuga.length > 0) return cartaMaisCara(fuga);
+  return cartaMaisBarata(vencedorasBaratasSemGarantida(contexto));
+}
+
+function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada): CartaAvaliada | null {
+  if (
+    contexto.necessidade <= 0 ||
+    contexto.folga > 1 ||
+    !liderQuerVaza(estado) ||
+    !temAlvo(estado, contexto.jogadorId)
+  ) {
+    return null;
+  }
+  const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
+  return candidatas.length > 0 ? cartaMaisBarata(candidatas) : null;
+}
+
+function escolherEmpate(estado: EstadoEmJogo, contexto: ContextoJogada, liderAlta: number): CartaAvaliada | null {
+  const lider = contexto.lider;
+  if (!lider || lider.score <= liderAlta) return null;
+  const empates = contexto.avaliadas.filter((avaliada) => cartasEmpatam(avaliada.carta, lider.carta, estado.manilha));
+  if (empates.length === 0) return null;
+  if (contexto.necessidade <= 0 || contexto.folga >= 2) return cartaMaisCara(empates);
+  return null;
+}
+
+function cartasDeFuga(contexto: ContextoJogada): CartaAvaliada[] {
+  return contexto.perdedoras.filter((avaliada) => !ehSeguraOuGarantida(avaliada));
+}
+
+function vencedorasBaratasSemGarantida(contexto: ContextoJogada): CartaAvaliada[] {
+  const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
+  return candidatas.filter((carta) =>
+    contexto.avaliadas.some((avaliada) => avaliada !== carta && ehGarantida(avaliada)),
+  );
+}
+
+function avaliarLider(estado: EstadoEmJogo): CartaAvaliada | null {
+  const carta = melhorCartaMesa(estado.mesa, estado.manilha);
+  if (!carta) return null;
+  return avaliarCartas([carta], estado.manilha, estado.cartasReveladas, estado.maos.length)[0];
+}
+
+function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
+  if (mesa.length === 0) return null;
+  return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
+}
+
+function liderQuerVaza(estado: EstadoEmJogo): boolean {
+  if (estado.mesa.length === 0) return false;
+  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
+  return calcularNecessidade(estado, lider.jogadorId) > 0;
+}
+
+function temAlvo(estado: EstadoEmJogo, jogadorId: string): boolean {
+  return Object.keys(estado.declaracoes).some((id) => id !== jogadorId && calcularNecessidade(estado, id) > 0);
+}
+
+function jogadorNaoQuerVaza(estado: EstadoEmJogo, item: MesaItem): boolean {
+  return calcularNecessidade(estado, item.jogadorId) <= 0;
+}
+
+function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {
+  return (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
+}
+
+function ehSeguraOuGarantida(avaliada: CartaAvaliada): boolean {
+  return avaliada.categoria === 'segura' || avaliada.categoria === 'garantida_agora';
+}
+
+function ehGarantida(avaliada: CartaAvaliada): boolean {
+  return avaliada.categoria === 'garantida_agora';
+}
+
+function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
+}
+
+function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => b.score - a.score)[0];
+}

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,5 +1,6 @@
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
@@ -10,15 +11,18 @@ import { subscreverEventos, type CallbacksRodada } from './subscricao-eventos-ro
 
 export type { CallbacksRodada } from './subscricao-eventos-rodada';
 
-function criarDecisores(decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao }): {
+function criarDecisores(
+  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  rng: RngComSeed,
+): {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
 } {
   const jogada = new Map<string, DecisorJogada>([
     ['humano', decisoresHumanos.jogada],
     ['bot1', new DecisorJogadaLinhaFria()],
-    ['bot2', new DecisorJogadaLinhaFria()],
-    ['bot3', new DecisorJogadaLinhaFria()],
+    ['bot2', new DecisorJogadaLinhaQuente({ temperatura: 0.55, rng })],
+    ['bot3', new DecisorJogadaLinhaQuente({ temperatura: 0.9, rng })],
   ]);
   const declaracao = new Map<string, DecisorDeclaracao>([
     ['humano', decisoresHumanos.declaracao],
@@ -36,7 +40,7 @@ export function fabricarPartida(
 ): Partida {
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
-  const decisores = criarDecisores(decisoresHumanos);
   const rng = new RngComSeed(Date.now());
+  const decisores = criarDecisores(decisoresHumanos, rng);
   return new Partida(jogadores, emissor, { ...decisores, rng });
 }

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { Carta } from '@/core/Carta';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+describe('DecisorJogadaLinhaQuente', () => {
+  it('deve escolher linha quente com segurança quando o RNG cai abaixo da temperatura', escolheLinhaQuente);
+  it('deve escolher linha fria com segurança quando a temperatura é zero', escolheLinhaFria);
+  it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
+  it('deve empatar alta quando já cumpriu para se livrar de carta indesejada', empataAltaCumprido);
+  it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
+  it('deve repetir a escolha com RNG determinístico', repeteEscolhaDeterministica);
+});
+
+async function escolheLinhaQuente(): Promise<void> {
+  const estado = criarEstado(cenarioBifurcacao());
+  const bot = criarBot(1, 0);
+
+  await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('Q', '♠'));
+}
+
+async function escolheLinhaFria(): Promise<void> {
+  const estado = criarEstado(cenarioBifurcacao());
+  const bot = criarBot(0, 0);
+
+  await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('3', '♦'));
+}
+
+async function atravessaComCartaBarata(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  const bot = criarBot(1, 0);
+
+  await expect(bot.decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
+    criarCarta('A', '♦'),
+  );
+}
+
+async function empataAltaCumprido(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 } });
+  const bot = criarBot(1, 0);
+
+  await expect(bot.decidirJogada([criarCarta('K', '♦'), criarCarta('4', '♦')], estado)).resolves.toEqual(
+    criarCarta('K', '♦'),
+  );
+}
+
+async function convergeSemPressao(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComBaixa(), declaracoes: { j2: 1, bot: 1 }, vazas: { j2: 0, bot: 0 } });
+  const mao = [criarCarta('A', '♦'), criarCarta('3', '♦')];
+  const bot = criarBot(1, 0);
+  const fria = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(await fria.decidirJogada(mao, estado));
+}
+
+async function repeteEscolhaDeterministica(): Promise<void> {
+  const estado = criarEstado(cenarioBifurcacao());
+  const primeiro = await criarBot(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
+  const segundo = await criarBot(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
+
+  expect(primeiro).toEqual(segundo);
+}
+
+function criarBot(temperatura: number, valorRng: number): DecisorJogadaLinhaQuente {
+  return new DecisorJogadaLinhaQuente({ temperatura, rng: { random: () => valorRng }, liderBaixa: 20, liderAlta: 10 });
+}
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = criarJogadores();
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function cenarioBifurcacao(): Partial<EstadoEmJogo> {
+  return {
+    mesa: mesaComK(),
+    declaracoes: { j1: 0, j2: 1, bot: 1 },
+    vazas: { j1: 0, j2: 0, bot: 0 },
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+  };
+}
+
+function maoBifurcacao(): Carta[] {
+  return [criarCarta('Q', '♠'), criarCarta('3', '♦')];
+}
+
+function criarJogadores(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
+}
+
+function mesaComBaixa(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('8', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('6', '♠') },
+  ];
+}
+
+function mesaComK(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('5', '♣'),
+    criarCarta('5', '♥'),
+    criarCarta('5', '♠'),
+    criarCarta('5', '♦'),
+  ];
+}


### PR DESCRIPTION
## Resumo

- Adiciona `DecisorJogadaLinhaQuente` com bifurcação quente/fria via temperatura e RNG.
- Implementa pressão, travessia e empate alto usando o avaliador de cartas e estado público da rodada.
- Integra bots com temperaturas distintas no factory Phaser: bot1 frio, bot2/bot3 quentes.

## Validação

- `pnpm test tests/adapters/DecisorJogadaLinhaQuente.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "hot line" strategy for AI bots, providing sophisticated game-decision logic with temperature-based evaluation to enhance opponent behavior during matches.

* **Tests**
  * Added comprehensive test coverage for the new bot strategy to ensure consistent and deterministic performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->