### PR TITLE
feat: adiciona modo debug dos bots

### DIFF
--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -3,10 +3,12 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { EstadoRodada } from '@/types/estado-rodada';
+import type { LoggerDebugBot } from './logger-debug-bot';
 
 export interface ParametrosDeclaracaoBot {
   poucasBaixas: number;
   declaracaoBaixa: number;
+  logger?: LoggerDebugBot;
 }
 
 export const parametrosDeclaracaoBotPadrao: ParametrosDeclaracaoBot = {
@@ -18,11 +20,13 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
   private readonly temperatura: number;
   private readonly rng: GeradorAleatorio;
   private readonly parametros: ParametrosDeclaracaoBot;
+  private readonly logger?: LoggerDebugBot;
 
   constructor(temperatura: number, rng: GeradorAleatorio, parametros = parametrosDeclaracaoBotPadrao) {
     this.temperatura = temperatura;
     this.rng = rng;
     this.parametros = parametros;
+    this.logger = parametros.logger;
   }
 
   declarar(estado: EstadoRodada, mao: Carta[]): Promise<number> {
@@ -33,15 +37,27 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
       avaliadas.map((avaliada) => avaliada.categoria),
       ['segura', 'garantida_agora'],
     );
-    const contagemAltas = avaliadas.filter((avaliada) => avaliada.categoria === 'alta' && this.deveContar()).length;
-    const contagemDefensiva = this.deveDeclararDefensivo(
+    const altasSorteadas = avaliadas
+      .filter((avaliada) => avaliada.categoria === 'alta')
+      .map(() => this.sortearContagem());
+    const contagemAltas = altasSorteadas.filter((sorteio) => sorteio.conta).length;
+    const defensivo = this.deveDeclararDefensivo(
       avaliadas.map((avaliada) => avaliada.categoria),
       contagemSegura + contagemAltas,
-    )
-      ? 1
-      : 0;
+    );
+    const contagemDefensiva = defensivo ? 1 : 0;
+    const declaracao = Math.min(mao.length, Math.max(0, contagemSegura + contagemAltas + contagemDefensiva));
 
-    return Promise.resolve(Math.min(mao.length, Math.max(0, contagemSegura + contagemAltas + contagemDefensiva)));
+    this.logger?.registrarDeclaracao({
+      mao: avaliadas,
+      seguras: contagemSegura,
+      altas: contagemAltas,
+      sorteouAlta: altasSorteadas.some((sorteio) => sorteio.conta),
+      defensivo,
+      declaracao,
+    });
+
+    return Promise.resolve(declaracao);
   }
 
   private deveDeclararDefensivo(categorias: CategoriaCarta[], declaracao: number): boolean {
@@ -51,6 +67,10 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
 
   private deveContar(): boolean {
     return this.rng.random() < 1 - this.temperatura;
+  }
+
+  private sortearContagem(): { conta: boolean } {
+    return { conta: this.deveContar() };
   }
 }
 

