### PR TITLE
Add explainable debug metadata to bot decisions

### DIFF
--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -2,6 +2,7 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
+import { criarContextoJogadaDebug, criarLinhaJogadaDebug } from './debug-jogada-bot';
 import { decidirAbertura } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
@@ -42,6 +43,9 @@ export class DecisorJogadaBot implements DecisorJogada {
         mao,
         linhaFria: carta,
         linhaQuente: carta,
+        contexto: criarContextoJogadaDebug(estado, mao.length),
+        fria: criarLinhaJogadaDebug(carta, 'abertura: árvore de abertura', ['jogada', 'abre a mesa', 'linha fria']),
+        quente: criarLinhaJogadaDebug(carta, 'abertura: segue linha fria', ['jogada', 'abre a mesa', 'linha quente']),
         carta,
         escolheuQuente: false,
       });

--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -2,10 +2,11 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
-import { criarContextoJogadaDebug, criarLinhaJogadaDebug } from './debug-jogada-bot';
+import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 import { decidirAbertura } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
+import { registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
 
 interface ConfigDecisorJogadaBot {
   temperatura: number;
@@ -38,18 +39,19 @@ export class DecisorJogadaBot implements DecisorJogada {
         temperatura: this.temperatura,
         urgenciaAbrirForte: this.urgenciaAbrirForte,
       });
-      this.logger?.registrarJogada({
-        estado,
+      return registrarEscolhaDireta({
+        logger: this.logger,
         mao,
+        estado,
+        carta,
         linhaFria: carta,
         linhaQuente: carta,
-        contexto: criarContextoJogadaDebug(estado, mao.length),
-        fria: criarLinhaJogadaDebug(carta, 'abertura: árvore de abertura', ['jogada', 'abre a mesa', 'linha fria']),
-        quente: criarLinhaJogadaDebug(carta, 'abertura: segue linha fria', ['jogada', 'abre a mesa', 'linha quente']),
-        carta,
+        motivoLinhaFria: 'abertura: árvore de abertura',
+        motivoLinhaQuente: 'abertura: segue linha fria',
+        caminhoLinhaFria: criarCaminhoJogadaDebug('abre', 'fria'),
+        caminhoLinhaQuente: criarCaminhoJogadaDebug('abre', 'quente'),
         escolheuQuente: false,
       });
-      return carta;
     }
 
     return this.quente.decidirJogada(mao, estado);

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -3,6 +3,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { criarContextoLinhaQuente, ehUltimoDaMesa, type ContextoJogadaQuente } from './contextoLinhaQuente';
+import { criarCaminhoJogadaDebug, type PosicaoMesaJogadaDebug } from './debug-jogada-bot';
 import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import { decidirNaoUltimoLinhaFria, decidirUltimoLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
@@ -59,11 +60,10 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
-    const quente = criarDecisaoQuente(decidirUltimoLinhaQuente(base.estadoAtual, base.contexto), [
-      'jogada',
-      'fecha a mesa',
-      'linha quente',
-    ]);
+    const quente = criarDecisaoQuente(
+      decidirUltimoLinhaQuente(base.estadoAtual, base.contexto),
+      criarCaminhoJogadaDebug(base.posicao, 'quente'),
+    );
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
   }
 
@@ -83,7 +83,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       );
     }
 
-    const quente = criarDecisaoQuente(escolherPressao(base.contexto), ['jogada', 'joga no meio', 'linha quente']);
+    const quente = criarDecisaoQuente(escolherPressao(base.contexto), criarCaminhoJogadaDebug(base.posicao, 'quente'));
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
   }
 
@@ -128,7 +128,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente,
       caminhoLinhaFria: base.caminhoLinhaFria,
-      caminhoLinhaQuente: ['jogada', 'linha quente', 'escolha direta'],
+      caminhoLinhaQuente: criarCaminhoJogadaDebug(base.posicao, 'quente', 'escolha direta'),
       escolheuQuente: true,
     });
   }
@@ -162,6 +162,7 @@ interface BaseJogada {
   estado: EstadoRodada;
   estadoAtual: EstadoEmJogo;
   contexto: ContextoJogadaQuente;
+  posicao: PosicaoMesaJogadaDebug;
   fria: Carta;
   motivoLinhaFria: string;
   caminhoLinhaFria: string[];
@@ -181,16 +182,17 @@ function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
     estado: config.estado,
     estadoAtual: config.estadoAtual,
     contexto: config.contexto,
+    posicao: definirPosicao(config.estadoAtual),
     fria: config.decisaoFria.carta,
     motivoLinhaFria: config.decisaoFria.motivo,
-    caminhoLinhaFria: ['jogada', caminhoPosicao(config.estadoAtual), 'linha fria'],
+    caminhoLinhaFria: criarCaminhoJogadaDebug(definirPosicao(config.estadoAtual), 'fria'),
   };
 }
 
