### PR TITLE
feat: sortear perfis dos bots no factory

### DIFF
--- a/src/adapters/bots/perfil-bot.ts
+++ b/src/adapters/bots/perfil-bot.ts
@@ -1,0 +1,59 @@
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { Jogador } from '@/types/entidades';
+
+export const nomesBotsPorTemperatura = [
+  'Brás',
+  'Saci',
+  'Iara',
+  'Bento',
+  'Narizinho',
+  'Emília',
+  'Quincas',
+  'Capitu',
+  'Bentinho',
+  'Esaú',
+  'Jacó',
+  'Policarpo',
+  'Isaías',
+  'Clara',
+  'Jeca',
+  'Cuca',
+  'Curupira',
+  'Boitatá',
+  'Peri',
+  'Iracema',
+] as const;
+
+export interface PerfilBot {
+  id: string;
+  nome: string;
+  temperatura: number;
+}
+
+export function nomePorTemperatura(temperatura: number): string {
+  const faixa = Math.min(Math.floor(temperatura * nomesBotsPorTemperatura.length), nomesBotsPorTemperatura.length - 1);
+  return nomesBotsPorTemperatura[faixa];
+}
+
+export function sortearPerfisBots(jogadores: Jogador[], rng: Pick<GeradorAleatorio, 'random'>): PerfilBot[] {
+  return jogadores.filter(ehBot).map((jogador) => {
+    const temperatura = rng.random();
+    return {
+      id: jogador.id,
+      nome: nomePorTemperatura(temperatura),
+      temperatura,
+    };
+  });
+}
+
+export function aplicarPerfisBots(jogadores: Jogador[], perfis: PerfilBot[]): Jogador[] {
+  return jogadores.map((jogador) => {
+    const perfil = perfis.find((item) => item.id === jogador.id);
+    if (!perfil) return jogador;
+    return { ...jogador, nome: perfil.nome, temperatura: perfil.temperatura };
+  });
+}
+
+function ehBot(jogador: Jogador): boolean {
+  return jogador.id.startsWith('bot');
+}

