### PR TITLE
feat: explicita linha fria do último bot

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -29,17 +29,17 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
   }
 
   private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
-    const perdedoras = cartasQuePerdem(estado, avaliadas);
-    if (perdedoras.length === 0) return cartaMaisBarata(avaliadas).carta;
-    return cartaMaisCara(perdedoras).carta;
+    const naoFazem = cartasQueNaoFazem(estado, avaliadas);
+    if (naoFazem.length === 0) return cartaMaisBarata(avaliadas).carta;
+    return cartaMaisCara(naoFazem).carta;
   }
 
   private buscarVaza(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], necessidade: number): Carta {
     const vencedoras = cartasQueVencem(estado, avaliadas);
     if (vencedoras.length > 0) return escolherGanhadora(vencedoras, estado.manilha, necessidade).carta;
 
-    const perdedoras = cartasQuePerdem(estado, avaliadas);
-    if (perdedoras.length > 0) return escolherPerdedora(perdedoras, estado.manilha, necessidade).carta;
+    const naoFazem = cartasQueNaoFazem(estado, avaliadas);
+    if (naoFazem.length > 0) return escolherPerdedora(naoFazem, estado.manilha, necessidade).carta;
     return cartaMaisBarata(avaliadas).carta;
   }
 }
@@ -91,14 +91,10 @@ function cartasQueVencem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Cart
   return avaliadas.filter((avaliada) => cartaVence(avaliada.carta, melhor, estado.manilha));
 }
 
-function cartasQuePerdem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
+function cartasQueNaoFazem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
   const melhor = melhorCartaMesa(estado.mesa, estado.manilha);
   if (!melhor) return [];
   return avaliadas.filter((avaliada) => !cartaVence(avaliada.carta, melhor, estado.manilha));
-}
-
-function cartasQueNaoFazem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
-  return cartasQuePerdem(estado, avaliadas);
 }
 
 function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -30,7 +30,6 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
 
   private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
     const perdedoras = cartasQuePerdem(estado, avaliadas);
-    if (ehUltimoDaMesa(estado)) return fugirNoFimDaMesa(estado, perdedoras, avaliadas);
     if (perdedoras.length === 0) return cartaMaisBarata(avaliadas).carta;
     return cartaMaisCara(perdedoras).carta;
   }
@@ -121,11 +120,6 @@ function escolherPerdedora(avaliadas: CartaAvaliada[], manilha: Carta['valor'], 
 
 function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
   return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
-}
-
-function fugirNoFimDaMesa(estado: EstadoEmJogo, perdedoras: CartaAvaliada[], avaliadas: CartaAvaliada[]): Carta {
-  if (perdedoras.length > 0) return cartaMaisForte(perdedoras, estado.manilha).carta;
-  return cartaMaisForte(avaliadas, estado.manilha).carta;
 }
 
 function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -5,6 +5,11 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
 import { decidirAbertura } from './decidirAbertura';
 
+export interface DecisaoLinhaFria {
+  carta: Carta;
+  motivo: string;
+}
+
 export class DecisorJogadaLinhaFria implements DecisorJogada {
   decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
     if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
@@ -18,6 +23,7 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
     const jogadorId = estadoAtual.maos[estadoAtual.jogadorAtual].jogador.id;
     const necessidade = calcularNecessidade(estadoAtual, jogadorId);
 
+    if (ehUltimoDaMesa(estadoAtual)) return Promise.resolve(decidirUltimoLinhaFria(mao, estadoAtual).carta);
     if (necessidade <= 0) return Promise.resolve(this.fugir(estadoAtual, avaliadas));
     return Promise.resolve(this.buscarVaza(estadoAtual, avaliadas, necessidade));
   }
@@ -39,6 +45,43 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
   }
 }
 
