### PR TITLE
fix: aplicar fuga fria no fim da mesa

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -24,8 +24,8 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
 
   private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
     const perdedoras = cartasQuePerdem(estado, avaliadas);
+    if (ehUltimoDaMesa(estado)) return fugirNoFimDaMesa(estado, perdedoras, avaliadas);
     if (perdedoras.length === 0) return cartaMaisBarata(avaliadas).carta;
-    if (ehUltimoDaMesa(estado) && liderPrecisaFazer(estado)) return cartaMaisBarata(perdedoras).carta;
     return cartaMaisCara(perdedoras).carta;
   }
 
@@ -76,6 +76,15 @@ function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']
   return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
 }
 
+function fugirNoFimDaMesa(estado: EstadoEmJogo, perdedoras: CartaAvaliada[], avaliadas: CartaAvaliada[]): Carta {
+  if (perdedoras.length > 0) return cartaMaisForte(perdedoras, estado.manilha).carta;
+  return cartaMaisForte(avaliadas, estado.manilha).carta;
+}
+
+function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
+  return ordenarPorForcaReal(avaliadas, manilha).at(-1) ?? avaliadas[0];
+}
+
 function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
   return [...avaliadas].sort((a, b) => a.score - b.score)[0];
 }
@@ -86,9 +95,4 @@ function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
 
 function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
   return estado.mesa.length === estado.maos.length - 1;
-}
-
-function liderPrecisaFazer(estado: EstadoEmJogo): boolean {
-  const indice = calcularIndiceVencedor(estado.mesa, estado.manilha);
-  return calcularNecessidade(estado, estado.mesa[indice].jogadorId) > 0;
 }

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -82,7 +82,8 @@ function fugirNoFimDaMesa(estado: EstadoEmJogo, perdedoras: CartaAvaliada[], ava
 }
 
 function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
-  return ordenarPorForcaReal(avaliadas, manilha).at(-1) ?? avaliadas[0];
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  return ordenadas[ordenadas.length - 1];
 }
 
 function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -15,8 +15,10 @@ describe('DecisorJogadaLinhaFria', () => {
   it('deve ordenar ganhadoras por força real com manilha e desempate por naipe', deveOrdenarPorForcaReal);
   it('deve jogar o menor prejuízo quando é o último, precisa fazer e não tem carta que ganha', deveJogarMenorPrejuizo);
   it('deve fugir com a carta alta que ainda perde quando já cumpriu', deveFugirComCartaAlta);
+  it('deve contar empate como fuga quando é o último e não quer fazer', deveFugirComEmpateNoFim);
+  it('deve jogar a mais forte quando fuga é impossível no fim', deveDescartarMaisForteSemFuga);
   it('deve fazer sem desperdiçar carta garantida quando ainda não é o último', devePreservarGarantida);
-  it('deve deixar outro jogador fazer quando a mesa está favorável', deveDeixarOutroFazer);
+  it('deve seguir fuga do fim sem considerar necessidade do líder', deveIgnorarNecessidadeDoLiderNoFim);
   it('deve decidir abertura cautelosamente quando a mesa está vazia', deveDecidirAbertura);
 });
 
@@ -106,6 +108,24 @@ async function deveFugirComCartaAlta(): Promise<void> {
   );
 }
 
+async function deveFugirComEmpateNoFim(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada([criarCarta('Q', '♦'), criarCarta('K', '♦')], estado)).resolves.toEqual(
+    criarCarta('K', '♦'),
+  );
+}
+
+async function deveDescartarMaisForteSemFuga(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' });
+  const bot = new DecisorJogadaLinhaFria();
+
+  await expect(
+    bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
+  ).resolves.toEqual(criarCarta('K', '♦'));
+}
+
 async function devePreservarGarantida(): Promise<void> {
   const estado = criarEstado(cenarioGarantida());
   const bot = new DecisorJogadaLinhaFria();
@@ -115,12 +135,12 @@ async function devePreservarGarantida(): Promise<void> {
   );
 }
 
-async function deveDeixarOutroFazer(): Promise<void> {
+async function deveIgnorarNecessidadeDoLiderNoFim(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 1, bot: 0 }, vazas: { j1: 0, bot: 0 } });
   const bot = new DecisorJogadaLinhaFria();
 
   await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
-    criarCarta('4', '♦'),
+    criarCarta('Q', '♠'),
   );
 }
 


### PR DESCRIPTION
## Resumo

- Aplica a regra da seção 6 para linha fria quando o bot é o último a jogar e `necessidade <= 0`.
- Joga a carta mais alta que não faz, tratando empate como fuga.
- Quando todas fazem, descarta a carta mais forte da mão.

## Verificações

- `pnpm test tests/adapters/DecisorJogadaLinhaFria.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- pre-push: `pnpm typecheck` + `vitest run` (37 arquivos, 633 testes)

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bot's card selection logic for end-of-table scenarios to prioritize strongest available cards.

* **Tests**
  * Added test cases for end-of-round bot decision scenarios, including tie states and card discard priorities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->