### PR TITLE
fix(prettier): configure endOfLine as auto to support Windows CRLF

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
Adiciona 'endOfLine': 'auto' no .prettierrc para evitar que o linter e o prettier falhem com erros de quebra de linha (CRLF vs LF) ao rodar o projeto no Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration settings to ensure consistent formatting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->