--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -4,6 +4,7 @@ import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { decidirAbertura } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
+import type { LoggerDebugBot } from './logger-debug-bot';
 
 interface ConfigDecisorJogadaBot {
   temperatura: number;
@@ -11,17 +12,20 @@ interface ConfigDecisorJogadaBot {
   liderBaixa?: number;
   liderAlta?: number;
   urgenciaAbrirForte?: number;
+  logger?: LoggerDebugBot;
 }
 
 export class DecisorJogadaBot implements DecisorJogada {
   private readonly quente: DecisorJogadaLinhaQuente;
   private readonly temperatura: number;
   private readonly urgenciaAbrirForte: number;
+  private readonly logger?: LoggerDebugBot;
 
   constructor(config: ConfigDecisorJogadaBot) {
     this.temperatura = config.temperatura;
     this.urgenciaAbrirForte = config.urgenciaAbrirForte ?? 0.5;
     this.quente = new DecisorJogadaLinhaQuente(config);
+    this.logger = config.logger;
   }
 
   async decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -29,10 +33,19 @@ export class DecisorJogadaBot implements DecisorJogada {
 
     const estadoAtual = estadoEmJogo(estado);
     if (estadoAtual.mesa.length === 0) {
-      return decidirAbertura(mao, estadoAtual, {
+      const carta = decidirAbertura(mao, estadoAtual, {
         temperatura: this.temperatura,
         urgenciaAbrirForte: this.urgenciaAbrirForte,
       });
+      this.logger?.registrarJogada({
+        estado,
+        mao,
+        linhaFria: carta,
+        linhaQuente: carta,
+        carta,
+        escolheuQuente: false,
+      });
+      return carta;
     }
 
     return this.quente.decidirJogada(mao, estado);

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -5,12 +5,15 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
 import { DecisorJogadaLinhaFria } from './DecisorJogadaLinhaFria';
+import type { LoggerDebugBot } from './logger-debug-bot';
+import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
 
 interface ConfigLinhaQuente {
   temperatura: number;
   rng: Pick<GeradorAleatorio, 'random'>;
   liderBaixa?: number;
   liderAlta?: number;
+  logger?: LoggerDebugBot;
 }
 
 export class DecisorJogadaLinhaQuente implements DecisorJogada {
@@ -19,12 +22,14 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   private readonly rng: Pick<GeradorAleatorio, 'random'>;
   private readonly liderBaixa: number;
   private readonly liderAlta: number;
+  private readonly logger?: LoggerDebugBot;
 
   constructor(config: ConfigLinhaQuente) {
     this.temperatura = config.temperatura;
     this.rng = config.rng;
     this.liderBaixa = config.liderBaixa ?? 8;
     this.liderAlta = config.liderAlta ?? 11;
+    this.logger = config.logger;
   }
 
   async decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -33,14 +38,31 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     const estadoAtual = estadoEmJogo(estado);
     const contexto = criarContexto(estadoAtual, mao);
     const empate = escolherEmpate(estadoAtual, contexto, this.liderAlta);
-    if (empate) return empate.carta;
+    if (empate) {
+      return registrarEscolhaDireta({ logger: this.logger, mao, estado, carta: empate.carta, escolheuQuente: true });
+    }
 
     const travessia = escolherTravessia(estadoAtual, contexto);
-    if (travessia) return travessia.carta;
+    if (travessia) {
+      return registrarEscolhaDireta({ logger: this.logger, mao, estado, carta: travessia.carta, escolheuQuente: true });
+    }
 
-    if (!podeBifurcar(estadoAtual, contexto, this.liderBaixa)) return this.fria.decidirJogada(mao, estado);
-    if (this.rng.random() >= this.temperatura) return this.fria.decidirJogada(mao, estado);
-    return escolherPressao(contexto).carta;
+    const fria = await this.fria.decidirJogada(mao, estado);
+    if (!podeBifurcar(estadoAtual, contexto, this.liderBaixa)) {
+      return registrarEscolhaDireta({ logger: this.logger, mao, estado, carta: fria, escolheuQuente: false });
+    }
+
+    const quente = escolherPressao(contexto).carta;
+    const sorteio = this.rng.random();
+    return registrarBifurcacao({
+      logger: this.logger,
+      temperatura: this.temperatura,
+      mao,
+      estado,
+      fria,
+      quente,
+      sorteio,
+    });
   }
 }
 

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -121,7 +121,7 @@ function simNao(valor: boolean): string {
 }
 
 function formatarSorteio(sorteio: number | undefined, quente: boolean, temperatura: number): string {
-  if (sorteio === undefined) return `RNG sorteou: ${quente ? 'quente' : 'fria'}`;
+  if (sorteio === undefined) return `Decisão determinística: linha ${quente ? 'quente' : 'fria'}`;
   const linha = quente ? 'quente' : 'fria';
   const comparacao = sorteio < temperatura ? 'sim' : 'não';
   return `RNG sorteou: ${linha} (${sorteio.toFixed(2)} < T=${temperatura.toFixed(2)}? ${comparacao} → ${linha})`;

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -65,7 +65,7 @@ function registrarJogada(nome: string, temperatura: number, decisao: DecisaoJoga
   );
   console.log(`Mesa: [${formatarMesa(estado.mesa)}]`);
   console.log(`Classificação: [${formatarAvaliadas(avaliadas)}]`);
-  console.log('Bifurcação: segurança para cumprir depois ✓, pressão disponível ✓');
+  console.log(formatarBifurcacao(decisao.sorteio));
   console.log(formatarLinhas(decisao));
   console.log(formatarSorteio(decisao.sorteio, decisao.escolheuQuente, temperatura));
   console.log(`→ Jogou: ${formatarCarta(decisao.carta)}`);
@@ -91,6 +91,11 @@ function formatarContagens(decisao: DecisaoDeclaracaoDebug): string {
   return `Seguras: ${seguras} | Altas consideradas: ${altas} (sorteou: ${simNao(
     decisao.sorteouAlta,
   )}) | +1 defensivo: ${simNao(decisao.defensivo)}`;
+}
+
+function formatarBifurcacao(sorteio: number | undefined): string {
+  if (sorteio === undefined) return 'Bifurcação: não ocorreu';
+  return 'Bifurcação: segurança para cumprir depois ✓, pressão disponível ✓';
 }
 
 function formatarTituloJogada(titulo: TituloJogada): string {

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -1,0 +1,128 @@
+import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { estadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
+/* eslint-disable no-console */
+
+export interface LoggerDebugBot {
+  registrarDeclaracao(decisao: DecisaoDeclaracaoDebug): void;
+  registrarJogada(decisao: DecisaoJogadaDebug): void;
+}
+
+export interface DecisaoDeclaracaoDebug {
+  mao: CartaAvaliada[];
+  seguras: number;
+  altas: number;
+  sorteouAlta: boolean;
+  defensivo: boolean;
+  declaracao: number;
+}
+
+export interface DecisaoJogadaDebug {
+  estado: EstadoRodada;
+  mao: Carta[];
+  linhaFria: Carta;
+  linhaQuente: Carta;
+  carta: Carta;
+  sorteio?: number;
+  escolheuQuente: boolean;
+}
+
+export function criarLoggerDebugBot(nome: string, temperatura: number): LoggerDebugBot {
+  return {
+    registrarDeclaracao: (decisao) => {
+      registrarDeclaracao(nome, temperatura, decisao);
+    },
+    registrarJogada: (decisao) => {
+      registrarJogada(nome, temperatura, decisao);
+    },
+  };
+}
+
+function registrarDeclaracao(nome: string, temperatura: number, decisao: DecisaoDeclaracaoDebug): void {
+  const prefixo = criarPrefixo(nome, temperatura);
+  console.groupCollapsed(`${prefixo} — DECLARAÇÃO`);
+  console.log(`Mão: [${formatarAvaliadas(decisao.mao)}]`);
+  console.log(formatarContagens(decisao));
+  console.log(`→ Declarou: ${decisao.declaracao.toString()}`);
+  console.groupEnd();
+}
+
+function registrarJogada(nome: string, temperatura: number, decisao: DecisaoJogadaDebug): void {
+  const estado = estadoEmJogo(decisao.estado);
+  const jogador = estado.maos[estado.jogadorAtual].jogador;
+  const necessidade = (estado.declaracoes[jogador.id] ?? 0) - (estado.vazas[jogador.id] ?? 0);
+  const folga = decisao.mao.length - necessidade;
+  const avaliadas = avaliarCartas(decisao.mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+  console.groupCollapsed(
+    formatarTituloJogada({
+      nome,
+      temperatura,
+      turno: estado.turno,
+      cartasPorRodada: estado.cartasPorRodada,
+      necessidade,
+      folga,
+    }),
+  );
+  console.log(`Mesa: [${formatarMesa(estado.mesa)}]`);
+  console.log(`Classificação: [${formatarAvaliadas(avaliadas)}]`);
+  console.log('Bifurcação: segurança para cumprir depois ✓, pressão disponível ✓');
+  console.log(formatarLinhas(decisao));
+  console.log(formatarSorteio(decisao.sorteio, decisao.escolheuQuente, temperatura));
+  console.log(`→ Jogou: ${formatarCarta(decisao.carta)}`);
+  console.groupEnd();
+}
+
+function criarPrefixo(nome: string, temperatura: number): string {
+  const emoji = temperatura < 0.3 ? '🔵' : temperatura > 0.7 ? '🔴' : '🟡';
+  return `${emoji} ${nome} (T=${temperatura.toFixed(2)})`;
+}
+
+function formatarAvaliadas(avaliadas: CartaAvaliada[]): string {
+  return avaliadas.map((avaliada) => `${formatarCarta(avaliada.carta)} ${avaliada.categoria}`).join(', ');
+}
+
+function formatarMesa(mesa: MesaItem[]): string {
+  return mesa.map((item) => `${item.jogadorId}: ${formatarCarta(item.carta)}`).join(', ');
+}
+
+function formatarContagens(decisao: DecisaoDeclaracaoDebug): string {
+  const seguras = decisao.seguras.toString();
+  const altas = decisao.altas.toString();
+  return `Seguras: ${seguras} | Altas consideradas: ${altas} (sorteou: ${simNao(
+    decisao.sorteouAlta,
+  )}) | +1 defensivo: ${simNao(decisao.defensivo)}`;
+}
+
+function formatarTituloJogada(titulo: TituloJogada): string {
+  return `${criarPrefixo(titulo.nome, titulo.temperatura)} — JOGADA (turno ${titulo.turno.toString()}/${titulo.cartasPorRodada.toString()}, necessário: ${titulo.necessidade.toString()}, folga: ${titulo.folga.toString()})`;
+}
+
+interface TituloJogada {
+  nome: string;
+  temperatura: number;
+  turno: number;
+  cartasPorRodada: number;
+  necessidade: number;
+  folga: number;
+}
+
+function formatarLinhas(decisao: DecisaoJogadaDebug): string {
+  return `Linha fria: jogar ${formatarCarta(decisao.linhaFria)} | Linha quente: jogar ${formatarCarta(
+    decisao.linhaQuente,
+  )}`;
+}
+
+function formatarCarta(carta: Carta): string {
+  return `${carta.valor}${carta.naipe}`;
+}
+
+function simNao(valor: boolean): string {
+  return valor ? 'sim' : 'não';
+}
+
+function formatarSorteio(sorteio: number | undefined, quente: boolean, temperatura: number): string {
+  if (sorteio === undefined) return `RNG sorteou: ${quente ? 'quente' : 'fria'}`;
+  const linha = quente ? 'quente' : 'fria';
+  const comparacao = sorteio < temperatura ? 'sim' : 'não';
+  return `RNG sorteou: ${linha} (${sorteio.toFixed(2)} < T=${temperatura.toFixed(2)}? ${comparacao} → ${linha})`;
+}

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -1,0 +1,48 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoRodada } from '@/types/estado-rodada';
+import type { LoggerDebugBot } from './logger-debug-bot';
+
+interface EscolhaDireta {
+  logger?: LoggerDebugBot;
+  mao: Carta[];
+  estado: EstadoRodada;
+  carta: Carta;
+  escolheuQuente: boolean;
+}
+
+interface Bifurcacao {
+  logger?: LoggerDebugBot;
+  temperatura: number;
+  mao: Carta[];
+  estado: EstadoRodada;
+  fria: Carta;
+  quente: Carta;
+  sorteio: number;
+}
+
+export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
+  config.logger?.registrarJogada({
+    mao: config.mao,
+    estado: config.estado,
+    linhaFria: config.carta,
+    linhaQuente: config.carta,
+    carta: config.carta,
+    escolheuQuente: config.escolheuQuente,
+  });
+  return config.carta;
+}
+
+export function registrarBifurcacao(config: Bifurcacao): Carta {
+  const escolheuQuente = config.sorteio < config.temperatura;
+  const carta = escolheuQuente ? config.quente : config.fria;
+  config.logger?.registrarJogada({
+    mao: config.mao,
+    estado: config.estado,
+    linhaFria: config.fria,
+    linhaQuente: config.quente,
+    carta,
+    escolheuQuente,
+    sorteio: config.sorteio,
+  });
+  return carta;
+}

--- a/src/adapters/phaser/factories/rodada-factory.ts
+++ b/src/adapters/phaser/factories/rodada-factory.ts
@@ -1,5 +1,6 @@
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
+import { criarLoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
 import { aplicarPerfisBots, sortearPerfisBots } from '@/adapters/bots/perfil-bot';
 import { Partida } from '@/core/Partida';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
@@ -11,33 +12,50 @@ import { subscreverEventos, type CallbacksRodada } from './subscricao-eventos-ro
 
 export type { CallbacksRodada } from './subscricao-eventos-rodada';
 
-function criarDecisores(
-  decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
-  jogadores: Jogador[],
-  rng: GeradorAleatorio,
-): {
+interface ConfigDecisores {
+  humanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao };
+  jogadores: Jogador[];
+  rng: GeradorAleatorio;
+  modoDebug: boolean;
+}
+
+interface CallbacksPartida extends CallbacksRodada {
+  modoDebug?: boolean;
+}
+
+function criarDecisores(config: ConfigDecisores): {
   jogada: Map<string, DecisorJogada>;
   declaracao: Map<string, DecisorDeclaracao>;
 } {
-  const jogada = new Map<string, DecisorJogada>([['humano', decisoresHumanos.jogada]]);
-  const declaracao = new Map<string, DecisorDeclaracao>([['humano', decisoresHumanos.declaracao]]);
-  jogadores.forEach((jogador) => {
+  const jogada = new Map<string, DecisorJogada>([['humano', config.humanos.jogada]]);
+  const declaracao = new Map<string, DecisorDeclaracao>([['humano', config.humanos.declaracao]]);
+  config.jogadores.forEach((jogador) => {
     if (!jogador.id.startsWith('bot') || jogador.temperatura === undefined) return;
-    jogada.set(jogador.id, new DecisorJogadaBot({ temperatura: jogador.temperatura, rng }));
-    declaracao.set(jogador.id, new DecisorDeclaracaoBot(jogador.temperatura, rng));
+    const logger = config.modoDebug ? criarLoggerDebugBot(jogador.nome, jogador.temperatura) : undefined;
+    jogada.set(jogador.id, new DecisorJogadaBot({ temperatura: jogador.temperatura, rng: config.rng, logger }));
+    declaracao.set(jogador.id, new DecisorDeclaracaoBot(jogador.temperatura, config.rng, { ...parametros(logger) }));
   });
   return { jogada, declaracao };
+}
+
+function parametros(logger: ReturnType<typeof criarLoggerDebugBot> | undefined) {
+  return { poucasBaixas: 1, declaracaoBaixa: 1, logger };
 }
 
 export function fabricarPartida(
   jogadores: Jogador[],
   decisoresHumanos: { jogada: DecisorJogada; declaracao: DecisorDeclaracao },
-  callbacks: CallbacksRodada,
+  callbacks: CallbacksPartida,
 ): Partida {
   const emissor = createEmissorEventos();
   subscreverEventos(emissor, callbacks);
   const rng = new RngComSeed(Date.now());
   const jogadoresComBots = aplicarPerfisBots(jogadores, sortearPerfisBots(jogadores, rng));
-  const decisores = criarDecisores(decisoresHumanos, jogadoresComBots, rng);
+  const decisores = criarDecisores({
+    humanos: decisoresHumanos,
+    jogadores: jogadoresComBots,
+    rng,
+    modoDebug: callbacks.modoDebug ?? false,
+  });
   return new Partida(jogadoresComBots, emissor, { ...decisores, rng });
 }

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -64,6 +64,7 @@ export class JogoScene extends Scene {
       objetosDeclaracao: this.objetosDeclaracao,
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
+      modoDebug: Boolean(this.game.registry.get('modoDebug')),
     };
   }
 

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -24,6 +24,7 @@ export interface DependenciasCena {
   objetosDeclaracao: Phaser.GameObjects.GameObject[];
   getLabels: () => Phaser.GameObjects.Text[];
   getDirecoesLabels: () => ('horizontal' | 'vertical')[];
+  modoDebug: boolean;
 }
 
 export class JogoController {
@@ -66,6 +67,7 @@ export class JogoController {
           this.deps.desativarResize();
           this.deps.mostrarFimJogo(classificacao);
         },
+        modoDebug: this.deps.modoDebug,
       },
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,11 @@ function obterDpr(): number {
   return window.devicePixelRatio || 1;
 }
 
+function obterModoDebug(): boolean {
+  const debug = new URLSearchParams(window.location.search).get('debug');
+  return debug === 'true' || debug === '1';
+}
+
 function criarConfiguracaoJogo(containerId?: string): Phaser.Types.Core.GameConfig {
   const dpr = obterDpr();
   return {
@@ -27,6 +32,7 @@ function criarConfiguracaoJogo(containerId?: string): Phaser.Types.Core.GameConf
 
 export function inicializarJogo(containerId?: string): Game {
   jogo = new Game(criarConfiguracaoJogo(containerId));
+  jogo.registry.set('modoDebug', obterModoDebug());
 
   aoRedimensionar = (): void => {
     if (!jogo) return;

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -38,6 +38,23 @@ function estado(): EstadoRodada {
   };
 }
 
+function estadoJogada(): EstadoRodada {
+  const rodada = estado();
+  if (rodada.fase !== 'aguardandoDeclaracao') return rodada;
+  return { ...rodada, fase: 'aguardandoJogada' };
+}
+
+function registrarJogadaDireta(): void {
+  criarLoggerDebugBot('Brás', 0.35).registrarJogada({
+    estado: estadoJogada(),
+    mao,
+    linhaFria: mao[0],
+    linhaQuente: mao[0],
+    carta: mao[0],
+    escolheuQuente: false,
+  });
+}
+
 describe('Logger debug dos bots', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -83,17 +100,17 @@ describe('Logger debug das jogadas dos bots', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
     vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
-    const logger = criarLoggerDebugBot('Brás', 0.35);
-
-    logger.registrarJogada({
-      estado: { ...estado(), fase: 'jogando' },
-      mao,
-      linhaFria: mao[0],
-      linhaQuente: mao[0],
-      carta: mao[0],
-      escolheuQuente: false,
-    });
+    registrarJogadaDireta();
 
     expect(log).toHaveBeenCalledWith('Decisão determinística: linha fria');
+  });
+
+  it('deve registrar bifurcação ausente em escolhas diretas', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+    registrarJogadaDireta();
+
+    expect(log).toHaveBeenCalledWith('Bifurcação: não ocorreu');
   });
 });

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
+import { criarLoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
+import type { Carta } from '@/core/Carta';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+
+const mao: Carta[] = [
+  { valor: '4', naipe: '♦' },
+  { valor: '3', naipe: '♣' },
+];
+
+function rng(valor: number): GeradorAleatorio {
+  return {
+    random: vi.fn(() => valor),
+    randomInt: vi.fn(() => 0),
+    shuffle: <T>(cartas: T[]) => [...cartas],
+  };
+}
+
+function estado(): EstadoRodada {
+  return {
+    fase: 'aguardandoDeclaracao',
+    pontos: { humano: 5, bot1: 5 },
+    cartasPorRodada: 2,
+    jogadorAtual: 1,
+    cartaVirada: { valor: 'Q', naipe: '♦' },
+    manilha: 'K',
+    maos: [
+      { jogador: { id: 'humano', nome: 'Você', pontos: 5 }, cartas: [], visivel: true },
+      { jogador: { id: 'bot1', nome: 'Brás', pontos: 5, temperatura: 0.35 }, cartas: mao, visivel: true },
+    ],
+    mesa: [],
+    declaracoes: {},
+    vazas: {},
+    cartasReveladas: mao,
+    turno: 1,
+  };
+}
+
+describe('Logger debug dos bots', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deve manter zero logs quando logger não é injetado', async () => {
+    const group = vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const decisor = new DecisorDeclaracaoBot(0.35, rng(0.1));
+
+    await decisor.declarar(estado(), mao);
+
+    expect(group).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('deve formatar decisão com groupCollapsed quando modo debug está ativo', async () => {
+    const group = vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+    const logger = criarLoggerDebugBot('Brás', 0.35);
+    const decisor = new DecisorDeclaracaoBot(0.35, rng(0.1), {
+      poucasBaixas: 1,
+      declaracaoBaixa: 1,
+      logger,
+    });
+
+    await decisor.declarar(estado(), mao);
+
+    expect(group).toHaveBeenCalledWith('🟡 Brás (T=0.35) — DECLARAÇÃO');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Mão: ['));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Seguras:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('→ Declarou:'));
+  });
+});

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -73,3 +73,27 @@ describe('Logger debug dos bots', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('→ Declarou:'));
   });
 });
+
+describe('Logger debug das jogadas dos bots', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deve registrar decisão determinística quando jogada não sorteia RNG', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+    const logger = criarLoggerDebugBot('Brás', 0.35);
+
+    logger.registrarJogada({
+      estado: { ...estado(), fase: 'jogando' },
+      mao,
+      linhaFria: mao[0],
+      linhaQuente: mao[0],
+      carta: mao[0],
+      escolheuQuente: false,
+    });
+
+    expect(log).toHaveBeenCalledWith('Decisão determinística: linha fria');
+  });
+});


### PR DESCRIPTION
## Resumo

- Lê `?debug=true` / `?debug=1` no boot e propaga `modoDebug` até o factory da partida.
- Injeta logger opcional nos decisores dos bots quando debug está ativo.
- Loga declarações e jogadas com `console.groupCollapsed`, nome/temperatura e detalhes da decisão.
- Adiciona testes para garantir zero logs sem debug e formato básico com debug.

## Validação

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional debug logging mode to track bot decision-making in real-time via console output. Enable debug mode by adding `?debug=true` to the game URL. Displays detailed information about bot declarations and card selections during gameplay.

* **Tests**
  * Added comprehensive test coverage for debug logging functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->