--- a/src/adapters/bots/perfil-bot.ts
+++ b/src/adapters/bots/perfil-bot.ts
@@ -2,26 +2,26 @@ import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { Jogador } from '@/types/entidades';
 
 export const nomesBotsPorTemperatura = [
-  'Brás',
-  'Saci',
-  'Iara',
-  'Bento',
-  'Narizinho',
-  'Emília',
-  'Quincas',
-  'Capitu',
-  'Bentinho',
-  'Esaú',
-  'Jacó',
-  'Policarpo',
-  'Isaías',
-  'Clara',
-  'Jeca',
-  'Cuca',
-  'Curupira',
-  'Boitatá',
-  'Peri',
-  'Iracema',
+  'Brás', // Brás Cubas — Memórias Póstumas de Brás Cubas (Machado de Assis)
+  'Severino', // Morte e Vida Severina (João Cabral de Melo Neto)
+  'Iara', // Iara — lenda do folclore brasileiro
+  'Bento', // Bento Santiago — D. Casmurro (Machado de Assis)
+  'Ana', // Ana Terra — O Tempo e o Vento (Érico Veríssimo)
+  'Pedro', // Pedro Bala — Capitães da Areia (Jorge Amado)
+  'Vitória', // Sinhá Vitória — Vidas Secas (Graciliano Ramos)
+  'Augusto', // Augusto Matraga — Sagarana (Guimarães Rosa)
+  'Leonardo', // Leonardo — Memórias de um Sargento de Milícias (Manuel Antônio de Almeida)
+  'Fabiano', // Fabiano — Vidas Secas (Graciliano Ramos)
+  'Sofia', // Sofia — Quincas Borba (Machado de Assis)
+  'Luís', // Luís da Silva — Angústia (Graciliano Ramos)
+  'Aurélia', // Aurélia Camargo — Senhora (José de Alencar)
+  'Clara', // Clara dos Anjos — Clara dos Anjos (Lima Barreto)
+  'Rita', // Rita Baiana — O Cortiço (Aluísio Azevedo)
+  'Sérgio', // narrador de O Ateneu (Raul Pompeia)
+  'Paulo', // Paulo Honório — São Bernardo (Graciliano Ramos)
+  'Flor', // Dona Flor — Dona Flor e Seus Dois Maridos (Jorge Amado)
+  'Jerônimo', // Jerônimo — O Cortiço (Aluísio Azevedo)
+  'Iracema', // Iracema — Iracema (José de Alencar)
 ] as const;
 
 export interface PerfilBot {

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,6 +1,6 @@
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
-import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { aplicarPerfisBots, sortearPerfisBots } from '@/adapters/bots/perfil-bot';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
@@ -13,23 +13,19 @@ export type { CallbacksRodada } from './subscricao-eventos-rodada';
 
 function criarDecisores(
   decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
+  jogadores: Jogador[],
   rng: GeradorAleatorio,
 ): {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
 } {
-  const jogada = new Map<string, DecisorJogada>([
-    ['humano', decisoresHumanos.jogada],
-    ['bot1', new DecisorJogadaLinhaFria()],
-    ['bot2', new DecisorJogadaBot({ temperatura: 0.55, rng })],
-    ['bot3', new DecisorJogadaBot({ temperatura: 0.9, rng })],
-  ]);
-  const declaracao = new Map<string, DecisorDeclaracao>([
-    ['humano', decisoresHumanos.declaracao],
-    ['bot1', new DecisorDeclaracaoBot(0.2, rng)],
-    ['bot2', new DecisorDeclaracaoBot(0.5, rng)],
-    ['bot3', new DecisorDeclaracaoBot(0.8, rng)],
-  ]);
+  const jogada = new Map<string, DecisorJogada>([['humano', decisoresHumanos.jogada]]);
+  const declaracao = new Map<string, DecisorDeclaracao>([['humano', decisoresHumanos.declaracao]]);
+  jogadores.forEach((jogador) => {
+    if (jogador.temperatura === undefined) return;
+    jogada.set(jogador.id, new DecisorJogadaBot({ temperatura: jogador.temperatura, rng }));
+    declaracao.set(jogador.id, new DecisorDeclaracaoBot(jogador.temperatura, rng));
+  });
   return { jogada, declaracao };
 }
 
@@ -41,6 +37,7 @@ export function fabricarPartida(
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
   const rng = new RngComSeed(Date.now());
-  const decisores = criarDecisores(decisoresHumanos, rng);
-  return new Partida(jogadores, emissor, { ...decisores, rng });
+  const jogadoresComBots = aplicarPerfisBots(jogadores, sortearPerfisBots(jogadores, rng));
+  const decisores = criarDecisores(decisoresHumanos, jogadoresComBots, rng);
+  return new Partida(jogadoresComBots, emissor, { ...decisores, rng });
 }

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -22,7 +22,7 @@ function criarDecisores(
   const jogada = new Map<string, DecisorJogada>([['humano', decisoresHumanos.jogada]]);
   const declaracao = new Map<string, DecisorDeclaracao>([['humano', decisoresHumanos.declaracao]]);
   jogadores.forEach((jogador) => {
-    if (jogador.temperatura === undefined) return;
+    if (!jogador.id.startsWith('bot') || jogador.temperatura === undefined) return;
     jogada.set(jogador.id, new DecisorJogadaBot({ temperatura: jogador.temperatura, rng }));
     declaracao.set(jogador.id, new DecisorDeclaracaoBot(jogador.temperatura, rng));
   });

--- a/src/types/entidades.ts
+++ b/src/types/entidades.ts
@@ -4,6 +4,7 @@ export interface Jogador {
   id: string;
   nome: string;
   pontos: number;
+  temperatura?: number;
   avatar?: string;
 }
 

--- a/tests/adapters/perfil-bot.test.ts
+++ b/tests/adapters/perfil-bot.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aplicarPerfisBots,
+  nomePorTemperatura,
+  nomesBotsPorTemperatura,
+  sortearPerfisBots,
+} from '@/adapters/bots/perfil-bot';
+import { RngComSeed } from '@/core/RngComSeed';
+import type { Jogador } from '@/types/entidades';
+
+function jogadores(): Jogador[] {
+  return [
+    { id: 'humano', nome: 'Humano', pontos: 5 },
+    { id: 'bot1', nome: 'Bot 1', pontos: 5 },
+    { id: 'bot2', nome: 'Bot 2', pontos: 5 },
+    { id: 'bot3', nome: 'Bot 3', pontos: 5 },
+  ];
+}
+
+describe('Nomes dos bots', () => {
+  it('deve ter exatamente 20 nomes sem duplicatas', () => {
+    expect(nomesBotsPorTemperatura).toHaveLength(20);
+    expect(new Set(nomesBotsPorTemperatura).size).toBe(20);
+  });
+
+  it('deve manter o nome estavel por faixa de temperatura', () => {
+    expect(nomePorTemperatura(0)).toBe('Brás');
+    expect(nomePorTemperatura(0.049)).toBe('Brás');
+    expect(nomePorTemperatura(0.05)).toBe('Saci');
+    expect(nomePorTemperatura(0.999)).toBe('Iracema');
+  });
+});
+
+describe('Perfil dos bots', () => {
+  it('deve sortear temperaturas deterministicas por seed', () => {
+    const primeiro = sortearPerfisBots(jogadores(), new RngComSeed(158));
+    const segundo = sortearPerfisBots(jogadores(), new RngComSeed(158));
+
+    expect(segundo).toEqual(primeiro);
+  });
+
+  it('deve sortear temperaturas no intervalo de 0 ate antes de 1', () => {
+    const perfis = sortearPerfisBots(jogadores(), new RngComSeed(158));
+
+    expect(perfis.every((perfil) => perfil.temperatura >= 0 && perfil.temperatura < 1)).toBe(true);
+  });
+
+  it('deve aplicar nome e temperatura apenas nos bots', () => {
+    const perfis = [
+      { id: 'bot1', nome: 'Saci', temperatura: 0.05 },
+      { id: 'bot2', nome: 'Iara', temperatura: 0.1 },
+      { id: 'bot3', nome: 'Bento', temperatura: 0.15 },
+    ];
+
+    expect(aplicarPerfisBots(jogadores(), perfis)).toEqual([
+      { id: 'humano', nome: 'Humano', pontos: 5 },
+      { id: 'bot1', nome: 'Saci', pontos: 5, temperatura: 0.05 },
+      { id: 'bot2', nome: 'Iara', pontos: 5, temperatura: 0.1 },
+      { id: 'bot3', nome: 'Bento', pontos: 5, temperatura: 0.15 },
+    ]);
+  });
+});

--- a/tests/adapters/perfil-bot.test.ts
+++ b/tests/adapters/perfil-bot.test.ts
@@ -26,7 +26,7 @@ describe('Nomes dos bots', () => {
   it('deve manter o nome estavel por faixa de temperatura', () => {
     expect(nomePorTemperatura(0)).toBe('Brás');
     expect(nomePorTemperatura(0.049)).toBe('Brás');
-    expect(nomePorTemperatura(0.05)).toBe('Saci');
+    expect(nomePorTemperatura(0.05)).toBe('Severino');
     expect(nomePorTemperatura(0.999)).toBe('Iracema');
   });
 });
@@ -47,14 +47,14 @@ describe('Perfil dos bots', () => {
 
   it('deve aplicar nome e temperatura apenas nos bots', () => {
     const perfis = [
-      { id: 'bot1', nome: 'Saci', temperatura: 0.05 },
+      { id: 'bot1', nome: 'Severino', temperatura: 0.05 },
       { id: 'bot2', nome: 'Iara', temperatura: 0.1 },
       { id: 'bot3', nome: 'Bento', temperatura: 0.15 },
     ];
 
     expect(aplicarPerfisBots(jogadores(), perfis)).toEqual([
       { id: 'humano', nome: 'Humano', pontos: 5 },
-      { id: 'bot1', nome: 'Saci', pontos: 5, temperatura: 0.05 },
+      { id: 'bot1', nome: 'Severino', pontos: 5, temperatura: 0.05 },
       { id: 'bot2', nome: 'Iara', pontos: 5, temperatura: 0.1 },
       { id: 'bot3', nome: 'Bento', pontos: 5, temperatura: 0.15 },
     ]);

--- a/tests/adapters/rodada-factory.test.ts
+++ b/tests/adapters/rodada-factory.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fabricarPartida } from '@/adapters/phaser/factories/rodada-factory';
+import type { CallbacksRodada } from '@/adapters/phaser/factories/subscricao-eventos-rodada';
+import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
+import type { DecisorJogada } from '@/core/portas/DecisorJogada';
+import type { Jogador } from '@/types/entidades';
+import { estadoEmJogo } from '@/types/estado-rodada';
+
+function jogadores(): Jogador[] {
+  return [
+    { id: 'humano', nome: 'Humano', pontos: 5 },
+    { id: 'bot1', nome: 'Bot 1', pontos: 5 },
+    { id: 'bot2', nome: 'Bot 2', pontos: 5 },
+    { id: 'bot3', nome: 'Bot 3', pontos: 5 },
+  ];
+}
+
+function callbacks(): CallbacksRodada {
+  return {
+    onCartaJogada: vi.fn(),
+    onTurnoGanho: vi.fn(),
+    onTurnoEmpatado: vi.fn(),
+    onRodadaEncerrada: vi.fn(),
+  };
+}
+
+function decisoresHumanos(): { jogada: DecisorJogada; declaracao: DecisorDeclaracao } {
+  return {
+    jogada: { decidirJogada: vi.fn() },
+    declaracao: { declarar: vi.fn() },
+  };
+}
+
+function perfisDaPrimeiraRodada(seed: number) {
+  vi.setSystemTime(seed);
+  const partida = fabricarPartida(jogadores(), decisoresHumanos(), callbacks());
+  partida.iniciarProximaRodada();
+  return estadoEmJogo(partida.estado)
+    .maos.map((mao) => mao.jogador)
+    .filter((jogador) => jogador.id.startsWith('bot'));
+}
+
+describe('Factory da rodada', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('deve gerar os mesmos nomes e temperaturas com seed fixa', () => {
+    vi.useFakeTimers();
+
+    expect(perfisDaPrimeiraRodada(158)).toEqual(perfisDaPrimeiraRodada(158));
+  });
+
+  it('deve expor temperatura e nome sorteados nos jogadores bots', () => {
+    vi.useFakeTimers();
+    const perfis = perfisDaPrimeiraRodada(158);
+
+    expect(perfis).toHaveLength(3);
+    expect(perfis.every((perfil) => !perfil.nome.startsWith('Bot '))).toBe(true);
+    expect(perfis.every((perfil) => perfil.temperatura !== undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumo

- Sorteia temperatura fixa por partida para cada bot no factory
- Atribui nomes por 20 faixas de temperatura e expõe `temperatura` em `Jogador`
- Instancia decisores de jogada e declaração com temperatura e RNG compartilhado

## Validação

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot players now receive personalized names and temperature profiles that define their difficulty and playing style.
  * Temperature profiles automatically determine bot characteristics when setting up game rounds.
  * Bot behavior remains consistent and deterministic across multiple games.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->