-function caminhoPosicao(estado: EstadoEmJogo): string {
-  if (estado.mesa.length === 0) return 'abre a mesa';
-  if (ehUltimoDaMesa(estado)) return 'fecha a mesa';
-  return 'joga no meio';
+function definirPosicao(estado: EstadoEmJogo): PosicaoMesaJogadaDebug {
+  if (estado.mesa.length === 0) return 'abre';
+  if (ehUltimoDaMesa(estado)) return 'fecha';
+  return 'meio';
 }
 
 function criarDecisaoQuente(decisao: { carta: Carta; motivo: string }, caminho: string[]): DecisaoQuente {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -59,7 +59,11 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private decidirUltimaJogada(base: BaseJogada): Carta {
-    const quente = decidirUltimoLinhaQuente(base.estadoAtual, base.contexto);
+    const quente = criarDecisaoQuente(decidirUltimoLinhaQuente(base.estadoAtual, base.contexto), [
+      'jogada',
+      'fecha a mesa',
+      'linha quente',
+    ]);
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
   }
 
@@ -72,10 +76,14 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       const motivo = bifurcacao.motivoRecusa
         ? formatarMotivoRecusaBifurcacao(bifurcacao.motivoRecusa)
         : MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS;
-      return this.registrarSemBifurcacao(base, { carta: base.fria, motivo }, motivo);
+      return this.registrarSemBifurcacao(
+        base,
+        criarDecisaoQuente({ carta: base.fria, motivo }, base.caminhoLinhaFria),
+        motivo,
+      );
     }
 
-    const quente = escolherPressao(base.contexto);
+    const quente = criarDecisaoQuente(escolherPressao(base.contexto), ['jogada', 'joga no meio', 'linha quente']);
     return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
   }
 
@@ -94,6 +102,8 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       quente: quente.carta,
       motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente: quente.motivo,
+      caminhoLinhaFria: base.caminhoLinhaFria,
+      caminhoLinhaQuente: quente.caminho,
       sorteio,
     });
   }
@@ -117,6 +127,8 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       linhaQuente: carta,
       motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente,
+      caminhoLinhaFria: base.caminhoLinhaFria,
+      caminhoLinhaQuente: ['jogada', 'linha quente', 'escolha direta'],
       escolheuQuente: true,
     });
   }
@@ -131,6 +143,8 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       linhaQuente: quente.carta,
       motivoLinhaFria: base.motivoLinhaFria,
       motivoLinhaQuente: quente.motivo,
+      caminhoLinhaFria: base.caminhoLinhaFria,
+      caminhoLinhaQuente: quente.caminho,
       motivoSemBifurcacao: motivo,
       escolheuQuente: false,
     });
@@ -140,6 +154,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
 interface DecisaoQuente {
   carta: Carta;
   motivo: string;
+  caminho: string[];
 }
 
 interface BaseJogada {
@@ -149,6 +164,7 @@ interface BaseJogada {
   contexto: ContextoJogadaQuente;
   fria: Carta;
   motivoLinhaFria: string;
+  caminhoLinhaFria: string[];
 }
 
 interface ConfigBaseJogada {
@@ -167,5 +183,16 @@ function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
     contexto: config.contexto,
     fria: config.decisaoFria.carta,
     motivoLinhaFria: config.decisaoFria.motivo,
+    caminhoLinhaFria: ['jogada', caminhoPosicao(config.estadoAtual), 'linha fria'],
   };
+}
+
+function caminhoPosicao(estado: EstadoEmJogo): string {
+  if (estado.mesa.length === 0) return 'abre a mesa';
+  if (ehUltimoDaMesa(estado)) return 'fecha a mesa';
+  return 'joga no meio';
+}
+
+function criarDecisaoQuente(decisao: { carta: Carta; motivo: string }, caminho: string[]): DecisaoQuente {
+  return { ...decisao, caminho };
 }

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -4,6 +4,7 @@ import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { criarContextoLinhaQuente, ehUltimoDaMesa, type ContextoJogadaQuente } from './contextoLinhaQuente';
 import { criarCaminhoJogadaDebug, type PosicaoMesaJogadaDebug } from './debug-jogada-bot';
