### PR TITLE
Refina debug da declaração dos bots

### DIFF
--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -46,6 +46,7 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
     this.logger?.registrarDeclaracao({
       mao: avaliadas,
       baseDeterministica,
+      fortesVisiveis: filtrarFortes(avaliadas),
       altasCandidatas,
       sorteiosAplicaveis: sorteiosAltas.aplicaveis,
       sorteiosNaoAplicaveis: sorteiosAltas.naoAplicaveis,
@@ -62,11 +63,13 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
     const visiveis = cartasVisiveisDosOutros(emJogo);
     const avaliadas = visiveis.flatMap((carta) => avaliarCartas([carta], emJogo.manilha, [], emJogo.maos.length));
     const temAltaVisivel = avaliadas.some((avaliada) => ehCategoriaForte(avaliada.categoria));
+    const fortesVisiveis = filtrarFortes(avaliadas);
     const declaracao = temAltaVisivel ? 0 : 1;
 
     this.logger?.registrarDeclaracao({
       mao: avaliadas,
       baseDeterministica: 0,
+      fortesVisiveis,
       altasCandidatas: filtrarCategorias(avaliadas, ['alta']),
       sorteiosAplicaveis: [],
       sorteiosNaoAplicaveis: [],
@@ -107,6 +110,10 @@ function contarCategorias(categorias: CategoriaCarta[], esperadas: CategoriaCart
 
 function filtrarCategorias(avaliadas: CartaAvaliada[], esperadas: CategoriaCarta[]): CartaAvaliada[] {
   return avaliadas.filter((avaliada) => esperadas.includes(avaliada.categoria));
+}
+
+function filtrarFortes(avaliadas: CartaAvaliada[]): CartaAvaliada[] {
+  return avaliadas.filter((avaliada) => ehCategoriaForte(avaliada.categoria));
 }
 
 function classificarSorteiosAltas(

--- a/src/adapters/bots/DecisorDeclaracaoBot.ts
+++ b/src/adapters/bots/DecisorDeclaracaoBot.ts
@@ -36,22 +36,21 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
     const avaliadas = avaliarCartas(mao, estado.manilha, cartasPublicas(estado), estado.maos.length);
     const segurasContadas = filtrarCategorias(avaliadas, ['segura', 'garantida_agora']);
     const altasCandidatas = filtrarCategorias(avaliadas, ['alta']);
-    const altasSorteadas = avaliadas
-      .filter((avaliada) => avaliada.categoria === 'alta')
-      .map((avaliada) => ({ carta: avaliada, conta: this.deveContar() }));
-    const contagemAltas = altasSorteadas.filter((sorteio) => sorteio.conta).length;
-    const base = segurasContadas.length + contagemAltas;
-    const defensivo = this.avaliarDefensivo(avaliadas, base, estado.cartasPorRodada);
+    const sorteiosAltas = classificarSorteiosAltas(altasCandidatas, () => this.deveContar());
+    const baseDeterministica = segurasContadas.length;
+    const baseComSorteios = baseDeterministica + sorteiosAltas.aplicaveis.length;
+    const defensivo = this.avaliarDefensivo(avaliadas, baseComSorteios, estado.cartasPorRodada);
     const contagemDefensiva = defensivo.estado === 'aplicado' ? 1 : 0;
-    const declaracao = Math.min(mao.length, Math.max(0, base + contagemDefensiva));
+    const declaracao = Math.min(mao.length, Math.max(0, baseComSorteios + contagemDefensiva));
 
     this.logger?.registrarDeclaracao({
       mao: avaliadas,
-      segurasContadas,
+      baseDeterministica,
       altasCandidatas,
-      sorteiosAltas: altasSorteadas,
+      sorteiosAplicaveis: sorteiosAltas.aplicaveis,
+      sorteiosNaoAplicaveis: sorteiosAltas.naoAplicaveis,
       defensivo,
-      declaracao,
+      resultadoFinal: declaracao,
       regraEspecialPrimeiraRodada: false,
     });
 
@@ -67,11 +66,12 @@ export class DecisorDeclaracaoBot implements DecisorDeclaracao {
 
     this.logger?.registrarDeclaracao({
       mao: avaliadas,
-      segurasContadas: filtrarCategorias(avaliadas, ['segura', 'garantida_agora']),
+      baseDeterministica: 0,
       altasCandidatas: filtrarCategorias(avaliadas, ['alta']),
-      sorteiosAltas: [],
+      sorteiosAplicaveis: [],
+      sorteiosNaoAplicaveis: [],
       defensivo: { estado: 'não elegível' },
-      declaracao,
+      resultadoFinal: declaracao,
       regraEspecialPrimeiraRodada: true,
     });
 
@@ -107,6 +107,23 @@ function contarCategorias(categorias: CategoriaCarta[], esperadas: CategoriaCart
 
 function filtrarCategorias(avaliadas: CartaAvaliada[], esperadas: CategoriaCarta[]): CartaAvaliada[] {
   return avaliadas.filter((avaliada) => esperadas.includes(avaliada.categoria));
+}
+
+function classificarSorteiosAltas(
+  altasCandidatas: CartaAvaliada[],
+  deveContar: () => boolean,
+): { aplicaveis: CartaAvaliada[]; naoAplicaveis: CartaAvaliada[] } {
+  return altasCandidatas.reduce(
+    (acumulado, avaliada) => {
+      if (deveContar()) {
+        acumulado.aplicaveis.push(avaliada);
+      } else {
+        acumulado.naoAplicaveis.push(avaliada);
+      }
+      return acumulado;
+    },
+    { aplicaveis: [] as CartaAvaliada[], naoAplicaveis: [] as CartaAvaliada[] },
+  );
 }
 
 function ehCategoriaForte(categoria: CategoriaCarta): boolean {

--- a/src/adapters/bots/debug-declaracao-bot.ts
+++ b/src/adapters/bots/debug-declaracao-bot.ts
@@ -1,0 +1,18 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+
+export interface DecisaoDeclaracaoDebug {
+  mao: CartaAvaliada[];
+  baseDeterministica: number;
+  altasCandidatas: CartaAvaliada[];
+  sorteiosAplicaveis: CartaAvaliada[];
+  sorteiosNaoAplicaveis: CartaAvaliada[];
+  defensivo: DefensivoDebug;
+  resultadoFinal: number;
+  regraEspecialPrimeiraRodada: boolean;
+}
+
+export type DefensivoDebug =
+  | { estado: 'não elegível' }
+  | { estado: 'sorteou'; aplicaria: boolean }
+  | { estado: 'bloqueado'; base: number; teto: number; resultado: number; cartasPorRodada: number }
+  | { estado: 'aplicado' };

--- a/src/adapters/bots/debug-declaracao-bot.ts
+++ b/src/adapters/bots/debug-declaracao-bot.ts
@@ -3,6 +3,7 @@ import type { CartaAvaliada } from '@/core/avaliador-carta';
 export interface DecisaoDeclaracaoDebug {
   mao: CartaAvaliada[];
   baseDeterministica: number;
+  fortesVisiveis: CartaAvaliada[];
   altasCandidatas: CartaAvaliada[];
   sorteiosAplicaveis: CartaAvaliada[];
   sorteiosNaoAplicaveis: CartaAvaliada[];

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -88,12 +88,20 @@ function formatarMesa(mesa: MesaItem[]): string {
 }
 
 function formatarContagens(decisao: DecisaoDeclaracaoDebug): string {
+  if (decisao.regraEspecialPrimeiraRodada) return formatarContagensPrimeiraRodada(decisao);
   return [
     `Base determinística: ${decisao.baseDeterministica.toString()}`,
     `Altas candidatas: [${formatarAvaliadas(decisao.altasCandidatas)}] (${decisao.altasCandidatas.length.toString()})`,
     `Sorteios aplicáveis: [${formatarAvaliadas(decisao.sorteiosAplicaveis)}] (${decisao.sorteiosAplicaveis.length.toString()})`,
     `Sorteios não aplicáveis: [${formatarAvaliadas(decisao.sorteiosNaoAplicaveis)}] (${decisao.sorteiosNaoAplicaveis.length.toString()})`,
     `+1 defensivo: ${formatarDefensivo(decisao.defensivo)}`,
+    `Resultado final: ${decisao.resultadoFinal.toString()}`,
+  ].join(' | ');
+}
+
+function formatarContagensPrimeiraRodada(decisao: DecisaoDeclaracaoDebug): string {
+  return [
+    `Fortes visíveis: [${formatarAvaliadas(decisao.fortesVisiveis)}] (${decisao.fortesVisiveis.length.toString()})`,
     `Resultado final: ${decisao.resultadoFinal.toString()}`,
   ].join(' | ');
 }

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -1,6 +1,7 @@
 import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import { estadoEmJogo, type EstadoRodada, type MesaItem } from '@/types/estado-rodada';
+import type { DecisaoDeclaracaoDebug, DefensivoDebug } from './debug-declaracao-bot';
 import type { ContextoJogadaDebug, LinhaJogadaDebug } from './debug-jogada-bot';
 /* eslint-disable no-console */
 
@@ -8,27 +9,6 @@ export interface LoggerDebugBot {
   registrarDeclaracao(decisao: DecisaoDeclaracaoDebug): void;
   registrarJogada(decisao: DecisaoJogadaDebug): void;
 }
-
-export interface DecisaoDeclaracaoDebug {
-  mao: CartaAvaliada[];
-  segurasContadas: CartaAvaliada[];
-  altasCandidatas: CartaAvaliada[];
-  sorteiosAltas: SorteioAltaDebug[];
-  defensivo: DefensivoDebug;
-  declaracao: number;
-  regraEspecialPrimeiraRodada: boolean;
-}
-
-export interface SorteioAltaDebug {
-  carta: CartaAvaliada;
-  conta: boolean;
-}
-
-export type DefensivoDebug =
-  | { estado: 'não elegível' }
-  | { estado: 'sorteou'; aplicaria: boolean }
-  | { estado: 'bloqueado'; base: number; teto: number; resultado: number; cartasPorRodada: number }
-  | { estado: 'aplicado' };
 
 export interface DecisaoJogadaDebug {
   estado: EstadoRodada;
@@ -65,7 +45,7 @@ function registrarDeclaracao(nome: string, temperatura: number, decisao: Decisao
   }
   console.log(`Mão: [${formatarAvaliadas(decisao.mao)}]`);
   console.log(formatarContagens(decisao));
-  console.log(`→ Declarou: ${decisao.declaracao.toString()}`);
+  console.log(`→ Declarou: ${decisao.resultadoFinal.toString()}`);
   console.groupEnd();
 }
 
@@ -109,17 +89,13 @@ function formatarMesa(mesa: MesaItem[]): string {
 
 function formatarContagens(decisao: DecisaoDeclaracaoDebug): string {
   return [
-    `Seguras contadas: [${formatarAvaliadas(decisao.segurasContadas)}] (${decisao.segurasContadas.length.toString()})`,
+    `Base determinística: ${decisao.baseDeterministica.toString()}`,
     `Altas candidatas: [${formatarAvaliadas(decisao.altasCandidatas)}] (${decisao.altasCandidatas.length.toString()})`,
-    formatarAltasSorteadas(decisao.sorteiosAltas),
+    `Sorteios aplicáveis: [${formatarAvaliadas(decisao.sorteiosAplicaveis)}] (${decisao.sorteiosAplicaveis.length.toString()})`,
+    `Sorteios não aplicáveis: [${formatarAvaliadas(decisao.sorteiosNaoAplicaveis)}] (${decisao.sorteiosNaoAplicaveis.length.toString()})`,
     `+1 defensivo: ${formatarDefensivo(decisao.defensivo)}`,
+    `Resultado final: ${decisao.resultadoFinal.toString()}`,
   ].join(' | ');
-}
-
-function formatarAltasSorteadas(sorteios: SorteioAltaDebug[]): string {
-  const consideradas = sorteios.filter((sorteio) => sorteio.conta).map((sorteio) => sorteio.carta);
-  const porCarta = sorteios.map((sorteio) => `${formatarCarta(sorteio.carta.carta)} ${simNao(sorteio.conta)}`);
-  return `Altas consideradas: [${formatarAvaliadas(consideradas)}] (${consideradas.length.toString()}/${sorteios.length.toString()}) | Sorteios de altas: ${porCarta.join(', ')}`;
 }
 
 function formatarDefensivo(defensivo: DefensivoDebug): string {

--- a/tests/adapters/debug-declaracao-bot.test.ts
+++ b/tests/adapters/debug-declaracao-bot.test.ts
@@ -8,7 +8,14 @@ import type { EstadoRodada } from '@/types/estado-rodada';
 function criarRng(valores: number[]): GeradorAleatorio {
   let indice = 0;
   return {
-    random: () => valores[indice++] ?? 0,
+    random: () => {
+      if (indice >= valores.length) {
+        throw new Error(`RNG de teste sem valor na posição ${indice.toString()}`);
+      }
+      const valor = valores[indice];
+      indice += 1;
+      return valor;
+    },
     randomInt: (min: number) => min,
     shuffle: <T>(array: T[]) => [...array],
   };
@@ -57,6 +64,7 @@ function esperarDeclaracaoComSorteios(decisao: DecisaoDeclaracaoDebug): void {
     resultadoFinal: 2,
     regraEspecialPrimeiraRodada: false,
   });
+  expect(identificarCartas(decisao.fortesVisiveis)).toEqual(['3♣', '2♦', '2♥']);
   expect(identificarCartas(decisao.altasCandidatas)).toEqual(['2♦', '2♥']);
   expect(identificarCartas(decisao.sorteiosAplicaveis)).toEqual(['2♦']);
   expect(identificarCartas(decisao.sorteiosNaoAplicaveis)).toEqual(['2♥']);
@@ -84,24 +92,49 @@ describe('Contrato de debug da declaração do bot com sorteios de altas', () =>
 });
 
 describe('Contrato de debug da declaração do bot na primeira rodada', () => {
-  it('deve manter o contrato mínimo também na regra especial da primeira rodada', async () => {
+  it('deve expor fortes visíveis quando a regra especial da primeira rodada zera a declaração', async () => {
     const debug: DecisaoDeclaracaoDebug[] = [];
-    const mao = [{ valor: '4', naipe: '♣' }] satisfies Carta[];
+    const mao = [{ valor: '5', naipe: '♦' }] satisfies Carta[];
+    const visiveis = [{ valor: '3', naipe: '♣' }] satisfies Carta[];
     const decisor = new DecisorDeclaracaoBot(0, criarRng([0]), {
       poucasBaixas: 1,
       declaracaoBaixa: 1,
       logger: criarLogger(debug),
     });
 
-    await expect(decisor.declarar(criarEstado(mao, 1), mao)).resolves.toBe(1);
+    await expect(decisor.declarar(criarEstadoPrimeiraRodada(mao, visiveis), mao)).resolves.toBe(0);
 
-    expect(esperarContratoBase(debug)).toMatchObject({
+    const decisao = esperarContratoBase(debug);
+    expect(decisao).toMatchObject({
       baseDeterministica: 0,
+      altasCandidatas: [],
       sorteiosAplicaveis: [],
       sorteiosNaoAplicaveis: [],
       defensivo: { estado: 'não elegível' },
-      resultadoFinal: 1,
+      resultadoFinal: 0,
       regraEspecialPrimeiraRodada: true,
     });
+    expect(identificarCartas(decisao.fortesVisiveis)).toEqual(['3♣']);
   });
 });
+
+function criarEstadoPrimeiraRodada(mao: Carta[], visiveis: Carta[]): EstadoRodada {
+  return {
+    fase: 'aguardandoDeclaracao',
+    pontos: { humano: 5, bot1: 5, bot2: 5 },
+    cartasPorRodada: 1,
+    jogadorAtual: 1,
+    cartaVirada: { valor: 'Q', naipe: '♦' },
+    manilha: 'K',
+    maos: [
+      { jogador: { id: 'humano', nome: 'Você', pontos: 5 }, cartas: visiveis, visivel: true },
+      { jogador: { id: 'bot1', nome: 'Brás', pontos: 5, temperatura: 0.35 }, cartas: mao, visivel: true },
+      { jogador: { id: 'bot2', nome: 'Lia', pontos: 5, temperatura: 0.2 }, cartas: [], visivel: true },
+    ],
+    mesa: [],
+    declaracoes: {},
+    vazas: {},
+    cartasReveladas: visiveis,
+    turno: 1,
+  };
+}

--- a/tests/adapters/debug-declaracao-bot.test.ts
+++ b/tests/adapters/debug-declaracao-bot.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { DecisaoDeclaracaoDebug } from '@/adapters/bots/debug-declaracao-bot';
+import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
+import type { Carta } from '@/core/Carta';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+
+function criarRng(valores: number[]): GeradorAleatorio {
+  let indice = 0;
+  return {
+    random: () => valores[indice++] ?? 0,
+    randomInt: (min: number) => min,
+    shuffle: <T>(array: T[]) => [...array],
+  };
+}
+
+function criarEstado(mao: Carta[], cartasPorRodada = mao.length): EstadoRodada {
+  return {
+    fase: 'aguardandoDeclaracao',
+    pontos: { humano: 5, bot1: 5 },
+    cartasPorRodada,
+    jogadorAtual: 1,
+    cartaVirada: { valor: 'Q', naipe: '♦' },
+    manilha: 'K',
+    maos: [
+      { jogador: { id: 'humano', nome: 'Você', pontos: 5 }, cartas: [], visivel: true },
+      { jogador: { id: 'bot1', nome: 'Brás', pontos: 5, temperatura: 0.35 }, cartas: mao, visivel: true },
+    ],
+    mesa: [],
+    declaracoes: {},
+    vazas: {},
+    cartasReveladas: [],
+    turno: 1,
+  };
+}
+
+function identificarCartas(avaliadas: { carta: Carta }[]): string[] {
+  return avaliadas.map(({ carta }) => `${carta.valor}${carta.naipe}`);
+}
+
+function criarLogger(debug: DecisaoDeclaracaoDebug[]) {
+  return {
+    registrarDeclaracao: (decisao: DecisaoDeclaracaoDebug) => debug.push(decisao),
+    registrarJogada: () => undefined,
+  };
+}
+
+function esperarContratoBase(debug: DecisaoDeclaracaoDebug[]): DecisaoDeclaracaoDebug {
+  expect(debug).toHaveLength(1);
+  return debug[0];
+}
+
+function esperarDeclaracaoComSorteios(decisao: DecisaoDeclaracaoDebug): void {
+  expect(decisao).toMatchObject({
+    baseDeterministica: 1,
+    defensivo: { estado: 'não elegível' },
+    resultadoFinal: 2,
+    regraEspecialPrimeiraRodada: false,
+  });
+  expect(identificarCartas(decisao.altasCandidatas)).toEqual(['2♦', '2♥']);
+  expect(identificarCartas(decisao.sorteiosAplicaveis)).toEqual(['2♦']);
+  expect(identificarCartas(decisao.sorteiosNaoAplicaveis)).toEqual(['2♥']);
+}
+
+describe('Contrato de debug da declaração do bot com sorteios de altas', () => {
+  it('deve expor base determinística e separar sorteios aplicáveis dos não aplicáveis', async () => {
+    const debug: DecisaoDeclaracaoDebug[] = [];
+    const mao = [
+      { valor: '3', naipe: '♣' },
+      { valor: '2', naipe: '♦' },
+      { valor: '2', naipe: '♥' },
+      { valor: '4', naipe: '♦' },
+    ] satisfies Carta[];
+    const decisor = new DecisorDeclaracaoBot(0.5, criarRng([0.1, 0.9]), {
+      poucasBaixas: 1,
+      declaracaoBaixa: 1,
+      logger: criarLogger(debug),
+    });
+
+    await expect(decisor.declarar(criarEstado(mao), mao)).resolves.toBe(2);
+
+    esperarDeclaracaoComSorteios(esperarContratoBase(debug));
+  });
+});
+
+describe('Contrato de debug da declaração do bot na primeira rodada', () => {
+  it('deve manter o contrato mínimo também na regra especial da primeira rodada', async () => {
+    const debug: DecisaoDeclaracaoDebug[] = [];
+    const mao = [{ valor: '4', naipe: '♣' }] satisfies Carta[];
+    const decisor = new DecisorDeclaracaoBot(0, criarRng([0]), {
+      poucasBaixas: 1,
+      declaracaoBaixa: 1,
+      logger: criarLogger(debug),
+    });
+
+    await expect(decisor.declarar(criarEstado(mao, 1), mao)).resolves.toBe(1);
+
+    expect(esperarContratoBase(debug)).toMatchObject({
+      baseDeterministica: 0,
+      sorteiosAplicaveis: [],
+      sorteiosNaoAplicaveis: [],
+      defensivo: { estado: 'não elegível' },
+      resultadoFinal: 1,
+      regraEspecialPrimeiraRodada: true,
+    });
+  });
+});

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -93,9 +93,11 @@ describe('Logger debug da declaração dos bots', () => {
 
     expect(group).toHaveBeenCalledWith('🟡 Brás (T=0.35) — DECLARAÇÃO');
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Mão: ['));
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Seguras contadas:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Base determinística:'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Altas candidatas:'));
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Sorteios de altas:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Sorteios aplicáveis:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Sorteios não aplicáveis:'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Resultado final:'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('→ Declarou:'));
   });
 });

--- a/tests/adapters/logger-debug-declaracao-primeira-rodada.test.ts
+++ b/tests/adapters/logger-debug-declaracao-primeira-rodada.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DecisorDeclaracaoBot } from '@/adapters/bots/DecisorDeclaracaoBot';
+import { criarLoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
+import type { Carta } from '@/core/Carta';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+
+function rng(valor: number): GeradorAleatorio {
+  return {
+    random: vi.fn(() => valor),
+    randomInt: vi.fn(() => 0),
+    shuffle: <T>(cartas: T[]) => [...cartas],
+  };
+}
+
+function estadoPrimeiraRodada(): EstadoRodada {
+  return {
+    fase: 'aguardandoDeclaracao',
+    pontos: { humano: 5, bot1: 5, bot2: 5 },
+    cartasPorRodada: 1,
+    jogadorAtual: 1,
+    cartaVirada: { valor: 'Q', naipe: '♦' },
+    manilha: 'K',
+    maos: [
+      { jogador: { id: 'humano', nome: 'Você', pontos: 5 }, cartas: [{ valor: '3', naipe: '♣' }], visivel: true },
+      {
+        jogador: { id: 'bot1', nome: 'Brás', pontos: 5, temperatura: 0.35 },
+        cartas: [{ valor: '5', naipe: '♦' }],
+        visivel: true,
+      },
+      { jogador: { id: 'bot2', nome: 'Lia', pontos: 5, temperatura: 0.2 }, cartas: [], visivel: true },
+    ],
+    mesa: [],
+    declaracoes: {},
+    vazas: {},
+    cartasReveladas: [{ valor: '3', naipe: '♣' }],
+    turno: 1,
+  };
+}
+
+describe('Logger debug da declaração dos bots na primeira rodada', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deve destacar fortes visíveis na regra especial', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+    const logger = criarLoggerDebugBot('Brás', 0.35);
+    const decisor = new DecisorDeclaracaoBot(0.35, rng(0.1), {
+      poucasBaixas: 1,
+      declaracaoBaixa: 1,
+      logger,
+    });
+    const mao: Carta[] = [{ valor: '5', naipe: '♦' }];
+
+    await decisor.declarar(estadoPrimeiraRodada(), mao);
+
+    expect(log).toHaveBeenCalledWith('Regra especial N=1: própria carta oculta não entrou no cálculo');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Fortes visíveis: [3♣ segura] (1)'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Resultado final: 0'));
+  });
+});


### PR DESCRIPTION
## Summary
- Reorganiza o contrato de debug da declaração para expor a base determinística, os sorteios aplicáveis e os não aplicáveis, além do resultado final.
- Ajusta o `DecisorDeclaracaoBot` para separar a classificação das cartas altas antes do cálculo da declaração.
- Atualiza o logger de debug para imprimir a nova estrutura de diagnóstico.
- Adiciona testes cobrindo o contrato de debug da declaração e atualiza a expectativa do logger.

## Testing
- `pnpm test` não foi executado nesta sessão.
- Cobertura adicionada em `tests/adapters/debug-declaracao-bot.test.ts` para validar o contrato de debug com sorteios e na primeira rodada.
- Cobertura ajustada em `tests/adapters/logger-debug-bot.test.ts` para verificar os novos campos logados.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal calculation logic for game declarations with better separation of deterministic and randomized components.
  * Enhanced debug logging and test infrastructure for declaration decision verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->