### PR TITLE
feat: implementar linha quente no fim da mesa

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -1,9 +1,17 @@
-import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
+import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { calcularIndiceVencedor, cartasEmpatam, cartaVence } from '@/core/comparador-carta';
+import { cartasEmpatam } from '@/core/comparador-carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
+import {
+  calcularNecessidade,
+  criarContextoLinhaQuente,
+  ehUltimoDaMesa,
+  liderQuerVaza,
+  type ContextoJogadaQuente,
+} from './contextoLinhaQuente';
+import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import { DecisorJogadaLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
 import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
@@ -36,8 +44,8 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
 
     const estadoAtual = estadoEmJogo(estado);
-    const contexto = criarContexto(estadoAtual, mao);
-    const deterministica = await this.decidirJogadaDeterministica({ mao, estado, estadoAtual, contexto });
+    const contexto = criarContextoLinhaQuente(estadoAtual, mao);
+    const deterministica = this.decidirJogadaDeterministica({ mao, estado, estadoAtual, contexto });
     if (deterministica) return deterministica;
 
     const empate = escolherEmpate(estadoAtual, contexto, this.liderAlta);
@@ -68,9 +76,9 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     });
   }
 
-  private async decidirJogadaDeterministica(config: ConfigJogadaDeterministica): Promise<Carta | null> {
-    if (!ehUltimoDaMesa(config.estadoAtual) || config.contexto.necessidade <= 0) return null;
-    const carta = await this.fria.decidirJogada(config.mao, config.estado);
+  private decidirJogadaDeterministica(config: ConfigJogadaDeterministica): Carta | null {
+    if (!ehUltimoDaMesa(config.estadoAtual)) return null;
+    const carta = decidirUltimoLinhaQuente(config.estadoAtual, config.contexto);
     return registrarEscolhaDireta({
       logger: this.logger,
       mao: config.mao,
@@ -85,36 +93,10 @@ interface ConfigJogadaDeterministica {
   mao: Carta[];
   estado: EstadoRodada;
   estadoAtual: EstadoEmJogo;
-  contexto: ContextoJogada;
+  contexto: ContextoJogadaQuente;
 }
 
-interface ContextoJogada {
-  jogadorId: string;
-  necessidade: number;
-  folga: number;
-  avaliadas: CartaAvaliada[];
-  vencedoras: CartaAvaliada[];
-  perdedoras: CartaAvaliada[];
-  lider: CartaAvaliada | null;
-}
-
-function criarContexto(estado: EstadoEmJogo, mao: Carta[]): ContextoJogada {
-  const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
-  const necessidade = calcularNecessidade(estado, jogadorId);
-  const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
-  const lider = avaliarLider(estado);
-  return {
-    jogadorId,
-    necessidade,
-    folga: mao.length - necessidade,
-    avaliadas,
-    vencedoras: lider ? avaliadas.filter((a) => cartaVence(a.carta, lider.carta, estado.manilha)) : [...avaliadas],
-    perdedoras: lider ? avaliadas.filter((a) => !cartaVence(a.carta, lider.carta, estado.manilha)) : [],
-    lider,
-  };
-}
-
-function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaixa: number): boolean {
+function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuente, liderBaixa: number): boolean {
   return (
     contexto.necessidade > 0 &&
     contexto.vencedoras.length > 0 &&
@@ -125,7 +107,7 @@ function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaixa
   );
 }
 
-function mesaPodePunir(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaixa: number): boolean {
+function mesaPodePunir(estado: EstadoEmJogo, contexto: ContextoJogadaQuente, liderBaixa: number): boolean {
   return Boolean(
     contexto.lider &&
     contexto.lider.score <= liderBaixa &&
@@ -133,21 +115,21 @@ function mesaPodePunir(estado: EstadoEmJogo, contexto: ContextoJogada, liderBaix
   );
 }
 
-function temSegurancaParaDepois(contexto: ContextoJogada): boolean {
+function temSegurancaParaDepois(contexto: ContextoJogadaQuente): boolean {
   return contexto.necessidade <= 1 && contexto.folga >= 1 && contexto.avaliadas.some(ehSeguraOuGarantida);
 }
 
-function temPressaoAgora(contexto: ContextoJogada): boolean {
+function temPressaoAgora(contexto: ContextoJogadaQuente): boolean {
   return cartasDeFuga(contexto).length > 0 || vencedorasBaratasSemGarantida(contexto).length > 0;
 }
 
-function escolherPressao(contexto: ContextoJogada): CartaAvaliada {
+function escolherPressao(contexto: ContextoJogadaQuente): CartaAvaliada {
   const fuga = cartasDeFuga(contexto);
   if (fuga.length > 0) return cartaMaisCara(fuga);
   return cartaMaisBarata(vencedorasBaratasSemGarantida(contexto));
 }
 
-function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada): CartaAvaliada | null {
+function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): CartaAvaliada | null {
   if (
     contexto.necessidade <= 0 ||
     contexto.folga > 1 ||
@@ -160,7 +142,7 @@ function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada): Cart
   return candidatas.length > 0 ? cartaMaisBarata(candidatas) : null;
 }
 
-function escolherEmpate(estado: EstadoEmJogo, contexto: ContextoJogada, liderAlta: number): CartaAvaliada | null {
+function escolherEmpate(estado: EstadoEmJogo, contexto: ContextoJogadaQuente, liderAlta: number): CartaAvaliada | null {
   const lider = contexto.lider;
   if (!lider || lider.score <= liderAlta) return null;
   const empates = contexto.avaliadas.filter((avaliada) => cartasEmpatam(avaliada.carta, lider.carta, estado.manilha));
@@ -169,32 +151,15 @@ function escolherEmpate(estado: EstadoEmJogo, contexto: ContextoJogada, liderAlt
   return null;
 }
 
-function cartasDeFuga(contexto: ContextoJogada): CartaAvaliada[] {
-  return contexto.perdedoras.filter((avaliada) => !ehSeguraOuGarantida(avaliada));
+function cartasDeFuga(contexto: ContextoJogadaQuente): CartaAvaliada[] {
+  return [...contexto.perdedoras, ...contexto.empates].filter((avaliada) => !ehSeguraOuGarantida(avaliada));
 }
 
-function vencedorasBaratasSemGarantida(contexto: ContextoJogada): CartaAvaliada[] {
+function vencedorasBaratasSemGarantida(contexto: ContextoJogadaQuente): CartaAvaliada[] {
   const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
   return candidatas.filter((carta) =>
     contexto.avaliadas.some((avaliada) => avaliada !== carta && ehGarantida(avaliada)),
   );
-}
-
-function avaliarLider(estado: EstadoEmJogo): CartaAvaliada | null {
-  const carta = melhorCartaMesa(estado.mesa, estado.manilha);
-  if (!carta) return null;
-  return avaliarCartas([carta], estado.manilha, estado.cartasReveladas, estado.maos.length)[0];
-}
-
-function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
-  if (mesa.length === 0) return null;
-  return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
-}
-
-function liderQuerVaza(estado: EstadoEmJogo): boolean {
-  if (estado.mesa.length === 0) return false;
-  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
-  return calcularNecessidade(estado, lider.jogadorId) > 0;
 }
 
 function temAlvo(estado: EstadoEmJogo, jogadorId: string): boolean {
@@ -203,14 +168,6 @@ function temAlvo(estado: EstadoEmJogo, jogadorId: string): boolean {
 
 function jogadorNaoQuerVaza(estado: EstadoEmJogo, item: MesaItem): boolean {
   return calcularNecessidade(estado, item.jogadorId) <= 0;
-}
-
-function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
-  return estado.mesa.length === estado.maos.length - 1;
-}
-
-function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {
-  return (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
 }
 
 function ehSeguraOuGarantida(avaliada: CartaAvaliada): boolean {

--- a/src/adapters/bots/contextoLinhaQuente.ts
+++ b/src/adapters/bots/contextoLinhaQuente.ts
@@ -1,0 +1,58 @@
+import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { calcularIndiceVencedor, cartasEmpatam, cartaVence } from '@/core/comparador-carta';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { cartaPerde } from './decidirUltimoLinhaQuente';
+
+export interface ContextoJogadaQuente {
+  jogadorId: string;
+  necessidade: number;
+  folga: number;
+  avaliadas: CartaAvaliada[];
+  vencedoras: CartaAvaliada[];
+  perdedoras: CartaAvaliada[];
+  empates: CartaAvaliada[];
+  lider: CartaAvaliada | null;
+}
+
+export function criarContextoLinhaQuente(estado: EstadoEmJogo, mao: Carta[]): ContextoJogadaQuente {
+  const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
+  const necessidade = calcularNecessidade(estado, jogadorId);
+  const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+  const lider = avaliarLider(estado);
+  return {
+    jogadorId,
+    necessidade,
+    folga: mao.length - necessidade,
+    avaliadas,
+    vencedoras: lider ? avaliadas.filter((a) => cartaVence(a.carta, lider.carta, estado.manilha)) : [...avaliadas],
+    perdedoras: lider ? avaliadas.filter((a) => cartaPerde(a.carta, lider.carta, estado.manilha)) : [],
+    empates: lider ? avaliadas.filter((a) => cartasEmpatam(a.carta, lider.carta, estado.manilha)) : [],
+    lider,
+  };
+}
+
+export function liderQuerVaza(estado: EstadoEmJogo): boolean {
+  if (estado.mesa.length === 0) return false;
+  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
+  return calcularNecessidade(estado, lider.jogadorId) > 0;
+}
+
+export function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {
+  return (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
+}
+
+export function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
+  return estado.mesa.length === estado.maos.length - 1;
+}
+
+function avaliarLider(estado: EstadoEmJogo): CartaAvaliada | null {
+  const carta = melhorCartaMesa(estado.mesa, estado.manilha);
+  if (!carta) return null;
+  return avaliarCartas([carta], estado.manilha, estado.cartasReveladas, estado.maos.length)[0];
+}
+
+function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
+  if (mesa.length === 0) return null;
+  return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
+}

--- a/src/adapters/bots/decidirUltimoLinhaQuente.ts
+++ b/src/adapters/bots/decidirUltimoLinhaQuente.ts
@@ -1,0 +1,96 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { calcularIndiceVencedor, cartasEmpatam, cartaVence, compararForcaReal } from '@/core/comparador-carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+
+export interface ContextoUltimoLinhaQuente {
+  necessidade: number;
+  avaliadas: CartaAvaliada[];
+  vencedoras: CartaAvaliada[];
+  perdedoras: CartaAvaliada[];
+  empates: CartaAvaliada[];
+  lider: CartaAvaliada | null;
+}
+
+export function decidirUltimoLinhaQuente(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): Carta {
+  if (contexto.necessidade > 0) return decidirQuandoPrecisaFazer(estado, contexto);
+  return decidirQuandoJaCumpriu(estado, contexto);
+}
+
+export function cartaPerde(carta: Carta, lider: Carta, manilha: Carta['valor']): boolean {
+  return !cartaVence(carta, lider, manilha) && !cartasEmpatam(carta, lider, manilha);
+}
+
+function decidirQuandoPrecisaFazer(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): Carta {
+  if (contexto.vencedoras.length === 0) {
+    return escolherPerdedora(cartasQueNaoVencem(contexto), estado.manilha, contexto).carta;
+  }
+  if (deveFazerAgora(estado, contexto)) return escolherGanhadora(contexto.vencedoras, estado.manilha, contexto).carta;
+  if (contexto.perdedoras.length > 0) return cartaMaisForte(contexto.perdedoras, estado.manilha).carta;
+  return escolherGanhadora(contexto.vencedoras, estado.manilha, contexto).carta;
+}
+
+function decidirQuandoJaCumpriu(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): Carta {
+  if (liderQuerVaza(estado)) return fugirContraLiderQuePrecisa(estado, contexto).carta;
+  if (contexto.perdedoras.length > 0) return cartaMaisForte(contexto.perdedoras, estado.manilha).carta;
+  if (contexto.empates.length > 0) return cartaMaisForte(contexto.empates, estado.manilha).carta;
+  return cartaMaisForte(contexto.avaliadas, estado.manilha).carta;
+}
+
+function fugirContraLiderQuePrecisa(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): CartaAvaliada {
+  if (contexto.lider && ehAltaOuMelhor(contexto.lider) && contexto.empates.length > 0) {
+    return cartaMaisForte(contexto.empates, estado.manilha);
+  }
+  if (contexto.perdedoras.length > 0) return cartaMaisForte(contexto.perdedoras, estado.manilha);
+  if (contexto.empates.length > 0) return cartaMaisForte(contexto.empates, estado.manilha);
+  return cartaMaisForte(contexto.avaliadas, estado.manilha);
+}
+
+function deveFazerAgora(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): boolean {
+  if (!contexto.lider) return true;
+  if (liderQuerVaza(estado) && ehAltaOuMelhor(contexto.lider)) return true;
+  return contexto.necessidade / contexto.avaliadas.length >= 0.66;
+}
+
+function escolherGanhadora(
+  avaliadas: CartaAvaliada[],
+  manilha: Carta['valor'],
+  contexto: ContextoUltimoLinhaQuente,
+): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length >= contexto.necessidade ? ordenadas.length - contexto.necessidade : 0;
+  return ordenadas[indice];
+}
+
+function escolherPerdedora(
+  avaliadas: CartaAvaliada[],
+  manilha: Carta['valor'],
+  contexto: ContextoUltimoLinhaQuente,
+): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length > contexto.necessidade ? ordenadas.length - contexto.necessidade : 0;
+  return ordenadas[indice];
+}
+
+function cartasQueNaoVencem(contexto: ContextoUltimoLinhaQuente): CartaAvaliada[] {
+  return [...contexto.perdedoras, ...contexto.empates];
+}
+
+function liderQuerVaza(estado: EstadoEmJogo): boolean {
+  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
+  const necessidade = (estado.declaracoes[lider.jogadorId] ?? 0) - (estado.vazas[lider.jogadorId] ?? 0);
+  return necessidade > 0;
+}
+
+function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
+  return ['alta', 'segura', 'garantida_agora'].includes(avaliada.categoria);
+}
+
+function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
+  return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
+}
+
+function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  return ordenadas[ordenadas.length - 1];
+}

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -12,8 +12,8 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve escolher linha fria com segurança quando a temperatura é zero', escolheLinhaFria);
   it('deve usar posicionamento determinístico quando é o último e precisa fazer', usaPosicionamentoDeterministico);
   it('deve registrar posicionamento determinístico quando logger é injetado', registraPosicionamentoDeterministico);
+  it('deve empatar quando já cumpriu, líder precisa e carta líder é alta', empataAltaCumprido);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
-  it('deve empatar alta quando já cumpriu para se livrar de carta indesejada', empataAltaCumprido);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
   it('deve repetir a escolha com RNG determinístico', repeteEscolhaDeterministica);
 });
@@ -70,11 +70,11 @@ async function atravessaComCartaBarata(): Promise<void> {
 }
 
 async function empataAltaCumprido(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 } });
+  const estado = criarEstado({ mesa: mesaComDois(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } });
   const bot = criarBot(1, 0);
 
-  await expect(bot.decidirJogada([criarCarta('K', '♦'), criarCarta('4', '♦')], estado)).resolves.toEqual(
-    criarCarta('K', '♦'),
+  await expect(bot.decidirJogada([criarCarta('2', '♦'), criarCarta('4', '♦')], estado)).resolves.toEqual(
+    criarCarta('2', '♦'),
   );
 }
 
@@ -159,9 +159,9 @@ function mesaComBaixa(): MesaItem[] {
   ];
 }
 
-function mesaComK(): MesaItem[] {
+function mesaComDois(): MesaItem[] {
   return [
-    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
     { jogadorId: 'j2', carta: criarCarta('7', '♥') },
     { jogadorId: 'j3', carta: criarCarta('8', '♠') },
   ];

--- a/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { Carta } from '@/core/Carta';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+describe('DecisorJogadaLinhaQuente no fim da mesa', () => {
+  it('deve atravessar quando líder precisa e carta líder é alta', atravessaLiderAlta);
+  it('deve adiar quando líder precisa, carta líder é média e urgência é baixa', adiaLiderMedia);
+  it('deve fazer quando líder precisa, carta líder é média e urgência é alta', fazLiderMediaUrgente);
+  it('deve adiar quando líder não precisa e urgência é baixa', adiaLiderSemNecessidade);
+  it('deve fazer quando líder não precisa e urgência é alta', fazLiderSemNecessidadeUrgente);
+  it('deve evitar empate quando já cumpriu, líder precisa e carta líder é média', evitaEmpateComMedia);
+  it('deve fugir com a maior perdedora quando líder não precisa', fogeComMaiorPerdedora);
+  it('deve empatar quando líder não precisa e só há empate como fuga', empataQuandoSoHaEmpate);
+  it('deve jogar a carta mais forte quando todas fazem', jogaMaisForteSemFuga);
+});
+
+async function atravessaLiderAlta(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComDois(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  await expect(bot().decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
+    criarCarta('3', '♦'),
+  );
+}
+
+async function adiaLiderMedia(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  await expect(jogarContraNove(estado)).resolves.toEqual(criarCarta('6', '♦'));
+}
+
+async function fazLiderMediaUrgente(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
+  await expect(jogarContraNove(estado)).resolves.toEqual(criarCarta('Q', '♦'));
+}
+
+async function adiaLiderSemNecessidade(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  await expect(jogarContraNove(estado)).resolves.toEqual(criarCarta('6', '♦'));
+}
+
+async function fazLiderSemNecessidadeUrgente(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 0, bot: 2 }, vazas: { j1: 0, bot: 0 } });
+  await expect(jogarContraNove(estado)).resolves.toEqual(criarCarta('Q', '♦'));
+}
+
+async function evitaEmpateComMedia(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+  const mao = [criarCarta('9', '♦'), criarCarta('6', '♦'), criarCarta('Q', '♦')];
+  await expect(bot().decidirJogada(mao, estado)).resolves.toEqual(criarCarta('6', '♦'));
+}
+
+async function fogeComMaiorPerdedora(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+  const mao = [criarCarta('4', '♦'), criarCarta('Q', '♠'), criarCarta('A', '♦')];
+  await expect(bot().decidirJogada(mao, estado)).resolves.toEqual(criarCarta('Q', '♠'));
+}
+
+async function empataQuandoSoHaEmpate(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+  await expect(bot().decidirJogada([criarCarta('K', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
+    criarCarta('K', '♦'),
+  );
+}
+
+async function jogaMaisForteSemFuga(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComNove(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+  await expect(bot().decidirJogada([criarCarta('Q', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
+    criarCarta('A', '♦'),
+  );
+}
+
+function jogarContraNove(estado: EstadoEmJogo): Promise<Carta> {
+  const mao = [criarCarta('6', '♦'), criarCarta('Q', '♦'), criarCarta('A', '♦')];
+  return bot().decidirJogada(mao, estado);
+}
+
+function bot(): DecisorJogadaLinhaQuente {
+  return new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random: () => 0 }, liderBaixa: 8, liderAlta: 11 });
+}
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = criarJogadores();
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function criarJogadores(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
+}
+
+function mesaComDois(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComK(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComNove(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('9', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('6', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('7', '♠') },
+  ];
+}


### PR DESCRIPTION
## Resumo

- Implementa a decisão determinística da linha quente quando o bot é o último a jogar.
- Separa contexto e regra final para manter arquivos dentro dos limites do projeto.
- Adiciona cobertura para os subcasos da seção 7, incluindo urgência, interação com líder, empate tático e fuga impossível.

Closes #177

## Verificações

- pnpm typecheck
- pnpm lint
- pnpm test