### PR TITLE
fix: corrigir declaração dos bots

### DIFF
--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -114,9 +114,7 @@ function ehCategoriaForte(categoria: CategoriaCarta): boolean {
 }
 
 function cartasVisiveisDosOutros(estado: EstadoEmJogo): Carta[] {
-  return estado.maos
-    .filter((mao, indice) => indice !== estado.jogadorAtual && mao.visivel)
-    .flatMap((mao) => mao.cartas);
+  return estado.maos.filter((_, indice) => indice !== estado.jogadorAtual).flatMap((mao) => mao.cartas);
 }
 
 function cartasPublicas(estado: EstadoRodada): Carta[] {

--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -61,7 +61,7 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
   private declararPrimeiraRodada(estado: EstadoRodada): number {
     const emJogo = estadoEmJogo(estado);
     const visiveis = cartasVisiveisDosOutros(emJogo);
-    const avaliadas = avaliarCartas(visiveis, emJogo.manilha, [], emJogo.maos.length);
+    const avaliadas = visiveis.flatMap((carta) => avaliarCartas([carta], emJogo.manilha, [], emJogo.maos.length));
     const temAltaVisivel = avaliadas.some((avaliada) => ehCategoriaForte(avaliada.categoria));
     const declaracao = temAltaVisivel ? 0 : 1;
 

--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -1,8 +1,8 @@
-import { avaliarCartas, type CategoriaCarta } from '@/core/avaliador-carta';
+import { avaliarCartas, type CartaAvaliada, type CategoriaCarta } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { DecisorDeclaracao } from '@/core/portas/DecisorDeclaracao';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
-import type { EstadoRodada } from '@/types/estado-rodada';
+import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import type { LoggerDebugBot } from './logger-debug-bot';
 
 export interface ParametrosDeclaracaoBot {
@@ -31,51 +31,92 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
 
   declarar(estado: EstadoRodada, mao: Carta[]): Promise<number> {
     if (estado.fase === 'distribuindo') return Promise.resolve(0);
+    if (estado.cartasPorRodada === 1) return Promise.resolve(this.declararPrimeiraRodada(estado));
 
     const avaliadas = avaliarCartas(mao, estado.manilha, cartasPublicas(estado), estado.maos.length);
-    const contagemSegura = contarCategorias(
-      avaliadas.map((avaliada) => avaliada.categoria),
-      ['segura', 'garantida_agora'],
-    );
+    const segurasContadas = filtrarCategorias(avaliadas, ['segura', 'garantida_agora']);
+    const altasCandidatas = filtrarCategorias(avaliadas, ['alta']);
     const altasSorteadas = avaliadas
       .filter((avaliada) => avaliada.categoria === 'alta')
-      .map(() => this.sortearContagem());
+      .map((avaliada) => ({ carta: avaliada, conta: this.deveContar() }));
     const contagemAltas = altasSorteadas.filter((sorteio) => sorteio.conta).length;
-    const defensivo = this.deveDeclararDefensivo(
-      avaliadas.map((avaliada) => avaliada.categoria),
-      contagemSegura + contagemAltas,
-    );
-    const contagemDefensiva = defensivo ? 1 : 0;
-    const declaracao = Math.min(mao.length, Math.max(0, contagemSegura + contagemAltas + contagemDefensiva));
+    const base = segurasContadas.length + contagemAltas;
+    const defensivo = this.avaliarDefensivo(avaliadas, base, estado.cartasPorRodada);
+    const contagemDefensiva = defensivo.estado === 'aplicado' ? 1 : 0;
+    const declaracao = Math.min(mao.length, Math.max(0, base + contagemDefensiva));
 
     this.logger?.registrarDeclaracao({
       mao: avaliadas,
-      seguras: contagemSegura,
-      altas: contagemAltas,
-      sorteouAlta: altasSorteadas.some((sorteio) => sorteio.conta),
+      segurasContadas,
+      altasCandidatas,
+      sorteiosAltas: altasSorteadas,
       defensivo,
       declaracao,
+      regraEspecialPrimeiraRodada: false,
     });
 
     return Promise.resolve(declaracao);
   }
 
-  private deveDeclararDefensivo(categorias: CategoriaCarta[], declaracao: number): boolean {
-    const baixas = contarCategorias(categorias, ['baixa']);
-    return declaracao <= this.parametros.declaracaoBaixa && baixas <= this.parametros.poucasBaixas && this.deveContar();
+  private declararPrimeiraRodada(estado: EstadoRodada): number {
+    const emJogo = estadoEmJogo(estado);
+    const visiveis = cartasVisiveisDosOutros(emJogo);
+    const avaliadas = avaliarCartas(visiveis, emJogo.manilha, [], emJogo.maos.length);
+    const temAltaVisivel = avaliadas.some((avaliada) => ehCategoriaForte(avaliada.categoria));
+    const declaracao = temAltaVisivel ? 0 : 1;
+
+    this.logger?.registrarDeclaracao({
+      mao: avaliadas,
+      segurasContadas: filtrarCategorias(avaliadas, ['segura', 'garantida_agora']),
+      altasCandidatas: filtrarCategorias(avaliadas, ['alta']),
+      sorteiosAltas: [],
+      defensivo: { estado: 'não elegível' },
+      declaracao,
+      regraEspecialPrimeiraRodada: true,
+    });
+
+    return declaracao;
+  }
+
+  private avaliarDefensivo(avaliadas: CartaAvaliada[], declaracao: number, cartasPorRodada: number) {
+    if (!this.ehElegivelDefensivo(avaliadas, declaracao)) return { estado: 'não elegível' as const };
+    const aplicaria = this.deveContar();
+    if (!aplicaria) return { estado: 'sorteou' as const, aplicaria };
+    const resultado = declaracao + 1;
+    const teto = Math.floor(cartasPorRodada / 2);
+    if (resultado > teto) return { estado: 'bloqueado' as const, base: declaracao, teto, resultado, cartasPorRodada };
+    return { estado: 'aplicado' as const };
+  }
+
+  private ehElegivelDefensivo(avaliadas: CartaAvaliada[], declaracao: number): boolean {
+    const baixas = contarCategorias(
+      avaliadas.map((avaliada) => avaliada.categoria),
+      ['baixa'],
+    );
+    return declaracao <= this.parametros.declaracaoBaixa && baixas <= this.parametros.poucasBaixas;
   }
 
   private deveContar(): boolean {
     return this.rng.random() < 1 - this.temperatura;
   }
-
-  private sortearContagem(): { conta: boolean } {
-    return { conta: this.deveContar() };
-  }
 }
 
 function contarCategorias(categorias: CategoriaCarta[], esperadas: CategoriaCarta[]): number {
   return categorias.filter((categoria) => esperadas.includes(categoria)).length;
+}
+
+function filtrarCategorias(avaliadas: CartaAvaliada[], esperadas: CategoriaCarta[]): CartaAvaliada[] {
+  return avaliadas.filter((avaliada) => esperadas.includes(avaliada.categoria));
+}
+
+function ehCategoriaForte(categoria: CategoriaCarta): boolean {
+  return ['alta', 'segura', 'garantida_agora'].includes(categoria);
+}
+
+function cartasVisiveisDosOutros(estado: EstadoEmJogo): Carta[] {
+  return estado.maos
+    .filter((mao, indice) => indice !== estado.jogadorAtual && mao.visivel)
+    .flatMap((mao) => mao.cartas);
 }
 
 function cartasPublicas(estado: EstadoRodada): Carta[] {

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -10,12 +10,24 @@ export interface LoggerDebugBot {
 
 export interface DecisaoDeclaracaoDebug {
   mao: CartaAvaliada[];
-  seguras: number;
-  altas: number;
-  sorteouAlta: boolean;
-  defensivo: boolean;
+  segurasContadas: CartaAvaliada[];
+  altasCandidatas: CartaAvaliada[];
+  sorteiosAltas: SorteioAltaDebug[];
+  defensivo: DefensivoDebug;
   declaracao: number;
+  regraEspecialPrimeiraRodada: boolean;
 }
+
+export interface SorteioAltaDebug {
+  carta: CartaAvaliada;
+  conta: boolean;
+}
+
+export type DefensivoDebug =
+  | { estado: 'não elegível' }
+  | { estado: 'sorteou'; aplicaria: boolean }
+  | { estado: 'bloqueado'; base: number; teto: number; resultado: number; cartasPorRodada: number }
+  | { estado: 'aplicado' };
 
 export interface DecisaoJogadaDebug {
   estado: EstadoRodada;
@@ -41,6 +53,9 @@ export function criarLoggerDebugBot(nome: string, temperatura: number): LoggerDe
 function registrarDeclaracao(nome: string, temperatura: number, decisao: DecisaoDeclaracaoDebug): void {
   const prefixo = criarPrefixo(nome, temperatura);
   console.groupCollapsed(`${prefixo} — DECLARAÇÃO`);
+  if (decisao.regraEspecialPrimeiraRodada) {
+    console.log('Regra especial N=1: própria carta oculta não entrou no cálculo');
+  }
   console.log(`Mão: [${formatarAvaliadas(decisao.mao)}]`);
   console.log(formatarContagens(decisao));
   console.log(`→ Declarou: ${decisao.declaracao.toString()}`);
@@ -86,11 +101,25 @@ function formatarMesa(mesa: MesaItem[]): string {
 }
 
 function formatarContagens(decisao: DecisaoDeclaracaoDebug): string {
-  const seguras = decisao.seguras.toString();
-  const altas = decisao.altas.toString();
-  return `Seguras: ${seguras} | Altas consideradas: ${altas} (sorteou: ${simNao(
-    decisao.sorteouAlta,
-  )}) | +1 defensivo: ${simNao(decisao.defensivo)}`;
+  return [
+    `Seguras contadas: [${formatarAvaliadas(decisao.segurasContadas)}] (${decisao.segurasContadas.length.toString()})`,
+    `Altas candidatas: [${formatarAvaliadas(decisao.altasCandidatas)}] (${decisao.altasCandidatas.length.toString()})`,
+    formatarAltasSorteadas(decisao.sorteiosAltas),
+    `+1 defensivo: ${formatarDefensivo(decisao.defensivo)}`,
+  ].join(' | ');
+}
+
+function formatarAltasSorteadas(sorteios: SorteioAltaDebug[]): string {
+  const consideradas = sorteios.filter((sorteio) => sorteio.conta).map((sorteio) => sorteio.carta);
+  const porCarta = sorteios.map((sorteio) => `${formatarCarta(sorteio.carta.carta)} ${simNao(sorteio.conta)}`);
+  return `Altas consideradas: [${formatarAvaliadas(consideradas)}] (${consideradas.length.toString()}/${sorteios.length.toString()}) | Sorteios de altas: ${porCarta.join(', ')}`;
+}
+
+function formatarDefensivo(defensivo: DefensivoDebug): string {
+  if (defensivo.estado === 'não elegível') return defensivo.estado;
+  if (defensivo.estado === 'sorteou') return `sorteou: ${simNao(defensivo.aplicaria)}`;
+  if (defensivo.estado === 'aplicado') return defensivo.estado;
+  return `bloqueado (base=${defensivo.base.toString()}, teto=floor(${defensivo.cartasPorRodada.toString()}/2)=${defensivo.teto.toString()}, aplicar +1 resultaria em ${defensivo.resultado.toString()})`;
 }
 
 function formatarBifurcacao(sorteio: number | undefined): string {

--- a/src/core/avaliador-carta.ts
+++ b/src/core/avaliador-carta.ts
@@ -21,7 +21,7 @@ export interface ParametrosAvaliacaoCarta {
 export const parametrosAvaliacaoPadrao: ParametrosAvaliacaoCarta = {
   limiarBaixa: 5.6,
   limiarAlta: 11,
-  limiarSegura: 20,
+  limiarSegura: 12,
   pesoDensidade: 3,
   baseManilha: 14,
 };

--- a/tests/adapters/DecisorDeclaracaoBot.test.ts
+++ b/tests/adapters/DecisorDeclaracaoBot.test.ts
@@ -5,7 +5,7 @@ import { RngComSeed, type GeradorAleatorio } from '@/core/RngComSeed';
 import type { EstadoRodada } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 
-function criarEstado(mao: Carta[], cartasReveladas: Carta[] = []): EstadoRodada {
+function criarEstado(mao: Carta[], cartasReveladas: Carta[] = [], cartasPorRodada = mao.length): EstadoRodada {
   const jogador = criarJogador('bot1', 'Bot 1');
   return {
     fase: 'aguardandoDeclaracao',
@@ -17,7 +17,7 @@ function criarEstado(mao: Carta[], cartasReveladas: Carta[] = []): EstadoRodada 
       { jogador: criarJogador('bot3', 'Bot 3'), cartas: [], visivel: true },
       { jogador: criarJogador('bot4', 'Bot 4'), cartas: [], visivel: true },
     ],
-    cartasPorRodada: mao.length,
+    cartasPorRodada,
     manilha: '4',
     cartaVirada: null,
     declaracoes: {},
@@ -49,7 +49,7 @@ describe('DecisorDeclaracaoBot', () => {
   it('deve declarar apenas seguras para bot quente', async () => {
     const decisor = new DecisorDeclaracaoBot(1, criarRng([0, 0]));
 
-    await expect(decisor.declarar(criarEstado(maoForte), maoForte)).resolves.toBe(2);
+    await expect(decisor.declarar(criarEstado(maoForte), maoForte)).resolves.toBe(3);
   });
 
   it('deve produzir resultado determinístico com seed fixa', async () => {
@@ -61,6 +61,31 @@ describe('DecisorDeclaracaoBot', () => {
   });
 });
 
+describe('DecisorDeclaracaoBot na primeira rodada', () => {
+  it('deve ignorar carta própria forte oculta e declarar 1 sem altas visíveis', async () => {
+    const mao = [criarCarta('4', '♣')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao, [], 1), mao)).resolves.toBe(1);
+  });
+
+  it('deve declarar 0 quando vê carta alta de outro jogador', async () => {
+    const mao = [criarCarta('5', '♦')];
+    const visiveis = [criarCarta('3', '♣')];
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao, visiveis, 1), mao)).resolves.toBe(0);
+  });
+
+  it('deve declarar 1 quando não vê cartas altas de outros jogadores', async () => {
+    const mao = [criarCarta('5', '♦')];
+    const visiveis = [criarCarta('6', '♦')];
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao, visiveis, 1), mao)).resolves.toBe(1);
+  });
+});
+
 describe('DecisorDeclaracaoBot com cartas reveladas', () => {
   it('não deve usar cartas visíveis da mão humana para declarar', async () => {
     const mao = [criarCarta('Q', '♣')];
@@ -68,18 +93,33 @@ describe('DecisorDeclaracaoBot com cartas reveladas', () => {
     const decisorComCartasHumanas = new DecisorDeclaracaoBot(0, criarRng([0]));
     const decisorSemCartasHumanas = new DecisorDeclaracaoBot(0, criarRng([0]));
 
-    await expect(decisorComCartasHumanas.declarar(criarEstado(mao, cartasHumanas), mao)).resolves.toBe(
-      await decisorSemCartasHumanas.declarar(criarEstado(mao), mao),
+    await expect(decisorComCartasHumanas.declarar(criarEstado(mao, cartasHumanas, 2), mao)).resolves.toBe(
+      await decisorSemCartasHumanas.declarar(criarEstado(mao, [], 2), mao),
     );
   });
 });
 
+describe('DecisorDeclaracaoBot com altas candidatas', () => {
+  it('deve sortear cada carta alta individualmente e respeitar o parcial', async () => {
+    const mao = [
+      criarCarta('3', '♣'),
+      criarCarta('3', '♥'),
+      criarCarta('3', '♠'),
+      criarCarta('3', '♦'),
+      criarCarta('6', '♦'),
+    ];
+    const decisor = new DecisorDeclaracaoBot(0.5, criarRng([0.1, 0.9, 0.2, 0.8, 0.9]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(2);
+  });
+});
+
 describe('DecisorDeclaracaoBot com limites', () => {
-  it('deve somar um defensivo quando tem poucas baixas e declaração baixa', async () => {
+  it('deve bloquear defensivo quando N=2 passaria do teto', async () => {
     const mao = [criarCarta('3', '♣'), criarCarta('Q', '♣')];
     const decisor = new DecisorDeclaracaoBot(0, criarRng([0, 0]));
 
-    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(2);
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(1);
   });
 
   it('não deve exceder o número de cartas da rodada', async () => {
@@ -94,6 +134,36 @@ describe('DecisorDeclaracaoBot com limites', () => {
     const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
 
     await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(0);
+  });
+});
+
+describe('DecisorDeclaracaoBot com teto defensivo', () => {
+  it('não deve aplicar defensivo em N=1', async () => {
+    const mao = [criarCarta('6', '♦')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao, [], 1), mao)).resolves.toBe(1);
+  });
+
+  it('deve bloquear defensivo em N=2 quando passaria do teto', async () => {
+    const mao = [criarCarta('3', '♣'), criarCarta('6', '♦')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(1);
+  });
+
+  it('deve bloquear defensivo em N=3 quando passaria do teto', async () => {
+    const mao = [criarCarta('3', '♣'), criarCarta('6', '♦'), criarCarta('7', '♦')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(1);
+  });
+
+  it('deve permitir defensivo em N=4 quando respeita o teto', async () => {
+    const mao = [criarCarta('3', '♣'), criarCarta('K', '♦'), criarCarta('Q', '♦'), criarCarta('J', '♦')];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(2);
   });
 });
 

--- a/tests/adapters/DecisorDeclaracaoBot.test.ts
+++ b/tests/adapters/DecisorDeclaracaoBot.test.ts
@@ -77,6 +77,13 @@ describe('DecisorDeclaracaoBot na primeira rodada', () => {
     await expect(decisor.declarar(criarEstado(mao, visiveis, 1), mao)).resolves.toBe(0);
   });
 
+  it('deve considerar carta forte do humano mesmo quando a UI oculta sua mão', async () => {
+    const mao = [criarCarta('5', '♦')];
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstadoComHumanoOculto(mao, [criarCarta('3', '♣')]), mao)).resolves.toBe(0);
+  });
+
   it('deve declarar 1 quando não vê cartas altas de outros jogadores', async () => {
     const mao = [criarCarta('5', '♦')];
     const visiveis = [criarCarta('6', '♦')];
@@ -184,4 +191,27 @@ function criarCartasHumanasVisiveis(): Carta[] {
     criarCarta('3', '♦'),
     criarCarta('2', '♣'),
   ];
+}
+
+function criarEstadoComHumanoOculto(mao: Carta[], cartasHumanas: Carta[]): EstadoRodada {
+  const jogador = criarJogador('bot1', 'Bot 1');
+  return {
+    fase: 'aguardandoDeclaracao',
+    jogadorAtual: 0,
+    pontos: { bot1: 5, humano: 5, bot3: 5, bot4: 5 },
+    maos: [
+      { jogador, cartas: mao, visivel: true },
+      { jogador: criarJogador('humano', 'Humano'), cartas: cartasHumanas, visivel: false },
+      { jogador: criarJogador('bot3', 'Bot 3'), cartas: [], visivel: true },
+      { jogador: criarJogador('bot4', 'Bot 4'), cartas: [], visivel: true },
+    ],
+    cartasPorRodada: 1,
+    manilha: '4',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 0,
+  };
 }

--- a/tests/adapters/DecisorDeclaracaoBot.test.ts
+++ b/tests/adapters/DecisorDeclaracaoBot.test.ts
@@ -84,6 +84,14 @@ describe('DecisorDeclaracaoBot na primeira rodada', () => {
 
     await expect(decisor.declarar(criarEstado(mao, visiveis, 1), mao)).resolves.toBe(1);
   });
+
+  it('deve avaliar cada carta visível como N=1', async () => {
+    const mao = [criarCarta('5', '♦')];
+    const visiveis = [criarCarta('3', '♦'), criarCarta('6', '♦'), criarCarta('7', '♦')];
+    const decisor = new DecisorDeclaracaoBot(1, criarRng([0]));
+
+    await expect(decisor.declarar(criarEstado(mao, visiveis, 1), mao)).resolves.toBe(0);
+  });
 });
 
 describe('DecisorDeclaracaoBot com cartas reveladas', () => {

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -70,6 +70,12 @@ describe('Logger debug dos bots', () => {
     expect(group).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
   });
+});
+
+describe('Logger debug da declaração dos bots', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('deve formatar decisão com groupCollapsed quando modo debug está ativo', async () => {
     const group = vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
@@ -86,7 +92,9 @@ describe('Logger debug dos bots', () => {
 
     expect(group).toHaveBeenCalledWith('🟡 Brás (T=0.35) — DECLARAÇÃO');
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Mão: ['));
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Seguras:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Seguras contadas:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Altas candidatas:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Sorteios de altas:'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('→ Declarou:'));
   });
 });

--- a/tests/core/avaliador-carta.test.ts
+++ b/tests/core/avaliador-carta.test.ts
@@ -8,23 +8,43 @@ describe('avaliador-carta', () => {
 
     expect(avaliada.categoria).toBe('baixa');
   });
+});
 
-  it('deve classificar 3 de paus não-manilha como alta', () => {
-    const [avaliada] = avaliarCartas([criarCarta('3', '♣')], '4', [], 4);
+describe('avaliador-carta com seguras em rodadas pequenas', () => {
+  it('deve classificar 3 de paus não-manilha como segura em N=3 com 4 jogadores', () => {
+    const mao = [criarCarta('3', '♣'), criarCarta('K', '♦'), criarCarta('Q', '♦')];
 
-    expect(avaliada.categoria).toBe('alta');
-  });
-
-  it('deve classificar manilha de paus como segura', () => {
-    const [avaliada] = avaliarCartas([criarCarta('4', '♣')], '4', [], 4);
+    const [avaliada] = avaliarCartas(mao, '4', [], 4);
 
     expect(avaliada.categoria).toBe('segura');
   });
 
-  it('deve classificar manilha de ouros como alta', () => {
-    const [avaliada] = avaliarCartas([criarCarta('4', '♦')], '4', [], 4);
+  it('deve classificar 3 de paus não-manilha abaixo de segura em N=5 com 4 jogadores', () => {
+    const mao = [
+      criarCarta('3', '♣'),
+      criarCarta('K', '♦'),
+      criarCarta('Q', '♦'),
+      criarCarta('J', '♦'),
+      criarCarta('10', '♦'),
+    ];
+
+    const [avaliada] = avaliarCartas(mao, '4', [], 4);
 
     expect(avaliada.categoria).toBe('alta');
+  });
+
+  it('deve classificar 3 de paus não-manilha como segura em N=1', () => {
+    const [avaliada] = avaliarCartas([criarCarta('3', '♣')], '4', [], 4);
+
+    expect(avaliada.categoria).toBe('segura');
+  });
+
+  it('deve classificar todas as manilhas como seguras em N=3 com 4 jogadores', () => {
+    const mao = [criarCarta('4', '♣'), criarCarta('4', '♥'), criarCarta('4', '♠'), criarCarta('4', '♦')];
+
+    const avaliadas = avaliarCartas(mao, '4', [], 4);
+
+    expect(avaliadas.map((avaliada) => avaliada.categoria)).toEqual(['segura', 'segura', 'segura', 'segura']);
   });
 });
 
@@ -40,7 +60,7 @@ describe('avaliador-carta com ajustes', () => {
     );
 
     expect(semReveladas[0].categoria).toBe('média');
-    expect(comReveladas[0].categoria).toBe('alta');
+    expect(comReveladas[0].categoria).toBe('segura');
   });
 });
 
@@ -90,6 +110,10 @@ describe('avaliador-carta contextual', () => {
 });
 
 describe('parametrosAvaliacaoPadrao', () => {
+  it('deve usar limiar seguro base 12', () => {
+    expect(parametrosAvaliacaoPadrao.limiarSegura).toBe(12);
+  });
+
   it('deve exportar parâmetros padrão editáveis separadamente', () => {
     expect(typeof parametrosAvaliacaoPadrao.baseManilha).toBe('number');
     expect(typeof parametrosAvaliacaoPadrao.limiarAlta).toBe('number');


### PR DESCRIPTION
Closes #171

## Summary

- aplica regra especial de declaração em N=1 usando apenas cartas visíveis dos outros jogadores
- reduz `limiarSegura` base para 12 e mantém ajuste por densidade
- torna altas candidatas auditáveis com sorteio por carta e limita o +1 defensivo ao teto `floor(N / 2)`
- expande o debug de declaração com listas nominais e estados do defensivo

## Checks

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced bot declaration logic with improved evaluation and defensive strategy handling.
  * Updated card evaluation thresholds to better categorize safe cards in gameplay decisions.

* **Documentation**
  * Expanded debug logging to display detailed declaration decision breakdowns, including evaluated cards and sorting decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->