### PR TITLE
fix: corrige motivo debug sem bifurcação

### DIFF
--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -16,9 +16,12 @@ export function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuent
 
 export function motivoSemBifurcacao(contexto: ContextoJogadaQuente): string {
   const urgencia = contexto.necessidade / contexto.avaliadas.length;
+  if (contexto.necessidade > 0 && contexto.vencedoras.length === 1) {
+    return 'sem bifurcação: ambas fazem porque precisam cumprir a declaração';
+  }
   if (contexto.necessidade > 0 && urgencia >= 0.66) return 'sem bifurcação: ambas fazem porque urgência >= 0.66';
   if (contexto.necessidade <= 0 && contexto.perdedoras.length === 0) return 'sem bifurcação: fuga impossível';
-  return 'sem bifurcação: ambas não querem fazer e escolheram a mesma carta';
+  return 'sem bifurcação: linha fria e linha quente convergiram na mesma carta';
 }
 
 export function cartasIguais(a: Carta, b: Carta): boolean {

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -16,7 +16,7 @@ export function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuent
 
 export function motivoSemBifurcacao(contexto: ContextoJogadaQuente): string {
   const urgencia = contexto.necessidade / contexto.avaliadas.length;
-  if (contexto.necessidade > 0 && contexto.vencedoras.length === 1) {
+  if (contexto.necessidade > 0 && contexto.vencedoras.length === 1 && contexto.perdedoras.length === 0) {
     return 'sem bifurcação: ambas fazem porque precisam cumprir a declaração';
   }
   if (contexto.necessidade > 0 && urgencia >= 0.66) return 'sem bifurcação: ambas fazem porque urgência >= 0.66';

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ContextoJogadaQuente } from '@/adapters/bots/contextoLinhaQuente';
 import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
 import { criarLoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
+import { motivoSemBifurcacao } from '@/adapters/bots/regras-linha-quente';
+import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { EstadoRodada } from '@/types/estado-rodada';
@@ -135,6 +138,56 @@ describe('Logger debug das jogadas dos bots', () => {
     expect(log).not.toHaveBeenCalledWith(expect.stringContaining('determinística'));
   });
 });
+
+describe('Motivo debug sem bifurcação', () => {
+  it('deve registrar que faz porque precisa quando só uma carta vence', () => {
+    const contexto = criarContexto({
+      necessidade: 1,
+      avaliadas: [avaliada('8', '♣'), avaliada('10', '♠'), avaliada('Q', '♣')],
+      vencedoras: [avaliada('8', '♣')],
+    });
+
+    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque precisam cumprir a declaração');
+  });
+
+  it('não deve dizer que não quer fazer quando ainda precisa de vaza', () => {
+    const contexto = criarContexto({
+      necessidade: 2,
+      avaliadas: [avaliada('3', '♦'), avaliada('4', '♣')],
+      vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
+    });
+
+    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque urgência >= 0.66');
+  });
+
+  it('deve usar motivo neutro quando as linhas só convergem', () => {
+    const contexto = criarContexto({
+      necessidade: 1,
+      avaliadas: [avaliada('3', '♦'), avaliada('4', '♣'), avaliada('5', '♠')],
+      vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
+    });
+
+    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: linha fria e linha quente convergiram na mesma carta');
+  });
+});
+
+function criarContexto(config: Partial<ContextoJogadaQuente>): ContextoJogadaQuente {
+  return {
+    jogadorId: 'bot1',
+    necessidade: 0,
+    folga: 0,
+    avaliadas: [],
+    vencedoras: [],
+    perdedoras: [],
+    empates: [],
+    lider: null,
+    ...config,
+  };
+}
+
+function avaliada(valor: Carta['valor'], naipe: Carta['naipe']): CartaAvaliada {
+  return { carta: { valor, naipe }, score: 1, categoria: 'baixa' };
+}
 
 function registrarJogadaComBifurcacao(): void {
   criarLoggerDebugBot('Brás', 0.35).registrarJogada({

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -140,36 +140,52 @@ describe('Logger debug das jogadas dos bots', () => {
 });
 
 describe('Motivo debug sem bifurcação', () => {
-  it('deve registrar que faz porque precisa quando só uma carta vence', () => {
-    const contexto = criarContexto({
-      necessidade: 1,
-      avaliadas: [avaliada('8', '♣'), avaliada('10', '♠'), avaliada('Q', '♣')],
-      vencedoras: [avaliada('8', '♣')],
-    });
-
-    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque precisam cumprir a declaração');
-  });
-
-  it('não deve dizer que não quer fazer quando ainda precisa de vaza', () => {
-    const contexto = criarContexto({
-      necessidade: 2,
-      avaliadas: [avaliada('3', '♦'), avaliada('4', '♣')],
-      vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
-    });
-
-    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque urgência >= 0.66');
-  });
-
-  it('deve usar motivo neutro quando as linhas só convergem', () => {
-    const contexto = criarContexto({
-      necessidade: 1,
-      avaliadas: [avaliada('3', '♦'), avaliada('4', '♣'), avaliada('5', '♠')],
-      vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
-    });
-
-    expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: linha fria e linha quente convergiram na mesma carta');
-  });
+  it('deve registrar que faz porque precisa quando só uma carta vence', deveRegistrarQueFazPorquePrecisa);
+  it('deve usar motivo neutro quando pode adiar a vaza com perdedora', deveUsarMotivoNeutroComPerdedora);
+  it('não deve dizer que não quer fazer quando ainda precisa de vaza', naoDeveDizerQueNaoQuerFazer);
+  it('deve usar motivo neutro quando as linhas só convergem', deveUsarMotivoNeutroQuandoConverge);
 });
+
+function deveRegistrarQueFazPorquePrecisa(): void {
+  const contexto = criarContexto({
+    necessidade: 1,
+    avaliadas: [avaliada('8', '♣'), avaliada('10', '♠'), avaliada('Q', '♣')],
+    vencedoras: [avaliada('8', '♣')],
+  });
+
+  expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque precisam cumprir a declaração');
+}
+
+function deveUsarMotivoNeutroComPerdedora(): void {
+  const contexto = criarContexto({
+    necessidade: 1,
+    avaliadas: [avaliada('8', '♣'), avaliada('10', '♠'), avaliada('Q', '♣')],
+    vencedoras: [avaliada('8', '♣')],
+    perdedoras: [avaliada('10', '♠')],
+  });
+
+  expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: linha fria e linha quente convergiram na mesma carta');
+}
+
+function naoDeveDizerQueNaoQuerFazer(): void {
+  const contexto = criarContexto({
+    necessidade: 2,
+    avaliadas: [avaliada('3', '♦'), avaliada('4', '♣')],
+    vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
+  });
+
+  expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: ambas fazem porque urgência >= 0.66');
+}
+
+function deveUsarMotivoNeutroQuandoConverge(): void {
+  const contexto = criarContexto({
+    necessidade: 1,
+    avaliadas: [avaliada('3', '♦'), avaliada('4', '♣'), avaliada('5', '♠')],
+    vencedoras: [avaliada('3', '♦'), avaliada('4', '♣')],
+  });
+
+  expect(motivoSemBifurcacao(contexto)).toBe('sem bifurcação: linha fria e linha quente convergiram na mesma carta');
+}
 
 function criarContexto(config: Partial<ContextoJogadaQuente>): ContextoJogadaQuente {
   return {


### PR DESCRIPTION
## Summary
- Corrige o motivo exibido quando não há bifurcação para não afirmar que o bot não quer fazer quando ainda precisa de vaza.
- Adiciona cobertura no debug para o caso de única carta vencedora, urgência alta e convergência neutra.

Closes #185

## Tests
- pnpm vitest run tests/adapters/logger-debug-bot.test.ts
- pnpm typecheck
- pnpm lint
- push hook: tsc --noEmit && tsc --noEmit -p tsconfig.tests.json
- push hook: vitest run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bot messaging to provide more accurate and clearer explanations for game decisions when specific conditions occur, improving user understanding of move selections during gameplay.

* **Tests**
  * Added comprehensive test coverage to validate the accuracy of bot explanations across multiple game scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->