### PR TITLE
feat: motivos confiáveis quando bot não é último a jogar (#194)

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -15,33 +15,51 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
     if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
 
     const estadoAtual = estadoEmJogo(estado);
-    if (estadoAtual.mesa.length === 0) {
-      return Promise.resolve(decidirAbertura(mao, estadoAtual, { temperatura: 0 }));
-    }
-
-    const avaliadas = avaliarCartas(mao, estadoAtual.manilha, estadoAtual.cartasReveladas, estadoAtual.maos.length);
-    const jogadorId = estadoAtual.maos[estadoAtual.jogadorAtual].jogador.id;
-    const necessidade = calcularNecessidade(estadoAtual, jogadorId);
-
     if (ehUltimoDaMesa(estadoAtual)) return Promise.resolve(decidirUltimoLinhaFria(mao, estadoAtual).carta);
-    if (necessidade <= 0) return Promise.resolve(this.fugir(estadoAtual, avaliadas));
-    return Promise.resolve(this.buscarVaza(estadoAtual, avaliadas, necessidade));
+    return Promise.resolve(decidirNaoUltimoLinhaFria(mao, estadoAtual).carta);
+  }
+}
+
+export function decidirNaoUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoLinhaFria {
+  if (estado.mesa.length === 0) {
+    return {
+      carta: decidirAbertura(mao, estado, { temperatura: 0 }),
+      motivo: 'abertura: sem referência na mesa',
+    };
   }
 
-  private fugir(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Carta {
-    const naoFazem = cartasQueNaoFazem(estado, avaliadas);
-    if (naoFazem.length === 0) return cartaMaisBarata(avaliadas).carta;
-    return cartaMaisCara(naoFazem).carta;
+  const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
+  const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
+  const necessidade = calcularNecessidade(estado, jogadorId);
+  if (necessidade <= 0) return fugirNaoUltimo(estado, avaliadas);
+  return buscarVazaNaoUltimo(estado, avaliadas, necessidade);
+}
+
+function fugirNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): DecisaoLinhaFria {
+  const naoFazem = cartasQueNaoFazem(estado, avaliadas);
+  if (naoFazem.length === 0) {
+    return { carta: cartaMaisBarata(avaliadas).carta, motivo: 'não quer fazer; fuga impossível' };
+  }
+  return { carta: cartaMaisCara(naoFazem).carta, motivo: 'não quer fazer; carta mais alta que não faz' };
+}
+
+function buscarVazaNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], necessidade: number): DecisaoLinhaFria {
+  const vencedoras = cartasQueVencem(estado, avaliadas);
+  if (vencedoras.length > 0) {
+    return {
+      carta: escolherGanhadora(vencedoras, estado.manilha, necessidade).carta,
+      motivo: 'precisa fazer; regra G[N-X]',
+    };
   }
 
-  private buscarVaza(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], necessidade: number): Carta {
-    const vencedoras = cartasQueVencem(estado, avaliadas);
-    if (vencedoras.length > 0) return escolherGanhadora(vencedoras, estado.manilha, necessidade).carta;
-
-    const naoFazem = cartasQueNaoFazem(estado, avaliadas);
-    if (naoFazem.length > 0) return escolherPerdedora(naoFazem, estado.manilha, necessidade).carta;
-    return cartaMaisBarata(avaliadas).carta;
+  const naoFazem = cartasQueNaoFazem(estado, avaliadas);
+  if (naoFazem.length > 0) {
+    return {
+      carta: escolherPerdedora(naoFazem, estado.manilha, necessidade).carta,
+      motivo: 'precisa fazer; regra P[N-X]',
+    };
   }
+  return { carta: cartaMaisBarata(avaliadas).carta, motivo: 'precisa fazer; carta mais barata' };
 }
 
 export function decidirUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoLinhaFria {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -4,7 +4,7 @@ import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { criarContextoLinhaQuente, ehUltimoDaMesa, type ContextoJogadaQuente } from './contextoLinhaQuente';
 import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
-import { decidirUltimoLinhaFria, DecisorJogadaLinhaFria } from './DecisorJogadaLinhaFria';
+import { decidirNaoUltimoLinhaFria, decidirUltimoLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
 import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
 import {
@@ -12,9 +12,10 @@ import {
   escolherEmpate,
   escolherPressao,
   escolherTravessia,
+  formatarMotivoRecusaBifurcacao,
+  type DecisaoCartaQuente,
   MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS,
   MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
-  MOTIVO_SEM_BIFURCACAO_NAO_PODE,
   podeBifurcar,
 } from './regras-linha-quente';
 
@@ -27,7 +28,6 @@ interface ConfigLinhaQuente {
 }
 
 export class DecisorJogadaLinhaQuente implements DecisorJogada {
-  private readonly fria = new DecisorJogadaLinhaFria();
   private readonly temperatura: number;
   private readonly rng: Pick<GeradorAleatorio, 'random'>;
   private readonly liderBaixa: number;
@@ -50,20 +50,20 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
     if (ehUltimoDaMesa(estadoAtual)) {
       const decisaoFria = decidirUltimoLinhaFria(mao, estadoAtual);
-      const base = { mao, estado, estadoAtual, contexto, fria: decisaoFria.carta };
-      return this.decidirUltimaJogada(base, decisaoFria.motivo);
+      const base = criarBaseJogada({ mao, estado, estadoAtual, contexto, decisaoFria });
+      return this.decidirUltimaJogada(base);
     }
 
-    const fria = await this.fria.decidirJogada(mao, estado);
-    return this.decidirAntesDoFim({ mao, estado, estadoAtual, contexto, fria });
+    const decisaoFria = decidirNaoUltimoLinhaFria(mao, estadoAtual);
+    const base = criarBaseJogada({ mao, estado, estadoAtual, contexto, decisaoFria });
+    return this.decidirAntesDoFim(base);
   }
 
-  private decidirUltimaJogada(base: BaseJogada, motivoLinhaFria: string): Carta {
+  private decidirUltimaJogada(base: BaseJogada): Carta {
     const quente = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
     return this.resolverBifurcacaoUltimo({
       base,
       quente,
-      motivoLinhaFria,
       motivoSemBifurcacao: MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
     });
   }
@@ -72,17 +72,22 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     const direta = this.escolherQuenteDireta(base);
     if (direta) return direta;
 
-    if (!podeBifurcar(base.estadoAtual, base.contexto, this.liderBaixa)) {
-      return this.registrarSemBifurcacao(base, base.fria, MOTIVO_SEM_BIFURCACAO_NAO_PODE);
+    const bifurcacao = podeBifurcar(base.estadoAtual, base.contexto, this.liderBaixa);
+    if (!bifurcacao.pode) {
+      const motivo = bifurcacao.motivoRecusa
+        ? formatarMotivoRecusaBifurcacao(bifurcacao.motivoRecusa)
+        : MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS;
+      return this.registrarSemBifurcacao(base, base.fria, motivo);
     }
 
-    const quente = escolherPressao(base.contexto).carta;
+    const quente = escolherPressao(base.contexto);
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
   }
 
-  private resolverBifurcacao(base: BaseJogada, quente: Carta, motivoSemBifurcacao: string): Carta {
-    if (cartasIguais(base.fria, quente)) {
-      return this.registrarSemBifurcacao(base, quente, motivoSemBifurcacao);
+  private resolverBifurcacao(base: BaseJogada, quente: DecisaoCartaQuente, motivoSemBifurcacao: string): Carta {
+    const cartaQuente = quente.carta.carta;
+    if (cartasIguais(base.fria, cartaQuente)) {
+      return this.registrarSemBifurcacao(base, cartaQuente, motivoSemBifurcacao);
     }
 
     const sorteio = this.rng.random();
@@ -92,7 +97,9 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       mao: base.mao,
       estado: base.estado,
       fria: base.fria,
-      quente,
+      quente: cartaQuente,
+      motivoLinhaFria: base.motivoLinhaFria,
+      motivoLinhaQuente: quente.motivo,
       sorteio,
     });
   }
@@ -110,7 +117,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       estado: config.base.estado,
       fria: config.base.fria,
       quente: config.quente.carta,
-      motivoLinhaFria: config.motivoLinhaFria,
+      motivoLinhaFria: config.base.motivoLinhaFria,
       motivoLinhaQuente: config.quente.motivo,
       sorteio,
     });
@@ -118,20 +125,11 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
   private escolherQuenteDireta(base: BaseJogada): Carta | null {
     const empate = escolherEmpate(base.contexto, this.liderAlta);
-    if (empate)
-      return this.registrarQuente(
-        base,
-        empate.carta,
-        'linha quente empatou: líder precisa fazer e carta do líder é alta+',
-      );
+    if (empate) return this.registrarQuente(base, empate.carta.carta, `linha quente empatou: ${empate.motivo}`);
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
     if (!travessia) return null;
-    return this.registrarQuente(
-      base,
-      travessia.carta,
-      'linha quente atravessou: líder precisa fazer e carta do líder é alta+',
-    );
+    return this.registrarQuente(base, travessia.carta.carta, `linha quente atravessou: ${travessia.motivo}`);
   }
 
   private registrarQuente(base: BaseJogada, carta: Carta, motivoLinhaQuente: string): Carta {
@@ -142,6 +140,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       carta,
       linhaFria: base.fria,
       linhaQuente: carta,
+      motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente,
       escolheuQuente: true,
     });
@@ -155,6 +154,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       carta: linhaQuente,
       linhaFria: base.fria,
       linhaQuente,
+      motivoLinhaFria: base.motivoLinhaFria,
       motivoSemBifurcacao: motivo,
       escolheuQuente: false,
     });
