### PR TITLE
fix: remover inflação por superiores reveladas

### DIFF
--- a/src/core/avaliador-carta.ts
+++ b/src/core/avaliador-carta.ts
@@ -71,20 +71,16 @@ interface ContextoAvaliacao {
 }
 
 function avaliarCarta(contexto: ContextoAvaliacao): CartaAvaliada {
-  const { carta, manilha, cartasReveladas } = contexto;
-  const score = calcularScore(carta, manilha, cartasReveladas);
+  const { carta, manilha } = contexto;
+  const score = calcularScore(carta, manilha);
   const categoria = obterCategoria({ ...contexto, score });
   return { carta, score, categoria };
 }
 
-function calcularScore(carta: Carta, manilha: Valor, cartasReveladas: Carta[]): number {
+function calcularScore(carta: Carta, manilha: Valor): number {
   if (ehManilha(carta, manilha)) return parametrosAvaliacaoPadrao.baseManilha + offsetManilha[carta.naipe];
 
-  return hierarquiaValores[carta.valor] + contarSuperioresReveladas(carta, manilha, cartasReveladas);
-}
-
-function contarSuperioresReveladas(carta: Carta, manilha: Valor, cartasReveladas: Carta[]): number {
-  return cartasReveladas.filter((revelada) => cartaVence(revelada, carta, manilha)).length;
+  return hierarquiaValores[carta.valor];
 }
 
 interface ContextoCategoria {

--- a/tests/core/avaliador-carta.test.ts
+++ b/tests/core/avaliador-carta.test.ts
@@ -49,7 +49,39 @@ describe('avaliador-carta com seguras em rodadas pequenas', () => {
 });
 
 describe('avaliador-carta com ajustes', () => {
-  it('deve subir categoria quando cartas superiores foram reveladas', () => {
+  it('deve manter 6 como baixa mesmo com superiores reveladas', () => {
+    const carta = criarCarta('6', '♣');
+    const reveladas = [
+      criarCarta('3', '♣'),
+      criarCarta('3', '♥'),
+      criarCarta('2', '♠'),
+      criarCarta('A', '♦'),
+      criarCarta('K', '♣'),
+    ];
+
+    const [avaliada] = avaliarCartas([carta], '4', reveladas, 4);
+
+    expect(avaliada.categoria).toBe('baixa');
+  });
+});
+
+describe('avaliador-carta sem inflação por reveladas', () => {
+  it('deve manter 10 abaixo de segura mesmo com superiores reveladas', () => {
+    const carta = criarCarta('10', '♣');
+    const reveladas = [
+      criarCarta('3', '♣'),
+      criarCarta('3', '♥'),
+      criarCarta('3', '♠'),
+      criarCarta('2', '♦'),
+      criarCarta('A', '♣'),
+    ];
+
+    const [avaliada] = avaliarCartas([carta], '4', reveladas, 4);
+
+    expect(avaliada.categoria).not.toBe('segura');
+  });
+
+  it('não deve subir categoria quando cartas superiores foram reveladas', () => {
     const carta = criarCarta('K', '♥');
     const semReveladas = avaliarCartas([carta], '4', [], 4);
     const comReveladas = avaliarCartas(
@@ -60,7 +92,7 @@ describe('avaliador-carta com ajustes', () => {
     );
 
     expect(semReveladas[0].categoria).toBe('média');
-    expect(comReveladas[0].categoria).toBe('segura');
+    expect(comReveladas[0].categoria).toBe('média');
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove o bônus de cartas superiores reveladas do score base do avaliador.
- Mantém `garantida_agora` usando cartas reveladas como verificação concreta.
- Adiciona cobertura para 6, 10 e K não subirem categoria por revelações parciais.

## Checks

- `pnpm test -- tests/core/avaliador-carta.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- pre-push: `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`
- pre-push: `vitest run`

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Card scoring and category evaluation are now independent of previously revealed cards, ensuring consistent card classification throughout gameplay regardless of what opponents have shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->