+export function decidirUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoLinhaFria {
+  const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+  const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
+  const necessidade = calcularNecessidade(estado, jogadorId);
+
+  if (necessidade > 0) return decidirUltimoQuandoPrecisaFazer(estado, avaliadas, necessidade);
+  return decidirUltimoQuandoJaCumpriu(estado, avaliadas);
+}
+
+function decidirUltimoQuandoPrecisaFazer(
+  estado: EstadoEmJogo,
+  avaliadas: CartaAvaliada[],
+  necessidade: number,
+): DecisaoLinhaFria {
+  const vencedoras = cartasQueVencem(estado, avaliadas);
+  if (vencedoras.length > 0) {
+    return {
+      carta: escolherGanhadora(vencedoras, estado.manilha, necessidade).carta,
+      motivo: 'precisa fazer; regra G[N-X]',
+    };
+  }
+
+  return {
+    carta: escolherPerdedora(cartasQueNaoFazem(estado, avaliadas), estado.manilha, necessidade).carta,
+    motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
+  };
+}
+
+function decidirUltimoQuandoJaCumpriu(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): DecisaoLinhaFria {
+  const naoFazem = cartasQueNaoFazem(estado, avaliadas);
+  if (naoFazem.length > 0) {
+    return { carta: cartaMaisForte(naoFazem, estado.manilha).carta, motivo: 'já cumpriu; carta mais alta que não faz' };
+  }
+
+  return { carta: cartaMaisForte(avaliadas, estado.manilha).carta, motivo: 'já cumpriu; fuga impossível' };
+}
+
 function calcularNecessidade(estado: EstadoEmJogo, jogadorId: string): number {
   return (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
 }
@@ -53,6 +96,10 @@ function cartasQuePerdem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Cart
   const melhor = melhorCartaMesa(estado.mesa, estado.manilha);
   if (!melhor) return [];
   return avaliadas.filter((avaliada) => !cartaVence(avaliada.carta, melhor, estado.manilha));
+}
+
+function cartasQueNaoFazem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {
+  return cartasQuePerdem(estado, avaliadas);
 }
 
 function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -4,6 +4,48 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 