+import { criarDecisaoQuente, definirPosicao, type DecisaoQuente } from './debug-linha-quente';
 import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import { decidirNaoUltimoLinhaFria, decidirUltimoLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
@@ -78,7 +79,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
         : MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS;
       return this.registrarSemBifurcacao(
         base,
-        criarDecisaoQuente({ carta: base.fria, motivo }, base.caminhoLinhaFria),
+        criarDecisaoQuente({ carta: base.fria, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente')),
         motivo,
       );
     }
@@ -151,12 +152,6 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 }
 
-interface DecisaoQuente {
-  carta: Carta;
-  motivo: string;
-  caminho: string[];
-}
-
 interface BaseJogada {
   mao: Carta[];
   estado: EstadoRodada;
@@ -177,24 +172,15 @@ interface ConfigBaseJogada {
 }
 
 function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
+  const posicao = definirPosicao(config.estadoAtual);
   return {
     mao: config.mao,
     estado: config.estado,
     estadoAtual: config.estadoAtual,
     contexto: config.contexto,
-    posicao: definirPosicao(config.estadoAtual),
+    posicao,
     fria: config.decisaoFria.carta,
     motivoLinhaFria: config.decisaoFria.motivo,
-    caminhoLinhaFria: criarCaminhoJogadaDebug(definirPosicao(config.estadoAtual), 'fria'),
+    caminhoLinhaFria: criarCaminhoJogadaDebug(posicao, 'fria'),
   };
-}
-
-function definirPosicao(estado: EstadoEmJogo): PosicaoMesaJogadaDebug {
-  if (estado.mesa.length === 0) return 'abre';
-  if (ehUltimoDaMesa(estado)) return 'fecha';
-  return 'meio';
-}
-
-function criarDecisaoQuente(decisao: { carta: Carta; motivo: string }, caminho: string[]): DecisaoQuente {
-  return { ...decisao, caminho };
 }

--- a/src/adapters/bots/debug-jogada-bot.ts
+++ b/src/adapters/bots/debug-jogada-bot.ts
@@ -1,0 +1,70 @@
+import type { Carta } from '@/core/Carta';
+import { calcularIndiceVencedor } from '@/core/comparador-carta';
+import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
+import { calcularNecessidade } from './contextoLinhaQuente';
+
+export interface ContextoJogadaDebug {
+  posicaoMesa: 'abre' | 'meio' | 'fecha';
+  necessidade: number;
+  urgencia: number;
+  urgenciaAlta: boolean;
+  jogadoresPorAgir: number;
+  liderId: string | null;
+  liderNecessidade: number | null;
+  jogadoresInteressadosPorAgir: number;
+}
+
+export interface LinhaJogadaDebug {
+  carta: Carta;
+  motivo: string;
+  caminho: string[];
+}
+
+export function criarContextoJogadaDebug(estado: EstadoRodada, tamanhoMao: number): ContextoJogadaDebug {
+  const atual = estadoEmJogo(estado);
+  const jogadorId = atual.maos[atual.jogadorAtual].jogador.id;
+  const necessidade = calcularNecessidade(atual, jogadorId);
+  const jogadoresPorAgir = calcularJogadoresPorAgir(atual);
+  const liderId = obterLiderId(atual);
+  return {
+    posicaoMesa: definirPosicaoMesa(atual, jogadoresPorAgir),
+    necessidade,
+    urgencia: tamanhoMao === 0 ? 0 : necessidade / tamanhoMao,
+    urgenciaAlta: tamanhoMao > 0 && necessidade / tamanhoMao >= 0.66,
+    jogadoresPorAgir,
+    liderId,
+    liderNecessidade: liderId ? calcularNecessidade(atual, liderId) : null,
+    jogadoresInteressadosPorAgir: contarInteressadosPorAgir(atual),
+  };
+}
+
+export function criarLinhaJogadaDebug(carta: Carta, motivo: string | undefined, caminho: string[]): LinhaJogadaDebug {
+  return {
+    carta,
+    motivo: motivo ?? 'motivo não registrado',
+    caminho,
+  };
+}
+
+function definirPosicaoMesa(estado: EstadoEmJogo, jogadoresPorAgir: number): ContextoJogadaDebug['posicaoMesa'] {
+  if (estado.mesa.length === 0) return 'abre';
+  if (jogadoresPorAgir === 0) return 'fecha';
+  return 'meio';
+}
+
+function calcularJogadoresPorAgir(estado: EstadoEmJogo): number {
+  return Math.max(0, estado.maos.length - estado.mesa.length - 1);
+}
+
+function obterLiderId(estado: EstadoEmJogo): string | null {
+  if (estado.mesa.length === 0) return null;
+  return estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)].jogadorId;
+}
+
+function contarInteressadosPorAgir(estado: EstadoEmJogo): number {
+  const jogadoresPorAgir = calcularJogadoresPorAgir(estado);
+  return Array.from({ length: jogadoresPorAgir }).filter((_, indice) => {
+    const jogador = estado.maos[(estado.jogadorAtual + indice + 1) % estado.maos.length].jogador;
+    return calcularNecessidade(estado, jogador.id) > 0;
+  }).length;
+}

