### PR TITLE
feat: posicionar cartas do bot ao reagir

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -1,6 +1,6 @@
 import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { calcularIndiceVencedor, cartaVence } from '@/core/comparador-carta';
+import { calcularIndiceVencedor, cartaVence, compararForcaReal } from '@/core/comparador-carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
 import { decidirAbertura } from './decidirAbertura';
@@ -19,7 +19,7 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
     const necessidade = calcularNecessidade(estadoAtual, jogadorId);
 
     if (necessidade <= 0) return Promise.resolve(this.fugir(estadoAtual, avaliadas));
-    return Promise.resolve(this.buscarVaza(estadoAtual, avaliadas));
+    return Promise.resolve(this.buscarVaza(estadoAtual, avaliadas, necessidade));
   }
 
   private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
@@ -29,12 +29,12 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
     return cartaMaisCara(perdedoras).carta;
   }
 
-  private buscarVaza(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
+  private buscarVaza(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], necessidade: number): Carta {
     const vencedoras = cartasQueVencem(estado, avaliadas);
-    if (vencedoras.length > 0) return escolherVencedoraFria(vencedoras).carta;
+    if (vencedoras.length > 0) return escolherGanhadora(vencedoras, estado.manilha, necessidade).carta;
 
     const perdedoras = cartasQuePerdem(estado, avaliadas);
-    if (perdedoras.length > 0) return cartaMaisCara(perdedoras).carta;
+    if (perdedoras.length > 0) return escolherPerdedora(perdedoras, estado.manilha, necessidade).carta;
     return cartaMaisBarata(avaliadas).carta;
   }
 }
@@ -60,9 +60,20 @@ function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | nul
   return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
 }
 
-function escolherVencedoraFria(avaliadas: CartaAvaliada[]): CartaAvaliada {
-  const naoGarantidas = avaliadas.filter((avaliada) => avaliada.categoria !== 'garantida_agora');
-  return cartaMaisBarata(naoGarantidas.length > 0 ? naoGarantidas : avaliadas);
+function escolherGanhadora(avaliadas: CartaAvaliada[], manilha: Carta['valor'], necessidade: number): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length >= necessidade ? ordenadas.length - necessidade : 0;
+  return ordenadas[indice];
+}
+
+function escolherPerdedora(avaliadas: CartaAvaliada[], manilha: Carta['valor'], necessidade: number): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length > necessidade ? ordenadas.length - necessidade : 0;
+  return ordenadas[indice];
+}
+
+function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
+  return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
 }
 
 function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -70,7 +70,14 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
   private async decidirJogadaDeterministica(config: ConfigJogadaDeterministica): Promise<Carta | null> {
     if (!ehUltimoDaMesa(config.estadoAtual) || config.contexto.necessidade <= 0) return null;
-    return this.fria.decidirJogada(config.mao, config.estado);
+    const carta = await this.fria.decidirJogada(config.mao, config.estado);
+    return registrarEscolhaDireta({
+      logger: this.logger,
+      mao: config.mao,
+      estado: config.estado,
+      carta,
+      escolheuQuente: false,
+    });
   }
 }
 

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -37,6 +37,9 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
     const estadoAtual = estadoEmJogo(estado);
     const contexto = criarContexto(estadoAtual, mao);
+    const deterministica = await this.decidirJogadaDeterministica({ mao, estado, estadoAtual, contexto });
+    if (deterministica) return deterministica;
+
     const empate = escolherEmpate(estadoAtual, contexto, this.liderAlta);
     if (empate) {
       return registrarEscolhaDireta({ logger: this.logger, mao, estado, carta: empate.carta, escolheuQuente: true });
@@ -64,6 +67,18 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       sorteio,
     });
   }