@@ -168,7 +168,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       carta: config.quente.carta,
       linhaFria: config.base.fria,
       linhaQuente: config.quente.carta,
-      motivoLinhaFria: config.motivoLinhaFria,
+      motivoLinhaFria: config.base.motivoLinhaFria,
       motivoLinhaQuente: config.quente.motivo,
       motivoSemBifurcacao: config.motivoSemBifurcacao,
       escolheuQuente: false,
@@ -179,7 +179,6 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 interface ResolucaoUltimo {
   base: BaseJogada;
   quente: { carta: Carta; motivo: string };
-  motivoLinhaFria: string;
   motivoSemBifurcacao: string;
 }
 
@@ -189,4 +188,24 @@ interface BaseJogada {
   estadoAtual: EstadoEmJogo;
   contexto: ContextoJogadaQuente;
   fria: Carta;
+  motivoLinhaFria: string;
+}
+
+interface ConfigBaseJogada {
+  mao: Carta[];
+  estado: EstadoRodada;
+  estadoAtual: EstadoEmJogo;
+  contexto: ContextoJogadaQuente;
+  decisaoFria: { carta: Carta; motivo: string };
+}
+
+function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
+  return {
+    mao: config.mao,
+    estado: config.estado,
+    estadoAtual: config.estadoAtual,
+    contexto: config.contexto,
+    fria: config.decisaoFria.carta,
+    motivoLinhaFria: config.decisaoFria.motivo,
+  };
 }

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -3,15 +3,28 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade, liderQuerVaza, type ContextoJogadaQuente } from './contextoLinhaQuente';
 
