### PR TITLE
fix: respeita bifurcação do último bot

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -13,8 +13,8 @@ import {
   escolherPressao,
   escolherTravessia,
   MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS,
+  MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
   MOTIVO_SEM_BIFURCACAO_NAO_PODE,
-  MOTIVO_SEM_BIFURCACAO_ULTIMO,
   podeBifurcar,
 } from './regras-linha-quente';
 
@@ -55,8 +55,21 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
-    const carta = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
-    return this.registrarSemBifurcacao(base, carta, MOTIVO_SEM_BIFURCACAO_ULTIMO);
+    const quente = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
+    if (cartasIguais(base.fria, quente)) {
+      return this.registrarSemBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
+    }
+
+    const sorteio = this.rng.random();
+    return registrarBifurcacao({
+      logger: this.logger,
+      temperatura: this.temperatura,
+      mao: base.mao,
+      estado: base.estado,
+      fria: base.fria,
+      quente,
+      sorteio,
+    });
   }
 
   private decidirAntesDoFim(base: BaseJogada): Carta {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -56,20 +56,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
     const quente = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
-    if (cartasIguais(base.fria, quente)) {
-      return this.registrarSemBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
-    }
-
-    const sorteio = this.rng.random();
-    return registrarBifurcacao({
-      logger: this.logger,
-      temperatura: this.temperatura,
-      mao: base.mao,
-      estado: base.estado,
-      fria: base.fria,
-      quente,
-      sorteio,
-    });
+    return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
   }
 
   private decidirAntesDoFim(base: BaseJogada): Carta {
@@ -81,8 +68,12 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     }
 
     const quente = escolherPressao(base.contexto).carta;
+    return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
+  }
+
+  private resolverBifurcacao(base: BaseJogada, quente: Carta, motivoSemBifurcacao: string): Carta {
     if (cartasIguais(base.fria, quente)) {
-      return this.registrarSemBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
+      return this.registrarSemBifurcacao(base, quente, motivoSemBifurcacao);
     }
 
     const sorteio = this.rng.random();

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -17,8 +17,8 @@ export function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuent
 export const MOTIVO_SEM_BIFURCACAO_URGENCIA = 'sem bifurcação: ambas fazem porque urgência >= 0.66';
 export const MOTIVO_SEM_BIFURCACAO_FUGA_IMPOSSIVEL = 'sem bifurcação: fuga impossível';
 export const MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS = 'sem bifurcação: ambas não querem fazer e escolheram a mesma carta';
+export const MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS = 'sem bifurcação: linhas fria e quente escolheram a mesma carta';
 export const MOTIVO_SEM_BIFURCACAO_NAO_PODE = 'sem bifurcação: não há condições para bifurcar';
-export const MOTIVO_SEM_BIFURCACAO_ULTIMO = 'sem bifurcação: último da mesa';
 
 export function cartasIguais(a: Carta, b: Carta): boolean {
   return a.valor === b.valor && a.naipe === b.naipe;

--- a/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
 import type { Carta } from '@/core/Carta';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
@@ -15,6 +16,8 @@ describe('DecisorJogadaLinhaQuente no fim da mesa', () => {
   it('deve fugir com a maior perdedora quando líder não precisa', fogeComMaiorPerdedora);
   it('deve empatar quando líder não precisa e só há empate como fuga', empataQuandoSoHaEmpate);
   it('deve jogar a carta mais forte quando todas fazem', jogaMaisForteSemFuga);
+  it('deve sortear por temperatura quando linha fria difere da quente', sorteiaQuandoLinhasDiferem);
+  it('deve registrar sem bifurcação quando linhas convergem', registraSemBifurcacaoQuandoConverge);
 });
 
 async function atravessaLiderAlta(): Promise<void> {
@@ -70,6 +73,43 @@ async function jogaMaisForteSemFuga(): Promise<void> {
   );
 }
 
+async function sorteiaQuandoLinhasDiferem(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 0 } });
+  const random = vi.fn(() => 0);
+  const decisor = new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random }, liderBaixa: 8, liderAlta: 11 });
+
+  await expect(decisor.decidirJogada([criarCarta('Q', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
+    criarCarta('Q', '♦'),
+  );
+  expect(random).toHaveBeenCalledOnce();
+}
+
+async function registraSemBifurcacaoQuandoConverge(): Promise<void> {
+  const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
+  const random = vi.fn(() => 0);
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const decisor = new DecisorJogadaLinhaQuente({
+    temperatura: 1,
+    rng: { random },
+    liderBaixa: 8,
+    liderAlta: 11,
+    logger: {
+      registrarDeclaracao: () => undefined,
+      registrarJogada: (jogada) => jogadas.push(jogada),
+    },
+  });
+
+  await decisor.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado);
+
+  expect(random).not.toHaveBeenCalled();
+  expect(jogadas[0]).toMatchObject({
+    carta: criarCarta('8', '♦'),
+    linhaFria: criarCarta('8', '♦'),
+    linhaQuente: criarCarta('8', '♦'),
+    motivoSemBifurcacao: 'sem bifurcação: linhas fria e quente escolheram a mesma carta',
+  });
+}
+
 function jogarContraNove(estado: EstadoEmJogo): Promise<Carta> {
   const mao = [criarCarta('6', '♦'), criarCarta('Q', '♦'), criarCarta('A', '♦')];
   return bot().decidirJogada(mao, estado);
@@ -107,6 +147,14 @@ function mesaComDois(): MesaItem[] {
     { jogadorId: 'j1', carta: criarCarta('2', '♣') },
     { jogadorId: 'j2', carta: criarCarta('7', '♥') },
     { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComQuatro(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('4', '♠') },
   ];
 }
 


### PR DESCRIPTION
## Summary

- Compara linha fria e linha quente quando o bot é o último da mesa.
- Usa o sorteio por temperatura quando as linhas divergem.
- Registra `sem bifurcação` apenas quando as linhas convergem, com motivo explícito.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Closes #187