+
+  private async decidirJogadaDeterministica(config: ConfigJogadaDeterministica): Promise<Carta | null> {
+    if (!ehUltimoDaMesa(config.estadoAtual) || config.contexto.necessidade <= 0) return null;
+    return this.fria.decidirJogada(config.mao, config.estado);
+  }
+}
+
+interface ConfigJogadaDeterministica {
+  mao: Carta[];
+  estado: EstadoRodada;
+  estadoAtual: EstadoEmJogo;
+  contexto: ContextoJogada;
 }
 
 interface ContextoJogada {
@@ -181,6 +196,10 @@ function temAlvo(estado: EstadoEmJogo, jogadorId: string): boolean {
 
 function jogadorNaoQuerVaza(estado: EstadoEmJogo, item: MesaItem): boolean {
   return calcularNecessidade(estado, item.jogadorId) <= 0;
+}
+
+function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
+  return estado.mesa.length === estado.maos.length - 1;
 }
 
 function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {

--- a/src/core/comparador-carta.ts
+++ b/src/core/comparador-carta.ts
@@ -1,5 +1,27 @@
-import { compararNaipe, compararValor, ehManilha } from './Carta';
-import type { Carta } from './Carta';
+import { compararNaipe, compararValor, ehManilha, type Carta, type Naipe, type Valor } from './Carta';
+
+const forcaValores: Record<Valor, number> = {
+  '3': 13,
+  '2': 12,
+  A: 11,
+  K: 10,
+  Q: 9,
+  J: 8,
+  '10': 7,
+  '9': 6,
+  '8': 5,
+  '7': 4,
+  '6': 3,
+  '5': 2,
+  '4': 1,
+};
+
+const forcaNaipes: Record<Naipe, number> = {
+  '♣': 4,
+  '♥': 3,
+  '♠': 2,
+  '♦': 1,
+};
 
 export function cartaVence(carta: Carta, outra: Carta, manilha: Carta['valor']): boolean {
   const cartaEhManilha = ehManilha(carta, manilha);
@@ -32,4 +54,15 @@ export function cartasEmpatam(carta: Carta, outra: Carta, manilha: Carta['valor'
   if (cartaEhManilha !== outraEhManilha) return false;
   if (cartaEhManilha && outraEhManilha) return false;
   return carta.valor === outra.valor;
+}
+
+export function compararForcaReal(a: Carta, b: Carta, manilha: Carta['valor']): number {
+  const aEhManilha = ehManilha(a, manilha);
+  const bEhManilha = ehManilha(b, manilha);
+  if (aEhManilha !== bEhManilha) return aEhManilha ? 1 : -1;
+  if (aEhManilha && bEhManilha) return forcaNaipes[a.naipe] - forcaNaipes[b.naipe];
+
+  const diferencaValor = forcaValores[a.valor] - forcaValores[b.valor];
+  if (diferencaValor !== 0) return diferencaValor;
+  return forcaNaipes[a.naipe] - forcaNaipes[b.naipe];
 }

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -22,7 +22,6 @@ async function deveDelegarReacao(): Promise<void> {
     mesa: [
       { jogadorId: 'j1', carta: criarCarta('4', '♣') },
       { jogadorId: 'j2', carta: criarCarta('4', '♥') },
-      { jogadorId: 'j3', carta: criarCarta('4', '♠') },
     ],
     declaracoes: { j1: 0, j2: 1, bot: 1 },
     vazas: { j1: 0, j2: 0, bot: 0 },

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -7,6 +7,12 @@ import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 
 describe('DecisorJogadaLinhaFria', () => {
   it('deve fazer a vaza quando é o último, precisa fazer e tem carta que ganha', deveFazerVazaNoFim);
+  it('deve escolher G[N-X] quando precisa fazer e tem ganhadoras suficientes', deveEscolherGanhadoraPorNecessidade);
+  it('deve escolher a ganhadora mais fraca quando ganhadoras são escassas', deveEscolherGanhadoraEscassa);
+  it('deve escolher P[N-X] quando precisa fazer mas não consegue agora', deveEscolherPerdedoraPorNecessidade);
+  it('deve escolher a perdedora mais fraca quando todas são candidatas futuras', deveEscolherPerdedoraEscassa);
+  it('não deve tratar empate como carta que faz a vaza', deveRejeitarEmpateComoVitoria);
+  it('deve ordenar ganhadoras por força real com manilha e desempate por naipe', deveOrdenarPorForcaReal);
   it('deve jogar o menor prejuízo quando é o último, precisa fazer e não tem carta que ganha', deveJogarMenorPrejuizo);
   it('deve fugir com a carta alta que ainda perde quando já cumpriu', deveFugirComCartaAlta);
   it('deve fazer sem desperdiçar carta garantida quando ainda não é o último', devePreservarGarantida);
@@ -20,6 +26,65 @@ async function deveFazerVazaNoFim(): Promise<void> {
 
   await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
     criarCarta('3', '♦'),
+  );
+}
+
+async function deveEscolherGanhadoraPorNecessidade(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(
+    bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
+  ).resolves.toEqual(criarCarta('8', '♦'));
+}
+
+async function deveEscolherGanhadoraEscassa(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 4 }, vazas: { bot: 0 }, manilha: '6' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(
+    bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
+  ).resolves.toEqual(criarCarta('5', '♦'));
+}
+
+async function deveEscolherPerdedoraPorNecessidade(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(
+    bot.decidirJogada([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')], estado),
+  ).resolves.toEqual(criarCarta('9', '♦'));
+}
+
+async function deveEscolherPerdedoraEscassa(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('6', '♦')], estado)).resolves.toEqual(
+    criarCarta('4', '♦'),
+  );
+}
+
+async function deveRejeitarEmpateComoVitoria(): Promise<void> {
+  const estado = criarEstado({
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+    declaracoes: { bot: 1 },
+    vazas: { bot: 0 },
+    manilha: '5',
+  });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('K', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
+    criarCarta('A', '♦'),
+  );
+}
+
+async function deveOrdenarPorForcaReal(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 }, manilha: '5' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('5', '♦'), criarCarta('5', '♣')], estado)).resolves.toEqual(
+    criarCarta('5', '♣'),
   );
 }
 
