### PR TITLE
fix: motivos precisos de sem bifurcação e propagação no caminho de bifurcação

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -12,7 +12,9 @@ import {
   escolherEmpate,
   escolherPressao,
   escolherTravessia,
-  motivoSemBifurcacao,
+  MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS,
+  MOTIVO_SEM_BIFURCACAO_NAO_PODE,
+  MOTIVO_SEM_BIFURCACAO_ULTIMO,
   podeBifurcar,
 } from './regras-linha-quente';
 
@@ -54,7 +56,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
     const carta = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
-    return this.registrarSemBifurcacao(base, carta);
+    return this.registrarSemBifurcacao(base, carta, MOTIVO_SEM_BIFURCACAO_ULTIMO);
   }
 
   private decidirAntesDoFim(base: BaseJogada): Carta {
@@ -62,11 +64,13 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     if (direta) return direta;
 
     if (!podeBifurcar(base.estadoAtual, base.contexto, this.liderBaixa)) {
-      return this.registrarSemBifurcacao(base, base.fria);
+      return this.registrarSemBifurcacao(base, base.fria, MOTIVO_SEM_BIFURCACAO_NAO_PODE);
     }
 
     const quente = escolherPressao(base.contexto).carta;
-    if (cartasIguais(base.fria, quente)) return this.registrarSemBifurcacao(base, quente);
+    if (cartasIguais(base.fria, quente)) {
+      return this.registrarSemBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
+    }
 
     const sorteio = this.rng.random();
     return registrarBifurcacao({
@@ -111,7 +115,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     });
   }
 
-  private registrarSemBifurcacao(base: BaseJogada, linhaQuente: Carta): Carta {
+  private registrarSemBifurcacao(base: BaseJogada, linhaQuente: Carta, motivo: string): Carta {
     return registrarEscolhaDireta({
       logger: this.logger,
       mao: base.mao,
@@ -119,7 +123,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       carta: linhaQuente,
       linhaFria: base.fria,
       linhaQuente,
-      motivoSemBifurcacao: motivoSemBifurcacao(base.contexto),
+      motivoSemBifurcacao: motivo,
       escolheuQuente: false,
     });
   }

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -22,6 +22,8 @@ interface Bifurcacao {
   estado: EstadoRodada;
   fria: Carta;
   quente: Carta;
+  motivoLinhaFria?: string;
+  motivoLinhaQuente?: string;
   sorteio: number;
 }
 
@@ -48,6 +50,8 @@ export function registrarBifurcacao(config: Bifurcacao): Carta {
     estado: config.estado,
     linhaFria: config.fria,
     linhaQuente: config.quente,
+    motivoLinhaFria: config.motivoLinhaFria,
+    motivoLinhaQuente: config.motivoLinhaQuente,
     carta,
     escolheuQuente,
     sorteio: config.sorteio,

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -14,12 +14,11 @@ export function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuent
   );
 }
 
-export function motivoSemBifurcacao(contexto: ContextoJogadaQuente): string {
-  const urgencia = contexto.necessidade / contexto.avaliadas.length;
-  if (contexto.necessidade > 0 && urgencia >= 0.66) return 'sem bifurcação: ambas fazem porque urgência >= 0.66';
-  if (contexto.necessidade <= 0 && contexto.perdedoras.length === 0) return 'sem bifurcação: fuga impossível';
-  return 'sem bifurcação: ambas não querem fazer e escolheram a mesma carta';
-}
+export const MOTIVO_SEM_BIFURCACAO_URGENCIA = 'sem bifurcação: ambas fazem porque urgência >= 0.66';
+export const MOTIVO_SEM_BIFURCACAO_FUGA_IMPOSSIVEL = 'sem bifurcação: fuga impossível';
+export const MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS = 'sem bifurcação: ambas não querem fazer e escolheram a mesma carta';
+export const MOTIVO_SEM_BIFURCACAO_NAO_PODE = 'sem bifurcação: não há condições para bifurcar';
+export const MOTIVO_SEM_BIFURCACAO_ULTIMO = 'sem bifurcação: último da mesa';
 
 export function cartasIguais(a: Carta, b: Carta): boolean {
   return a.valor === b.valor && a.naipe === b.naipe;

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { criarLoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
-
 import type { Carta } from '@/core/Carta';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { EstadoRodada } from '@/types/estado-rodada';
@@ -136,8 +135,6 @@ describe('Logger debug das jogadas dos bots', () => {
     expect(log).not.toHaveBeenCalledWith(expect.stringContaining('determinística'));
   });
 });
-
-
 
 function registrarJogadaComBifurcacao(): void {
   criarLoggerDebugBot('Brás', 0.35).registrarJogada({


### PR DESCRIPTION
## Resumo

Corrige dois apontamentos de review do PR #183:

### 1. Motivos imprecisos em `motivoSemBifurcacao` (Codex)

A função antiga inferia o motivo a partir do contexto, mas era chamada em situações onde o fallback genérico (`ambas não querem fazer...`) contradizia o cenário real (ex: último da mesa, não pode bifurcar por falta de pressão/alvo).

**Solução**: Substituí a função por constantes explícitas, e quem chama informa o motivo correto:
- `MOTIVO_SEM_BIFURCACAO_ULTIMO` — último da mesa
- `MOTIVO_SEM_BIFURCACAO_NAO_PODE` — não há condições para bifurcar
- `MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS` — fria e quente escolheram a mesma carta
- `MOTIVO_SEM_BIFURCACAO_URGENCIA` — urgência ≥ 0.66
- `MOTIVO_SEM_BIFURCACAO_FUGA_IMPOSSIVEL` — fuga impossível

### 2. Propagação de motivos em `registrarBifurcacao` (CodeRabbit)

O caminho de bifurcação real (sorteio por temperatura) não propagava `motivoLinhaFria`/`motivoLinhaQuente`, perdendo justificativas no log.

**Solução**: Interface `Bifurcacao` agora aceita `motivoLinhaFria?` e `motivoLinhaQuente?`, repassados ao logger.

## Verificações

- `pnpm test` — 644 testes passando
- `pnpm typecheck` — limpo
- `pnpm lint` — limpo