+const cenariosDeUltimo: {
+  nome: string;
+  mao: Carta[];
+  estado: EstadoEmJogo;
+  esperado: { carta: Carta; motivo: string };
+}[] = [
+  {
+    nome: 'deve escolher G[N-X] no último quando precisa fazer e tem ganhadoras',
+    mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' }),
+    esperado: { carta: criarCarta('8', '♦'), motivo: 'precisa fazer; regra G[N-X]' },
+  },
+  {
+    nome: 'deve escolher P[N-X] no último quando precisa fazer sem carta que vence',
+    mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
+    estado: criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' }),
+    esperado: { carta: criarCarta('9', '♦'), motivo: 'precisa fazer sem carta que vence; regra P[N-X]' },
+  },
+  {
+    nome: 'deve fugir no último com a carta mais alta que não faz quando já cumpriu',
+    mao: [criarCarta('Q', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' }),
+    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; carta mais alta que não faz' },
+  },
+  {
+    nome: 'deve tratar empate como carta que não faz no último quando já cumpriu',
+    mao: [criarCarta('K', '♦'), criarCarta('A', '♦')],
+    estado: criarEstado({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+      declaracoes: { bot: 1 },
+      vazas: { bot: 1 },
+    }),
+    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; carta mais alta que não faz' },
+  },
+  {
+    nome: 'deve jogar a carta mais alta no último quando fuga é impossível',
+    mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' }),
+    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; fuga impossível' },
+  },
+];
+
 describe('DecisorJogadaLinhaFria', () => {
   it('deve escolher G[N-X] quando precisa fazer e tem ganhadoras suficientes', deveEscolherGanhadoraPorNecessidade);
   it('deve escolher a ganhadora mais fraca quando ganhadoras são escassas', deveEscolherGanhadoraEscassa);
@@ -11,7 +53,9 @@ describe('DecisorJogadaLinhaFria', () => {
   it('deve escolher a perdedora mais fraca quando todas são candidatas futuras', deveEscolherPerdedoraEscassa);
   it('não deve tratar empate como carta que faz a vaza', deveRejeitarEmpateComoVitoria);
   it('deve ordenar ganhadoras por força real com manilha e desempate por naipe', deveOrdenarPorForcaReal);
-  it('deve expor árvore fria de último com carta e motivo', deveExporArvoreFriaDeUltimo);
+  it.each(cenariosDeUltimo)('$nome', ({ mao, estado, esperado }) => {
+    expect(decidirUltimoLinhaFria(mao, estado)).toEqual(esperado);
+  });
   it('deve fazer sem desperdiçar carta garantida quando ainda não é o último', devePreservarGarantida);
   it('deve seguir fuga do fim sem considerar necessidade do líder', deveIgnorarNecessidadeDoLiderNoFim);
   it('deve decidir abertura cautelosamente quando a mesa está vazia', deveDecidirAbertura);
@@ -20,7 +64,6 @@ describe('DecisorJogadaLinhaFria', () => {
 async function deveEscolherGanhadoraPorNecessidade(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(
     bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
   ).resolves.toEqual(criarCarta('8', '♦'));
@@ -29,7 +72,6 @@ async function deveEscolherGanhadoraPorNecessidade(): Promise<void> {
 async function deveEscolherGanhadoraEscassa(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 4 }, vazas: { bot: 0 }, manilha: '6' });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(
     bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
   ).resolves.toEqual(criarCarta('5', '♦'));
@@ -38,7 +80,6 @@ async function deveEscolherGanhadoraEscassa(): Promise<void> {
 async function deveEscolherPerdedoraPorNecessidade(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(
     bot.decidirJogada([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')], estado),
   ).resolves.toEqual(criarCarta('9', '♦'));
@@ -47,7 +88,6 @@ async function deveEscolherPerdedoraPorNecessidade(): Promise<void> {
 async function deveEscolherPerdedoraEscassa(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('6', '♦')], estado)).resolves.toEqual(
     criarCarta('4', '♦'),
   );
@@ -61,7 +101,6 @@ async function deveRejeitarEmpateComoVitoria(): Promise<void> {
     manilha: '5',
   });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(bot.decidirJogada([criarCarta('K', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
     criarCarta('A', '♦'),
   );
@@ -70,44 +109,14 @@ async function deveRejeitarEmpateComoVitoria(): Promise<void> {
 async function deveOrdenarPorForcaReal(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 }, manilha: '5' });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(bot.decidirJogada([criarCarta('5', '♦'), criarCarta('5', '♣')], estado)).resolves.toEqual(
     criarCarta('5', '♣'),
   );
 }
 
-function deveExporArvoreFriaDeUltimo(): void {
-  const cenarioG = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' });
-  const cenarioP = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' });
-  const impossivel = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' });
-
-  expect(decidirUltimoLinhaFria([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], cenarioG)).toEqual({
-    carta: criarCarta('8', '♦'),
-    motivo: 'precisa fazer; regra G[N-X]',
-  });
-  expect(
-    decidirUltimoLinhaFria(
-      [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
-      cenarioP,
-    ),
-  ).toEqual({ carta: criarCarta('9', '♦'), motivo: 'precisa fazer sem carta que vence; regra P[N-X]' });
-  expect(decidirUltimoLinhaFria([criarCarta('Q', '♦'), criarCarta('K', '♦')], estado)).toEqual({
-    carta: criarCarta('K', '♦'),
-    motivo: 'já cumpriu; carta mais alta que não faz',
-  });
-  expect(
-    decidirUltimoLinhaFria([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], impossivel),
-  ).toEqual({
-    carta: criarCarta('K', '♦'),
-    motivo: 'já cumpriu; fuga impossível',
-  });
-}
-
 async function devePreservarGarantida(): Promise<void> {
   const estado = criarEstado(cenarioGarantida());
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(bot.decidirJogada([criarCarta('6', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
     criarCarta('6', '♦'),
   );
@@ -116,19 +125,13 @@ async function devePreservarGarantida(): Promise<void> {
 async function deveIgnorarNecessidadeDoLiderNoFim(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 1, bot: 0 }, vazas: { j1: 0, bot: 0 } });
   const bot = new DecisorJogadaLinhaFria();
-
   await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
     criarCarta('Q', '♠'),
   );
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
-  const jogadores = [
-    criarJogador('j1', 'J1'),
-    criarJogador('j2', 'J2'),
-    criarJogador('j3', 'J3'),
-    criarJogador('bot', 'Bot'),
-  ];
+  const jogadores = ['j1', 'j2', 'j3', 'bot'].map((id) => criarJogador(id, id === 'bot' ? 'Bot' : id.toUpperCase()));
   return {
     fase: 'aguardandoJogada',
     jogadorAtual: 3,
@@ -194,6 +197,5 @@ async function deveDecidirAbertura(): Promise<void> {
   });
   const bot = new DecisorJogadaLinhaFria();
   const mao = [criarCarta('3', '♦'), criarCarta('8', '♦')];
-
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('8', '♦'));
 }

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -1,35 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { DecisorJogadaLinhaFria, decidirUltimoLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
 import type { Carta } from '@/core/Carta';
-import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
 
 describe('DecisorJogadaLinhaFria', () => {
-  it('deve fazer a vaza quando é o último, precisa fazer e tem carta que ganha', deveFazerVazaNoFim);
   it('deve escolher G[N-X] quando precisa fazer e tem ganhadoras suficientes', deveEscolherGanhadoraPorNecessidade);
   it('deve escolher a ganhadora mais fraca quando ganhadoras são escassas', deveEscolherGanhadoraEscassa);
   it('deve escolher P[N-X] quando precisa fazer mas não consegue agora', deveEscolherPerdedoraPorNecessidade);
   it('deve escolher a perdedora mais fraca quando todas são candidatas futuras', deveEscolherPerdedoraEscassa);
   it('não deve tratar empate como carta que faz a vaza', deveRejeitarEmpateComoVitoria);
   it('deve ordenar ganhadoras por força real com manilha e desempate por naipe', deveOrdenarPorForcaReal);
-  it('deve jogar o menor prejuízo quando é o último, precisa fazer e não tem carta que ganha', deveJogarMenorPrejuizo);
-  it('deve fugir com a carta alta que ainda perde quando já cumpriu', deveFugirComCartaAlta);
-  it('deve contar empate como fuga quando é o último e não quer fazer', deveFugirComEmpateNoFim);
-  it('deve jogar a mais forte quando fuga é impossível no fim', deveDescartarMaisForteSemFuga);
+  it('deve expor árvore fria de último com carta e motivo', deveExporArvoreFriaDeUltimo);
   it('deve fazer sem desperdiçar carta garantida quando ainda não é o último', devePreservarGarantida);
   it('deve seguir fuga do fim sem considerar necessidade do líder', deveIgnorarNecessidadeDoLiderNoFim);
   it('deve decidir abertura cautelosamente quando a mesa está vazia', deveDecidirAbertura);
 });
-
-async function deveFazerVazaNoFim(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 } });
-  const bot = new DecisorJogadaLinhaFria();
-
-  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
-    criarCarta('3', '♦'),
-  );
-}
 
 async function deveEscolherGanhadoraPorNecessidade(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' });
@@ -90,40 +76,32 @@ async function deveOrdenarPorForcaReal(): Promise<void> {
   );
 }
 
-async function deveJogarMenorPrejuizo(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 } });
-  const bot = new DecisorJogadaLinhaFria();
-
-  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
-    criarCarta('Q', '♠'),
-  );
-}
-
-async function deveFugirComCartaAlta(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 } });
-  const bot = new DecisorJogadaLinhaFria();
-
-  await expect(bot.decidirJogada([criarCarta('4', '♦'), criarCarta('Q', '♠')], estado)).resolves.toEqual(
-    criarCarta('Q', '♠'),
-  );
-}
-
-async function deveFugirComEmpateNoFim(): Promise<void> {
+function deveExporArvoreFriaDeUltimo(): void {
+  const cenarioG = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' });
+  const cenarioP = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' });
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' });
-  const bot = new DecisorJogadaLinhaFria();
+  const impossivel = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' });
 
-  await expect(bot.decidirJogada([criarCarta('Q', '♦'), criarCarta('K', '♦')], estado)).resolves.toEqual(
-    criarCarta('K', '♦'),
-  );
-}
-
-async function deveDescartarMaisForteSemFuga(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' });
-  const bot = new DecisorJogadaLinhaFria();
-
-  await expect(
-    bot.decidirJogada([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
-  ).resolves.toEqual(criarCarta('K', '♦'));
+  expect(decidirUltimoLinhaFria([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], cenarioG)).toEqual({
+    carta: criarCarta('8', '♦'),
+    motivo: 'precisa fazer; regra G[N-X]',
+  });
+  expect(
+    decidirUltimoLinhaFria(
+      [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
+      cenarioP,
+    ),
+  ).toEqual({ carta: criarCarta('9', '♦'), motivo: 'precisa fazer sem carta que vence; regra P[N-X]' });
+  expect(decidirUltimoLinhaFria([criarCarta('Q', '♦'), criarCarta('K', '♦')], estado)).toEqual({
+    carta: criarCarta('K', '♦'),
+    motivo: 'já cumpriu; carta mais alta que não faz',
+  });
+  expect(
+    decidirUltimoLinhaFria([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], impossivel),
+  ).toEqual({
+    carta: criarCarta('K', '♦'),
+    motivo: 'já cumpriu; fuga impossível',
+  });
 }
 
 async function devePreservarGarantida(): Promise<void> {
@@ -145,7 +123,12 @@ async function deveIgnorarNecessidadeDoLiderNoFim(): Promise<void> {
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
-  const jogadores = criarJogadores();
+  const jogadores = [
+    criarJogador('j1', 'J1'),
+    criarJogador('j2', 'J2'),
+    criarJogador('j3', 'J3'),
+    criarJogador('bot', 'Bot'),
+  ];
   return {
     fase: 'aguardandoJogada',
     jogadorAtual: 3,
@@ -161,10 +144,6 @@ function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
     turno: 1,
     ...config,
   };
-}
-
-function criarJogadores(): Jogador[] {
-  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
 }
 
 function mesaComK(): MesaItem[] {


### PR DESCRIPTION
## Summary

- Explicita a decisão da linha fria quando o bot é o último da mesa em `decidirUltimoLinhaFria`.
- Retorna carta e motivo para preparar o contrato de debug sem inferência posterior.
- Mantém a estratégia quente e o mecanismo de temperatura inalterados.

## Tests

- `pnpm vitest run tests/adapters/DecisorJogadaLinhaFria.test.ts tests/adapters/DecisorJogadaLinhaQuente.test.ts tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts tests/adapters/DecisorJogadaBot.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #188