### PR TITLE
[codex] Corrige propagação de motivos do bot

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,23 +6,14 @@ import * as ts from 'typescript-eslint';
 
 export default defineConfig(
   {
-    ignores: [
-      'dist/**',
-      'node_modules/**',
-      'public/**',
-      'coverage/**',
-      '.pi/**',
-      '.sandcastle/worktrees/**',
-      'eslint.config.js',
-      'playwright.config.js',
-    ],
+    ignores: ['dist/**', 'node_modules/**', 'public/**', 'coverage/**', '.pi/**', '.sandcastle/worktrees/**'],
   },
   ts.configs.strictTypeChecked,
   {
     languageOptions: {
       globals: { ...globals.browser },
       parserOptions: {
-        project: ['./tsconfig.json', './tsconfig.tests.json', './.sandcastle/tsconfig.json'],
+        project: ['./tsconfig.eslint.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -39,7 +30,7 @@ export default defineConfig(
     settings: {
       'import/resolver': {
         typescript: {
-          project: ['./tsconfig.json', './tsconfig.tests.json', './.sandcastle/tsconfig.json'],
+          project: ['./tsconfig.eslint.json'],
         },
       },
     },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,6 @@ export default defineConfig({
   webServer: {
     command: 'pnpm dev',
     url: 'http://localhost:5173',
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     reuseExistingServer: !process.env.CI,
   },
   expect: {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -13,7 +13,6 @@ import {
   escolherPressao,
   escolherTravessia,
   formatarMotivoRecusaBifurcacao,
-  type DecisaoCartaQuente,
   MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS,
   MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
   podeBifurcar,
@@ -61,11 +60,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
     const quente = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
-    return this.resolverBifurcacaoUltimo({
-      base,
-      quente,
-      motivoSemBifurcacao: MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
-    });
+    return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
   }
 
   private decidirAntesDoFim(base: BaseJogada): Carta {
@@ -77,17 +72,16 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       const motivo = bifurcacao.motivoRecusa
         ? formatarMotivoRecusaBifurcacao(bifurcacao.motivoRecusa)
         : MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS;
-      return this.registrarSemBifurcacao(base, base.fria, motivo);
+      return this.registrarSemBifurcacao(base, { carta: base.fria, motivo }, motivo);
     }
 
     const quente = escolherPressao(base.contexto);
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
   }
 
-  private resolverBifurcacao(base: BaseJogada, quente: DecisaoCartaQuente, motivoSemBifurcacao: string): Carta {
-    const cartaQuente = quente.carta.carta;
-    if (cartasIguais(base.fria, cartaQuente)) {
-      return this.registrarSemBifurcacao(base, cartaQuente, motivoSemBifurcacao);
+  private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente, motivoSemBifurcacao: string): Carta {
+    if (cartasIguais(base.fria, quente.carta)) {
+      return this.registrarSemBifurcacao(base, quente, motivoSemBifurcacao);
     }
 
     const sorteio = this.rng.random();
@@ -97,39 +91,20 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       mao: base.mao,
       estado: base.estado,
       fria: base.fria,
-      quente: cartaQuente,
+      quente: quente.carta,
       motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente: quente.motivo,
       sorteio,
     });
   }
 
-  private resolverBifurcacaoUltimo(config: ResolucaoUltimo): Carta {
-    if (cartasIguais(config.base.fria, config.quente.carta)) {
-      return this.registrarSemBifurcacaoUltimo(config);
-    }
-
-    const sorteio = this.rng.random();
-    return registrarBifurcacao({
-      logger: this.logger,
-      temperatura: this.temperatura,
-      mao: config.base.mao,
-      estado: config.base.estado,
-      fria: config.base.fria,
-      quente: config.quente.carta,
-      motivoLinhaFria: config.base.motivoLinhaFria,
-      motivoLinhaQuente: config.quente.motivo,
-      sorteio,
-    });
-  }
-
   private escolherQuenteDireta(base: BaseJogada): Carta | null {
     const empate = escolherEmpate(base.contexto, this.liderAlta);
-    if (empate) return this.registrarQuente(base, empate.carta.carta, `linha quente empatou: ${empate.motivo}`);
+    if (empate) return this.registrarQuente(base, empate.carta, `linha quente empatou: ${empate.motivo}`);
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
     if (!travessia) return null;
-    return this.registrarQuente(base, travessia.carta.carta, `linha quente atravessou: ${travessia.motivo}`);
+    return this.registrarQuente(base, travessia.carta, `linha quente atravessou: ${travessia.motivo}`);
   }
 
   private registrarQuente(base: BaseJogada, carta: Carta, motivoLinhaQuente: string): Carta {
@@ -146,40 +121,25 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     });
   }
 
-  private registrarSemBifurcacao(base: BaseJogada, linhaQuente: Carta, motivo: string): Carta {
+  private registrarSemBifurcacao(base: BaseJogada, quente: DecisaoQuente, motivo: string): Carta {
     return registrarEscolhaDireta({
       logger: this.logger,
       mao: base.mao,
       estado: base.estado,
-      carta: linhaQuente,
+      carta: quente.carta,
       linhaFria: base.fria,
-      linhaQuente,
+      linhaQuente: quente.carta,
       motivoLinhaFria: base.motivoLinhaFria,
+      motivoLinhaQuente: quente.motivo,
       motivoSemBifurcacao: motivo,
-      escolheuQuente: false,
-    });
-  }
-
-  private registrarSemBifurcacaoUltimo(config: ResolucaoUltimo): Carta {
-    return registrarEscolhaDireta({
-      logger: this.logger,
-      mao: config.base.mao,
-      estado: config.base.estado,
-      carta: config.quente.carta,
-      linhaFria: config.base.fria,
-      linhaQuente: config.quente.carta,
-      motivoLinhaFria: config.base.motivoLinhaFria,
-      motivoLinhaQuente: config.quente.motivo,
-      motivoSemBifurcacao: config.motivoSemBifurcacao,
       escolheuQuente: false,
     });
   }
 }
 
-interface ResolucaoUltimo {
-  base: BaseJogada;
-  quente: { carta: Carta; motivo: string };
-  motivoSemBifurcacao: string;
+interface DecisaoQuente {
+  carta: Carta;
+  motivo: string;
 }
 
 interface BaseJogada {

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -9,7 +9,7 @@ export interface ResultadoPodeBifurcar {
 }
 
 export interface DecisaoCartaQuente {
-  carta: CartaAvaliada;
+  carta: Carta;
   motivo: string;
 }
 
@@ -43,9 +43,9 @@ export function cartasIguais(a: Carta, b: Carta): boolean {
 
 export function escolherPressao(contexto: ContextoJogadaQuente): DecisaoCartaQuente {
   const fuga = cartasDeFuga(contexto);
-  if (fuga.length > 0) return { carta: cartaMaisCara(fuga), motivo: 'pressão: fuga mais cara' };
+  if (fuga.length > 0) return { carta: cartaMaisCara(fuga).carta, motivo: 'pressão: fuga mais cara' };
   return {
-    carta: cartaMaisBarata(vencedorasBaratasSemGarantida(contexto)),
+    carta: cartaMaisBarata(vencedorasBaratasSemGarantida(contexto)).carta,
     motivo: 'pressão: vencedora barata sem garantida',
   };
 }
@@ -61,14 +61,14 @@ export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada
   }
   const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
   if (candidatas.length === 0) return null;
-  return { carta: cartaMaisBarata(candidatas), motivo: 'travessia: líder alta+ e urgência baixa' };
+  return { carta: cartaMaisBarata(candidatas).carta, motivo: 'travessia: líder alta+ e urgência baixa' };
 }
 
 export function escolherEmpate(contexto: ContextoJogadaQuente, liderAlta: number): DecisaoCartaQuente | null {
   const lider = contexto.lider;
   if (!lider || lider.score <= liderAlta || contexto.empates.length === 0) return null;
   if (contexto.necessidade <= 0 || contexto.folga >= 2) {
-    return { carta: cartaMaisCara(contexto.empates), motivo: 'empate com líder alta+' };
+    return { carta: cartaMaisCara(contexto.empates).carta, motivo: 'empate com líder alta+' };
   }
   return null;
 }

--- a/tests/adapters/regras-linha-quente.test.ts
+++ b/tests/adapters/regras-linha-quente.test.ts
@@ -38,7 +38,7 @@ describe('escolherEmpate', () => {
     const contexto = criarContextoLinhaQuente(estado, [criarCarta('2', '♦'), criarCarta('4', '♦')]);
 
     const decisao = escolherEmpate(contexto, 11);
-    expect(decisao?.carta.carta).toEqual(criarCarta('2', '♦'));
+    expect(decisao?.carta).toEqual(criarCarta('2', '♦'));
     expect(decisao?.motivo).toBe('empate com líder alta+');
   });
 });
@@ -53,7 +53,7 @@ describe('escolherTravessia', () => {
     const contexto = criarContextoLinhaQuente(estado, [criarCarta('A', '♦'), criarCarta('3', '♦')]);
 
     const decisao = escolherTravessia(estado, contexto);
-    expect(decisao?.carta.carta).toEqual(criarCarta('A', '♦'));
+    expect(decisao?.carta).toEqual(criarCarta('A', '♦'));
     expect(decisao?.motivo).toBe('travessia: líder alta+ e urgência baixa');
   });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.tests.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "types": ["vite/client", "@playwright/test", "node"]
+  },
+  "include": ["src", "tests", ".sandcastle/**/*.ts", "*.config.ts", "*.config.js"],
+  "exclude": ["dist", "node_modules", "public", "coverage", ".pi", ".sandcastle/worktrees"]
+}


### PR DESCRIPTION
## O que mudou

- Unifica a resolução de bifurcação da linha quente para último e não-último a jogar.
- Normaliza decisões quentes para carregar `{ carta, motivo }`, evitando o shape intermediário com `CartaAvaliada` no orquestrador.
- Garante que caminhos sem bifurcação também propaguem `motivoLinhaQuente` quando a linha quente já produziu motivo.
- Substitui a configuração relaxada do ESLint por um `tsconfig.eslint.json` único, mantendo configs sob lint e removendo o acoplamento por lista de projetos no ESLint.
- Remove um `eslint-disable` que ficou desnecessário em `playwright.config.js`.

## Por quê

A revisão termo-nuclear encontrou que o fluxo não-último descartava o motivo da linha quente quando a bifurcação convergia, mesmo depois de `escolherPressao` produzir um motivo válido. A causa era a duplicação entre `resolverBifurcacao` e `resolverBifurcacaoUltimo`, com contratos diferentes para a mesma ideia.

## Impacto

O debug do bot fica mais confiável nos caminhos convergentes e o arquivo `DecisorJogadaLinhaQuente.ts` volta a ficar abaixo do limite local de 200 linhas, com menos plumbing duplicado.

## Validação

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run tests/adapters/DecisorJogadaLinhaQuente.test.ts tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts tests/adapters/regras-linha-quente.test.ts tests/adapters/logger-debug-bot.test.ts tests/adapters/decidirUltimoLinhaQuente.test.ts tests/adapters/decidirNaoUltimoLinhaFria.test.ts`
- `pnpm build`
- pre-push hooks: `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`, `vitest run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal bot decision logic by consolidating multiple execution paths and simplifying card evaluation handling for improved code maintainability.

* **Chores**
  * Updated development configuration files for TypeScript compiler and ESLint analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->