-export function podeBifurcar(estado: EstadoEmJogo, contexto: ContextoJogadaQuente, liderBaixa: number): boolean {
-  return (
-    contexto.necessidade > 0 &&
-    contexto.vencedoras.length > 0 &&
-    mesaPodePunir(estado, contexto, liderBaixa) &&
-    temSegurancaParaDepois(contexto) &&
-    temPressaoAgora(contexto) &&
-    temAlvo(estado, contexto.jogadorId)
-  );
+export interface ResultadoPodeBifurcar {
+  pode: boolean;
+  motivoRecusa?: string;
+}
+
+export interface DecisaoCartaQuente {
+  carta: CartaAvaliada;
+  motivo: string;
+}
+
+export function podeBifurcar(
+  estado: EstadoEmJogo,
+  contexto: ContextoJogadaQuente,
+  liderBaixa: number,
+): ResultadoPodeBifurcar {
+  if (contexto.necessidade <= 0) return { pode: false, motivoRecusa: 'sem necessidade' };
+  if (contexto.vencedoras.length === 0) return { pode: false, motivoRecusa: 'sem vencedoras' };
+  if (!mesaPodePunir(estado, contexto, liderBaixa)) return { pode: false, motivoRecusa: 'mesa não pode punir' };
+  if (!temSegurancaParaDepois(contexto)) return { pode: false, motivoRecusa: 'sem segurança para depois' };
+  if (!temPressaoAgora(contexto)) return { pode: false, motivoRecusa: 'sem pressão agora' };
+  if (!temAlvo(estado, contexto.jogadorId)) return { pode: false, motivoRecusa: 'sem alvo na mesa' };
+  return { pode: true };
 }
 
 export const MOTIVO_SEM_BIFURCACAO_URGENCIA = 'sem bifurcação: ambas fazem porque urgência >= 0.66';
@@ -20,17 +33,24 @@ export const MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS = 'sem bifurcação: ambas não
 export const MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS = 'sem bifurcação: linhas fria e quente escolheram a mesma carta';
 export const MOTIVO_SEM_BIFURCACAO_NAO_PODE = 'sem bifurcação: não há condições para bifurcar';
 
+export function formatarMotivoRecusaBifurcacao(motivoRecusa: string): string {
+  return `sem bifurcação: ${motivoRecusa}`;
+}
+
 export function cartasIguais(a: Carta, b: Carta): boolean {
   return a.valor === b.valor && a.naipe === b.naipe;
 }
 
-export function escolherPressao(contexto: ContextoJogadaQuente): CartaAvaliada {
+export function escolherPressao(contexto: ContextoJogadaQuente): DecisaoCartaQuente {
   const fuga = cartasDeFuga(contexto);
-  if (fuga.length > 0) return cartaMaisCara(fuga);
-  return cartaMaisBarata(vencedorasBaratasSemGarantida(contexto));
+  if (fuga.length > 0) return { carta: cartaMaisCara(fuga), motivo: 'pressão: fuga mais cara' };
+  return {
+    carta: cartaMaisBarata(vencedorasBaratasSemGarantida(contexto)),
+    motivo: 'pressão: vencedora barata sem garantida',
+  };
 }
 
-export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): CartaAvaliada | null {
+export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): DecisaoCartaQuente | null {
   if (
     contexto.necessidade <= 0 ||
     contexto.folga > 1 ||
@@ -40,13 +60,16 @@ export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada
     return null;
   }
   const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
-  return candidatas.length > 0 ? cartaMaisBarata(candidatas) : null;
+  if (candidatas.length === 0) return null;
+  return { carta: cartaMaisBarata(candidatas), motivo: 'travessia: líder alta+ e urgência baixa' };
 }
 
-export function escolherEmpate(contexto: ContextoJogadaQuente, liderAlta: number): CartaAvaliada | null {
+export function escolherEmpate(contexto: ContextoJogadaQuente, liderAlta: number): DecisaoCartaQuente | null {
   const lider = contexto.lider;
   if (!lider || lider.score <= liderAlta || contexto.empates.length === 0) return null;
-  if (contexto.necessidade <= 0 || contexto.folga >= 2) return cartaMaisCara(contexto.empates);
+  if (contexto.necessidade <= 0 || contexto.folga >= 2) {
+    return { carta: cartaMaisCara(contexto.empates), motivo: 'empate com líder alta+' };
+  }
   return null;
 }
 

--- a/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
+++ b/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { decidirNaoUltimoLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+const cenarios: {
+  nome: string;
+  mao: Carta[];
+  estado: EstadoEmJogo;
+  esperado: { carta: Carta; motivo: string };
+}[] = [
+  {
+    nome: 'deve abrir com motivo de sem referência na mesa',
+    mao: [criarCarta('3', '♦'), criarCarta('8', '♦')],
+    estado: criarEstado({
+      mesa: [],
+      declaracoes: { bot: 0 },
+      vazas: { bot: 0 },
+      cartasReveladas: cartasQueGarantemTresDeOuros(),
+    }),
+    esperado: { carta: criarCarta('8', '♦'), motivo: 'abertura: sem referência na mesa' },
+  },
+  {
+    nome: 'deve fugir com carta mais alta que não faz',
+    mao: [criarCarta('Q', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' }),
+    esperado: { carta: criarCarta('K', '♦'), motivo: 'não quer fazer; carta mais alta que não faz' },
+  },
+  {
+    nome: 'deve indicar fuga impossível quando todas fazem',
+    mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' }),
+    esperado: { carta: criarCarta('5', '♦'), motivo: 'não quer fazer; fuga impossível' },
+  },
+  {
+    nome: 'deve buscar vaza com G[N-X] quando precisa fazer e tem vencedoras',
+    mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
+    estado: criarEstado({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' }),
+    esperado: { carta: criarCarta('8', '♦'), motivo: 'precisa fazer; regra G[N-X]' },
+  },
+  {
+    nome: 'deve buscar vaza com P[N-X] quando precisa fazer sem vencedoras',
+    mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
+    estado: criarEstado({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' }),
+    esperado: { carta: criarCarta('9', '♦'), motivo: 'precisa fazer; regra P[N-X]' },
+  },
+];
+
+describe('decidirNaoUltimoLinhaFria', () => {
+  it.each(cenarios)('$nome', ({ mao, estado, esperado }) => {
+    expect(decidirNaoUltimoLinhaFria(mao, estado)).toEqual(esperado);
+  });
+});
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = ['j1', 'j2', 'j3', 'bot'].map((id) => criarJogador(id, id === 'bot' ? 'Bot' : id.toUpperCase()));
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function mesaComK(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComQuatro(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('4', '♠') },
+  ];
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('4', '♣'),
+    criarCarta('4', '♥'),
+    criarCarta('4', '♠'),
+    criarCarta('4', '♦'),
+  ];
+}

--- a/tests/adapters/regras-linha-quente.test.ts
+++ b/tests/adapters/regras-linha-quente.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
+import { escolherEmpate, escolherPressao, escolherTravessia, podeBifurcar } from '@/adapters/bots/regras-linha-quente';
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+describe('podeBifurcar', () => {
+  it('deve recusar quando não há necessidade', () => {
+    const estado = criarEstado({ mesa: mesaComBaixa(), declaracoes: { j2: 1, bot: 1 }, vazas: { j2: 1, bot: 1 } });
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('A', '♦'), criarCarta('3', '♦')]);
+
+    expect(podeBifurcar(estado, contexto, 8)).toEqual({ pode: false, motivoRecusa: 'sem necessidade' });
+  });
+
+  it('deve recusar quando não há vencedoras', () => {
+    const estado = criarEstado({
+      mesa: mesaComK(),
+      declaracoes: { j1: 1, bot: 2 },
+      vazas: { j1: 0, bot: 0 },
+    });
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('4', '♦'), criarCarta('6', '♦')]);
+
+    expect(podeBifurcar(estado, contexto, 8)).toEqual({ pode: false, motivoRecusa: 'sem vencedoras' });
+  });
+
+  it('deve permitir bifurcação quando todas as condições passam', () => {
+    const estado = criarEstado(cenarioBifurcacao());
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('3', '♦'), criarCarta('4', '♦')]);
+
+    expect(podeBifurcar(estado, contexto, 8)).toEqual({ pode: true });
+  });
+});
+
+describe('escolherEmpate', () => {
+  it('deve retornar carta e motivo quando já cumpriu e líder é alta+', () => {
+    const estado = criarEstado({ mesa: mesaComDois(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('2', '♦'), criarCarta('4', '♦')]);
+
+    const decisao = escolherEmpate(contexto, 11);
+    expect(decisao?.carta.carta).toEqual(criarCarta('2', '♦'));
+    expect(decisao?.motivo).toBe('empate com líder alta+');
+  });
+});
+
+describe('escolherTravessia', () => {
+  it('deve retornar carta e motivo quando precisa com folga baixa', () => {
+    const estado = criarEstado({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+      declaracoes: { j1: 1, bot: 1 },
+      vazas: { j1: 0, bot: 0 },
+    });
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('A', '♦'), criarCarta('3', '♦')]);
+
+    const decisao = escolherTravessia(estado, contexto);
+    expect(decisao?.carta.carta).toEqual(criarCarta('A', '♦'));
+    expect(decisao?.motivo).toBe('travessia: líder alta+ e urgência baixa');
+  });
+});
+
+describe('escolherPressao', () => {
+  it('deve preferir fuga mais cara quando há cartas de fuga', () => {
+    const estado = criarEstado(cenarioBifurcacao());
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('3', '♦'), criarCarta('4', '♦')]);
+
+    expect(escolherPressao(contexto).motivo).toBe('pressão: fuga mais cara');
+  });
+});
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = [
+    criarJogador('j1', 'J1'),
+    criarJogador('j2', 'J2'),
+    criarJogador('j3', 'J3'),
+    criarJogador('bot', 'Bot'),
+  ];
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function cenarioBifurcacao(): Partial<EstadoEmJogo> {
+  return {
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+      { jogadorId: 'j3', carta: criarCarta('4', '♠') },
+    ],
+    declaracoes: { j1: 0, j2: 1, bot: 1 },
+    vazas: { j1: 0, j2: 0, bot: 0 },
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+  };
+}
+
+function mesaComBaixa(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('8', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('6', '♠') },
+  ];
+}
+
+function mesaComDois(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function mesaComK(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('K', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('5', '♣'),
+    criarCarta('5', '♥'),
+    criarCarta('5', '♠'),
+    criarCarta('5', '♦'),
+  ];
+}


### PR DESCRIPTION
## Summary

- Adiciona decidirNaoUltimoLinhaFria com motivo em abertura, fuga, busca de vaza (G[N-X]/P[N-X]) e fallback.
- Linha quente (escolherEmpate, escolherTravessia, escolherPressao) e podeBifurcar passam a retornar motivo junto com a decisão; o orquestrador propaga para o logger sem inferência posterior.
- Testes Vitest cobrem as funções puras novas/alteradas.

## Test plan

- [x] pnpm test (665 testes)
- [x] pnpm typecheck
- [x] pnpm lint
- [x] Validar no preview: debug do bot em jogada não-última mostra motivos distintos por linha e recusa de bifurcação específica

Closes #194

Made with [Cursor](https://cursor.com)