@@ -87,6 +152,14 @@ function mesaComK(): MesaItem[] {
     { jogadorId: 'j1', carta: criarCarta('K', '♣') },
     { jogadorId: 'j2', carta: criarCarta('7', '♥') },
     { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComQuatro(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('4', '♠') },
   ];
 }
 

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -9,6 +9,7 @@ import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 describe('DecisorJogadaLinhaQuente', () => {
   it('deve escolher linha quente com segurança quando o RNG cai abaixo da temperatura', escolheLinhaQuente);
   it('deve escolher linha fria com segurança quando a temperatura é zero', escolheLinhaFria);
+  it('deve usar posicionamento determinístico quando é o último e precisa fazer', usaPosicionamentoDeterministico);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve empatar alta quando já cumpriu para se livrar de carta indesejada', empataAltaCumprido);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
@@ -16,7 +17,7 @@ describe('DecisorJogadaLinhaQuente', () => {
 });
 
 async function escolheLinhaQuente(): Promise<void> {
-  const estado = criarEstado(cenarioBifurcacao());
+  const estado = criarEstado(cenarioBifurcacaoAntesDoFim());
   const bot = criarBot(1, 0);
 
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('4', '♦'));
@@ -29,8 +30,21 @@ async function escolheLinhaFria(): Promise<void> {
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('3', '♦'));
 }
 
+async function usaPosicionamentoDeterministico(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
+  const bot = criarBot(1, 0);
+
+  await expect(
+    bot.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
+  ).resolves.toEqual(criarCarta('8', '♦'));
+}
+
 async function atravessaComCartaBarata(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  const estado = criarEstado({
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+    declaracoes: { j1: 1, bot: 1 },
+    vazas: { j1: 0, bot: 0 },
+  });
   const bot = criarBot(1, 0);
 
   await expect(bot.decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
@@ -93,6 +107,16 @@ function cenarioBifurcacao(): Partial<EstadoEmJogo> {
     declaracoes: { j1: 0, j2: 1, bot: 1 },
     vazas: { j1: 0, j2: 0, bot: 0 },
     cartasReveladas: cartasQueGarantemTresDeOuros(),
+  };
+}
+
+function cenarioBifurcacaoAntesDoFim(): Partial<EstadoEmJogo> {
+  return {
+    ...cenarioBifurcacao(),
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    ],
   };
 }
 

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
 import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { DecisaoJogadaDebug, LoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
 import type { Carta } from '@/core/Carta';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
@@ -10,6 +11,7 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve escolher linha quente com segurança quando o RNG cai abaixo da temperatura', escolheLinhaQuente);
   it('deve escolher linha fria com segurança quando a temperatura é zero', escolheLinhaFria);
   it('deve usar posicionamento determinístico quando é o último e precisa fazer', usaPosicionamentoDeterministico);
+  it('deve registrar posicionamento determinístico quando logger é injetado', registraPosicionamentoDeterministico);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve empatar alta quando já cumpriu para se livrar de carta indesejada', empataAltaCumprido);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
@@ -37,6 +39,21 @@ async function usaPosicionamentoDeterministico(): Promise<void> {
   await expect(
     bot.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
   ).resolves.toEqual(criarCarta('8', '♦'));
+}
+
+async function registraPosicionamentoDeterministico(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBot(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await bot.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado);
+
+  expect(jogadas).toHaveLength(1);
+  expect(jogadas[0]).toMatchObject({ carta: criarCarta('8', '♦'), escolheuQuente: false });
+  expect(jogadas[0]?.sorteio).toBeUndefined();
 }
 
 async function atravessaComCartaBarata(): Promise<void> {
@@ -78,8 +95,14 @@ async function repeteEscolhaDeterministica(): Promise<void> {
   expect(primeiro).toEqual(segundo);
 }
 
-function criarBot(temperatura: number, valorRng: number): DecisorJogadaLinhaQuente {
-  return new DecisorJogadaLinhaQuente({ temperatura, rng: { random: () => valorRng }, liderBaixa: 8, liderAlta: 11 });
+function criarBot(temperatura: number, valorRng: number, logger?: LoggerDebugBot): DecisorJogadaLinhaQuente {
+  return new DecisorJogadaLinhaQuente({
+    temperatura,
+    rng: { random: () => valorRng },
+    liderBaixa: 8,
+    liderAlta: 11,
+    logger,
+  });
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {

--- a/tests/core/comparador-carta.test.ts
+++ b/tests/core/comparador-carta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cartaVence, calcularIndiceVencedor, cartasEmpatam } from '@/core/comparador-carta';
+import { cartaVence, calcularIndiceVencedor, cartasEmpatam, compararForcaReal } from '@/core/comparador-carta';
 import { criarCarta } from './rodada-fixtures';
 
 describe('comparador-carta', () => {
@@ -44,5 +44,15 @@ describe('cartasEmpatam', () => {
 
   it('deve rejeitar empate entre cartas de valores diferentes', () => {
     expect(cartasEmpatam(criarCarta('3', '♣'), criarCarta('2', '♦'), '4')).toBe(false);
+  });
+});
+
+describe('compararForcaReal', () => {
+  it('deve ordenar manilha acima de não-manilha', () => {
+    expect(compararForcaReal(criarCarta('4', '♦'), criarCarta('3', '♣'), '4')).toBeGreaterThan(0);
+  });
+
+  it('deve desempatar cartas de mesmo valor pelo naipe', () => {
+    expect(compararForcaReal(criarCarta('K', '♣'), criarCarta('K', '♦'), '4')).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Resumo

- Implementa posicionamento determinístico G[N-X] para cartas que fazem a vaza.
- Implementa posicionamento P[N-X] para cartas que não fazem a vaza agora.
- Adiciona comparação de força real com manilha e desempate por naipe.
- Faz a linha quente convergir para a decisão determinística quando o bot é o último e ainda precisa fazer.

Closes #175

## Validação

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`