--- a/src/adapters/bots/debug-jogada-bot.ts
+++ b/src/adapters/bots/debug-jogada-bot.ts
@@ -3,8 +3,11 @@ import { calcularIndiceVencedor } from '@/core/comparador-carta';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { calcularNecessidade } from './contextoLinhaQuente';
 
+export type PosicaoMesaJogadaDebug = 'abre' | 'meio' | 'fecha';
+export type LinhaDecisaoJogadaDebug = 'fria' | 'quente';
+
 export interface ContextoJogadaDebug {
-  posicaoMesa: 'abre' | 'meio' | 'fecha';
+  posicaoMesa: PosicaoMesaJogadaDebug;
   necessidade: number;
   urgencia: number;
   urgenciaAlta: boolean;
@@ -46,10 +49,25 @@ export function criarLinhaJogadaDebug(carta: Carta, motivo: string | undefined, 
   };
 }
 
-function definirPosicaoMesa(estado: EstadoEmJogo, jogadoresPorAgir: number): ContextoJogadaDebug['posicaoMesa'] {
+export function criarCaminhoJogadaDebug(
+  posicao: PosicaoMesaJogadaDebug,
+  linha: LinhaDecisaoJogadaDebug,
+  etapa?: string,
+): string[] {
+  const caminho = ['jogada', rotuloPosicao(posicao), `linha ${linha}`];
+  return etapa ? [...caminho, etapa] : caminho;
+}
+
+function definirPosicaoMesa(estado: EstadoEmJogo, jogadoresPorAgir: number): PosicaoMesaJogadaDebug {
   if (estado.mesa.length === 0) return 'abre';
   if (jogadoresPorAgir === 0) return 'fecha';
   return 'meio';
+}
+
+function rotuloPosicao(posicao: PosicaoMesaJogadaDebug): string {
+  if (posicao === 'abre') return 'abre a mesa';
+  if (posicao === 'fecha') return 'fecha a mesa';
+  return 'joga no meio';
 }
 
 function calcularJogadoresPorAgir(estado: EstadoEmJogo): number {

--- a/src/adapters/bots/debug-linha-quente.ts
+++ b/src/adapters/bots/debug-linha-quente.ts
@@ -1,0 +1,20 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { ehUltimoDaMesa } from './contextoLinhaQuente';
+import type { PosicaoMesaJogadaDebug } from './debug-jogada-bot';
+
+export interface DecisaoQuente {
+  carta: Carta;
+  motivo: string;
+  caminho: string[];
+}
+
+export function definirPosicao(estado: EstadoEmJogo): PosicaoMesaJogadaDebug {
+  if (estado.mesa.length === 0) return 'abre';
+  if (ehUltimoDaMesa(estado)) return 'fecha';
+  return 'meio';
+}
+
+export function criarDecisaoQuente(decisao: { carta: Carta; motivo: string }, caminho: string[]): DecisaoQuente {
+  return { ...decisao, caminho };
+}

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -1,6 +1,7 @@
 import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import { estadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
+import type { ContextoJogadaDebug, LinhaJogadaDebug } from './debug-jogada-bot';
 /* eslint-disable no-console */
 
 export interface LoggerDebugBot {
@@ -34,6 +35,9 @@ export interface DecisaoJogadaDebug {
   mao: Carta[];
   linhaFria: Carta;
   linhaQuente: Carta;
+  contexto?: ContextoJogadaDebug;
+  fria?: LinhaJogadaDebug;
+  quente?: LinhaJogadaDebug;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
   motivoSemBifurcacao?: string;

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -12,8 +12,8 @@ interface EscolhaDireta {
   linhaQuente?: Carta;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
-  caminhoLinhaFria?: string[];
-  caminhoLinhaQuente?: string[];
+  caminhoLinhaFria: string[];
+  caminhoLinhaQuente: string[];
   motivoSemBifurcacao?: string;
   escolheuQuente: boolean;
 }
@@ -27,8 +27,8 @@ interface Bifurcacao {
   quente: Carta;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
-  caminhoLinhaFria?: string[];
-  caminhoLinhaQuente?: string[];
+  caminhoLinhaFria: string[];
+  caminhoLinhaQuente: string[];
   sorteio: number;
 }
 
@@ -39,15 +39,11 @@ export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
     linhaFria: config.linhaFria ?? config.carta,
     linhaQuente: config.linhaQuente ?? config.carta,
     contexto: criarContextoJogadaDebug(config.estado, config.mao.length),
-    fria: criarLinhaJogadaDebug(
-      config.linhaFria ?? config.carta,
-      config.motivoLinhaFria,
-      config.caminhoLinhaFria ?? [],
-    ),
+    fria: criarLinhaJogadaDebug(config.linhaFria ?? config.carta, config.motivoLinhaFria, config.caminhoLinhaFria),
     quente: criarLinhaJogadaDebug(
       config.linhaQuente ?? config.carta,
       config.motivoLinhaQuente,
-      config.caminhoLinhaQuente ?? [],
+      config.caminhoLinhaQuente,
     ),
     motivoLinhaFria: config.motivoLinhaFria,
     motivoLinhaQuente: config.motivoLinhaQuente,
@@ -67,8 +63,8 @@ export function registrarBifurcacao(config: Bifurcacao): Carta {
     linhaFria: config.fria,
     linhaQuente: config.quente,
     contexto: criarContextoJogadaDebug(config.estado, config.mao.length),
-    fria: criarLinhaJogadaDebug(config.fria, config.motivoLinhaFria, config.caminhoLinhaFria ?? []),
-    quente: criarLinhaJogadaDebug(config.quente, config.motivoLinhaQuente, config.caminhoLinhaQuente ?? []),
+    fria: criarLinhaJogadaDebug(config.fria, config.motivoLinhaFria, config.caminhoLinhaFria),
+    quente: criarLinhaJogadaDebug(config.quente, config.motivoLinhaQuente, config.caminhoLinhaQuente),
     motivoLinhaFria: config.motivoLinhaFria,
     motivoLinhaQuente: config.motivoLinhaQuente,
     carta,

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -1,5 +1,6 @@
 import type { Carta } from '@/core/Carta';
 import type { EstadoRodada } from '@/types/estado-rodada';
+import { criarContextoJogadaDebug, criarLinhaJogadaDebug } from './debug-jogada-bot';
 import type { LoggerDebugBot } from './logger-debug-bot';
 
 interface EscolhaDireta {
@@ -11,6 +12,8 @@ interface EscolhaDireta {
   linhaQuente?: Carta;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
+  caminhoLinhaFria?: string[];
+  caminhoLinhaQuente?: string[];
   motivoSemBifurcacao?: string;
   escolheuQuente: boolean;
 }
@@ -24,6 +27,8 @@ interface Bifurcacao {
   quente: Carta;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
+  caminhoLinhaFria?: string[];
+  caminhoLinhaQuente?: string[];
   sorteio: number;
 }
 
@@ -33,6 +38,17 @@ export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
     estado: config.estado,
     linhaFria: config.linhaFria ?? config.carta,
     linhaQuente: config.linhaQuente ?? config.carta,
+    contexto: criarContextoJogadaDebug(config.estado, config.mao.length),
+    fria: criarLinhaJogadaDebug(
+      config.linhaFria ?? config.carta,
+      config.motivoLinhaFria,
+      config.caminhoLinhaFria ?? [],
+    ),
+    quente: criarLinhaJogadaDebug(
+      config.linhaQuente ?? config.carta,
+      config.motivoLinhaQuente,
+      config.caminhoLinhaQuente ?? [],
+    ),
     motivoLinhaFria: config.motivoLinhaFria,
     motivoLinhaQuente: config.motivoLinhaQuente,
     motivoSemBifurcacao: config.motivoSemBifurcacao,
@@ -50,6 +66,9 @@ export function registrarBifurcacao(config: Bifurcacao): Carta {
     estado: config.estado,
     linhaFria: config.fria,
     linhaQuente: config.quente,
+    contexto: criarContextoJogadaDebug(config.estado, config.mao.length),
+    fria: criarLinhaJogadaDebug(config.fria, config.motivoLinhaFria, config.caminhoLinhaFria ?? []),
+    quente: criarLinhaJogadaDebug(config.quente, config.motivoLinhaQuente, config.caminhoLinhaQuente ?? []),
     motivoLinhaFria: config.motivoLinhaFria,
     motivoLinhaQuente: config.motivoLinhaQuente,
     carta,

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { decidirAbertura } from '@/adapters/bots/decidirAbertura';
 import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
 import type { Carta } from '@/core/Carta';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
@@ -14,6 +15,7 @@ describe('DecisorJogadaBot', () => {
   it('deve escolher a de menor score dentro da mesma categoria na abertura', abrirMenorScoreNaCategoria);
   it('deve jogar garantida quando só tem ela na abertura', abrirGarantidaInevitavel);
   it('deve lidar com folga negativa na abertura sem quebrar ou dar NaN/Infinity', abrirFolgaNegativa);
+  it('deve registrar contexto explicável quando abre a mesa', registraContextoAbertura);
   it('deve falhar se a mão estiver vazia na abertura', deveFalharMaoVaziaAbertura);
 });
 
@@ -110,6 +112,38 @@ async function abrirFolgaNegativa(): Promise<void> {
 
   // A urgência deve ser alta (quebra de cautela) e escolher a carta '2' de Espadas (alta)
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('2', '♠'));
+}
+
+async function registraContextoAbertura(): Promise<void> {
+  const estado = criarEstado({
+    mesa: [],
+    declaracoes: { bot: 2 },
+    vazas: { bot: 0 },
+  });
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = new DecisorJogadaBot({
+    temperatura: 0,
+    rng: { random: () => 0 },
+    logger: {
+      registrarDeclaracao: () => undefined,
+      registrarJogada: (jogada) => jogadas.push(jogada),
+    },
+  });
+
+  await bot.decidirJogada([criarCarta('8', '♦'), criarCarta('4', '♦')], estado);
+
+  expect(jogadas[0]?.contexto).toMatchObject({
+    posicaoMesa: 'abre',
+    necessidade: 2,
+    urgencia: 1,
+    urgenciaAlta: true,
+    jogadoresPorAgir: 3,
+  });
+  expect(jogadas[0]?.fria?.caminho).toEqual(['jogada', 'abre a mesa', 'linha fria']);
+  expect(jogadas[0]?.quente).toMatchObject({
+    motivo: 'abertura: segue linha fria',
+    caminho: ['jogada', 'abre a mesa', 'linha quente'],
+  });
 }
 
 function deveFalharMaoVaziaAbertura(): void {

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -12,6 +12,7 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve escolher linha fria com segurança quando a temperatura é zero', escolheLinhaFria);
   it('deve usar posicionamento determinístico quando é o último e precisa fazer', usaPosicionamentoDeterministico);
   it('deve registrar posicionamento determinístico quando logger é injetado', registraPosicionamentoDeterministico);
+  it('deve registrar contexto e caminhos auditáveis da decisão', registraContratoExplicavel);
   it('deve empatar quando já cumpriu, líder precisa e carta líder é alta', empataAltaCumprido);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
@@ -55,6 +56,34 @@ async function registraPosicionamentoDeterministico(): Promise<void> {
   expect(jogadas).toHaveLength(1);
   expect(jogadas[0]).toMatchObject({ carta: criarCarta('8', '♦'), escolheuQuente: false });
   expect(jogadas[0]?.sorteio).toBeUndefined();
+}
+
+async function registraContratoExplicavel(): Promise<void> {
+  const estado = criarEstado(cenarioBifurcacaoAntesDoFim());
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBot(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await bot.decidirJogada(maoBifurcacao(), estado);
+
+  expect(jogadas[0]?.contexto).toMatchObject({
+    posicaoMesa: 'meio',
+    necessidade: 1,
+    urgencia: 0.5,
+    urgenciaAlta: false,
+    jogadoresPorAgir: 1,
+    liderId: 'j1',
+    liderNecessidade: 0,
+    jogadoresInteressadosPorAgir: 0,
+  });
+  expect(jogadas[0]?.fria).toMatchObject({
+    carta: criarCarta('3', '♦'),
+    motivo: 'precisa fazer; regra G[N-X]',
+    caminho: ['jogada', 'joga no meio', 'linha fria'],
+  });
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
 }
 
 async function atravessaComCartaBarata(): Promise<void> {

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -26,14 +26,12 @@ async function escolheLinhaQuente(): Promise<void> {
 
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('4', '♦'));
 }
-
 async function escolheLinhaFria(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacao());
   const bot = criarBot(0, 0);
 
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('3', '♦'));
 }
-
 async function usaPosicionamentoDeterministico(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
   const bot = criarBot(1, 0);
@@ -42,7 +40,6 @@ async function usaPosicionamentoDeterministico(): Promise<void> {
     bot.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
   ).resolves.toEqual(criarCarta('8', '♦'));
 }
-
 async function registraPosicionamentoDeterministico(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
   const jogadas: DecisaoJogadaDebug[] = [];
@@ -57,7 +54,6 @@ async function registraPosicionamentoDeterministico(): Promise<void> {
   expect(jogadas[0]).toMatchObject({ carta: criarCarta('8', '♦'), escolheuQuente: false });
   expect(jogadas[0]?.sorteio).toBeUndefined();
 }
-
 async function registraContratoExplicavel(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacaoAntesDoFim());
   const jogadas: DecisaoJogadaDebug[] = [];
@@ -68,6 +64,7 @@ async function registraContratoExplicavel(): Promise<void> {
 
   await bot.decidirJogada(maoBifurcacao(), estado);
 
+  expect(jogadas).toHaveLength(1);
   expect(jogadas[0]?.contexto).toMatchObject({
     posicaoMesa: 'meio',
     necessidade: 1,
@@ -118,13 +115,19 @@ async function convergeSemPressao(): Promise<void> {
 }
 
 async function naoSorteiaSemBifurcacao(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComBaixa(), declaracoes: { j2: 1, bot: 1 }, vazas: { j2: 0, bot: 0 } });
+  const estado = criarEstado({ mesa: [{ jogadorId: 'j1', carta: criarCarta('8', '♣') }], declaracoes: { bot: 1 } });
+  const jogadas: DecisaoJogadaDebug[] = [];
   const random = vi.fn(() => 0);
-  const bot = new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random }, liderBaixa: 8, liderAlta: 11 });
+  const bot = new DecisorJogadaLinhaQuente({
+    temperatura: 1,
+    rng: { random },
+    logger: { registrarDeclaracao: () => undefined, registrarJogada: (jogada) => jogadas.push(jogada) },
+  });
 
   await bot.decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado);
 
   expect(random).not.toHaveBeenCalled();
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
 }
 
 async function repeteEscolhaDeterministica(): Promise<void> {
@@ -139,8 +142,6 @@ function criarBot(temperatura: number, valorRng: number, logger?: LoggerDebugBot
   return new DecisorJogadaLinhaQuente({
     temperatura,
     rng: { random: () => valorRng },
-    liderBaixa: 8,
-    liderAlta: 11,
     logger,
   });
 }

--- a/tests/adapters/debug-jogada-bot.test.ts
+++ b/tests/adapters/debug-jogada-bot.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { criarContextoJogadaDebug, criarLinhaJogadaDebug } from '@/adapters/bots/debug-jogada-bot';
+import {
+  criarCaminhoJogadaDebug,
+  criarContextoJogadaDebug,
+  criarLinhaJogadaDebug,
+} from '@/adapters/bots/debug-jogada-bot';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
@@ -8,6 +12,7 @@ describe('debug da jogada dos bots', () => {
   it('deve descrever abertura com jogadores por agir em ordem circular', deveDescreverAbertura);
   it('deve descrever jogada no meio com líder e interessados por agir', deveDescreverMeio);
   it('deve descrever fechamento sem jogadores por agir', deveDescreverFechamento);
+  it('deve criar caminho canônico com etapa opcional', deveCriarCaminhoCanonico);
   it('deve criar linha com motivo padrão quando motivo não foi registrado', deveCriarLinhaComMotivoPadrao);
 });
 
@@ -77,6 +82,16 @@ function deveCriarLinhaComMotivoPadrao(): void {
     motivo: 'motivo não registrado',
     caminho: ['jogada', 'linha fria'],
   });
+}
+
+function deveCriarCaminhoCanonico(): void {
+  expect(criarCaminhoJogadaDebug('meio', 'quente', 'escolha direta')).toEqual([
+    'jogada',
+    'joga no meio',
+    'linha quente',
+    'escolha direta',
+  ]);
+  expect(criarCaminhoJogadaDebug('fecha', 'fria')).toEqual(['jogada', 'fecha a mesa', 'linha fria']);
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {

--- a/tests/adapters/debug-jogada-bot.test.ts
+++ b/tests/adapters/debug-jogada-bot.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { criarContextoJogadaDebug, criarLinhaJogadaDebug } from '@/adapters/bots/debug-jogada-bot';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+describe('debug da jogada dos bots', () => {
+  it('deve descrever abertura com jogadores por agir em ordem circular', deveDescreverAbertura);
+  it('deve descrever jogada no meio com líder e interessados por agir', deveDescreverMeio);
+  it('deve descrever fechamento sem jogadores por agir', deveDescreverFechamento);
+  it('deve criar linha com motivo padrão quando motivo não foi registrado', deveCriarLinhaComMotivoPadrao);
+});
+
+function deveDescreverAbertura(): void {
+  const estado = criarEstado({
+    jogadorAtual: 1,
+    mesa: [],
+    declaracoes: { bot: 2, j1: 0, j3: 1, j4: 0 },
+    vazas: { bot: 0, j1: 0, j3: 0, j4: 0 },
+  });
+
+  expect(criarContextoJogadaDebug(estado, 3)).toMatchObject({
+    posicaoMesa: 'abre',
+    necessidade: 2,
+    urgencia: 2 / 3,
+    urgenciaAlta: true,
+    jogadoresPorAgir: 3,
+    liderId: null,
+    liderNecessidade: null,
+    jogadoresInteressadosPorAgir: 1,
+  });
+}
+
+function deveDescreverMeio(): void {
+  const estado = criarEstado({
+    jogadorAtual: 1,
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+    declaracoes: { j1: 2, bot: 1, j3: 1, j4: 0 },
+    vazas: { j1: 1, bot: 0, j3: 0, j4: 0 },
+  });
+
+  expect(criarContextoJogadaDebug(estado, 2)).toMatchObject({
+    posicaoMesa: 'meio',
+    necessidade: 1,
+    urgencia: 0.5,
+    urgenciaAlta: false,
+    jogadoresPorAgir: 2,
+    liderId: 'j1',
+    liderNecessidade: 1,
+    jogadoresInteressadosPorAgir: 1,
+  });
+}
+
+function deveDescreverFechamento(): void {
+  const estado = criarEstado({
+    jogadorAtual: 1,
+    mesa: mesaComTres(),
+    declaracoes: { bot: 0, j2: 1 },
+    vazas: { bot: 1, j2: 0 },
+  });
+
+  expect(criarContextoJogadaDebug(estado, 1)).toMatchObject({
+    posicaoMesa: 'fecha',
+    necessidade: -1,
+    urgencia: -1,
+    urgenciaAlta: false,
+    jogadoresPorAgir: 0,
+    jogadoresInteressadosPorAgir: 0,
+  });
+}
+
+function deveCriarLinhaComMotivoPadrao(): void {
+  const carta = criarCarta('4', '♦');
+
+  expect(criarLinhaJogadaDebug(carta, undefined, ['jogada', 'linha fria'])).toEqual({
+    carta,
+    motivo: 'motivo não registrado',
+    caminho: ['jogada', 'linha fria'],
+  });
+}
+
+function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = criarJogadores();
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function criarJogadores(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('bot', 'Bot'), criarJogador('j3', 'J3'), criarJogador('j4', 'J4')];
+}
+
+function mesaComTres(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('K', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds structured debug metadata to bot decision logging so each jogada can be traced with context, motive, and decision path.
- Extends `DecisorJogadaBot` and `DecisorJogadaLinhaQuente` to emit explainable paths for abertura, meio, and fechamento decisions.
- Introduces shared helpers for building debug context and line metadata in `src/adapters/bots/debug-jogada-bot.ts`.
- Adds coverage for the new debug contract and the expected context values in opening, mid-round, and deterministic decision scenarios.

## Testing
- `pnpm test` not run in this branch review.
- New Vitest coverage added for `DecisorJogadaBot`, `DecisorJogadaLinhaQuente`, and `debug-jogada-bot`.
- Concrete checks added for `contexto.posicaoMesa`, `necessidade`, `urgencia`, `liderId`, `jogadoresInteressadosPorAgir`, and emitted `caminho` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced decision logging with structured context including table position, urgency metrics, leader/interest data, and breadcrumb-like decision paths.
  * Decisions now carry traceable metadata for both cold and hot choices (reason text plus path arrays).

* **Tests**
  * Added tests validating context generation, default reasons, and canonical decision-path sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->