### PR TITLE
Simplify linha quente bifurcation debug logging

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -15,8 +15,6 @@ import {
   escolherPressao,
   escolherTravessia,
   formatarMotivoRecusaBifurcacao,
-  MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS,
-  MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS,
   podeBifurcar,
 } from './regras-linha-quente';
 
@@ -65,7 +63,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       decidirUltimoLinhaQuente(base.estadoAtual, base.contexto),
       criarCaminhoJogadaDebug(base.posicao, 'quente'),
     );
-    return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS);
+    return this.resolverBifurcacao(base, quente);
   }
 
   private decidirAntesDoFim(base: BaseJogada): Carta {
@@ -76,21 +74,20 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     if (!bifurcacao.pode) {
       const motivo = bifurcacao.motivoRecusa
         ? formatarMotivoRecusaBifurcacao(bifurcacao.motivoRecusa)
-        : MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS;
+        : base.motivoLinhaFria;
       return this.registrarSemBifurcacao(
         base,
         criarDecisaoQuente({ carta: base.fria, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente')),
-        motivo,
       );
     }
 
     const quente = criarDecisaoQuente(escolherPressao(base.contexto), criarCaminhoJogadaDebug(base.posicao, 'quente'));
-    return this.resolverBifurcacao(base, quente, MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS);
+    return this.resolverBifurcacao(base, quente);
   }
 
-  private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente, motivoSemBifurcacao: string): Carta {
+  private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {
     if (cartasIguais(base.fria, quente.carta)) {
-      return this.registrarSemBifurcacao(base, quente, motivoSemBifurcacao);
+      return this.registrarSemBifurcacao(base, quente);
     }
 
     const sorteio = this.rng.random();
@@ -134,7 +131,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     });
   }
 
-  private registrarSemBifurcacao(base: BaseJogada, quente: DecisaoQuente, motivo: string): Carta {
+  private registrarSemBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {
     return registrarEscolhaDireta({
       logger: this.logger,
       mao: base.mao,
@@ -146,7 +143,6 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       motivoLinhaQuente: quente.motivo,
       caminhoLinhaFria: base.caminhoLinhaFria,
       caminhoLinhaQuente: quente.caminho,
-      motivoSemBifurcacao: motivo,
       escolheuQuente: false,
     });
   }

--- a/src/adapters/bots/logger-debug-bot.ts
+++ b/src/adapters/bots/logger-debug-bot.ts
@@ -20,7 +20,6 @@ export interface DecisaoJogadaDebug {
   quente?: LinhaJogadaDebug;
   motivoLinhaFria?: string;
   motivoLinhaQuente?: string;
-  motivoSemBifurcacao?: string;
   carta: Carta;
   sorteio?: number;
   escolheuQuente: boolean;
@@ -119,8 +118,7 @@ function formatarBifurcacao(decisao: DecisaoJogadaDebug): string {
       decisao.linhaQuente,
     )}`;
   }
-  const motivo = decisao.motivoSemBifurcacao ? ` | ${decisao.motivoSemBifurcacao}` : '';
-  return `Bifurcação: não ocorreu${motivo}`;
+  return 'Bifurcação: não ocorreu';
 }
 
 function formatarTituloJogada(titulo: TituloJogada): string {

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -14,7 +14,6 @@ interface EscolhaDireta {
   motivoLinhaQuente?: string;
   caminhoLinhaFria: string[];
   caminhoLinhaQuente: string[];
-  motivoSemBifurcacao?: string;
   escolheuQuente: boolean;
 }
 
@@ -47,7 +46,6 @@ export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
     ),
     motivoLinhaFria: config.motivoLinhaFria,
     motivoLinhaQuente: config.motivoLinhaQuente,
-    motivoSemBifurcacao: config.motivoSemBifurcacao,
     carta: config.carta,
     escolheuQuente: config.escolheuQuente,
   });

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -27,14 +27,8 @@ export function podeBifurcar(
   return { pode: true };
 }
 
-export const MOTIVO_SEM_BIFURCACAO_URGENCIA = 'sem bifurcação: ambas fazem porque urgência >= 0.66';
-export const MOTIVO_SEM_BIFURCACAO_FUGA_IMPOSSIVEL = 'sem bifurcação: fuga impossível';
-export const MOTIVO_SEM_BIFURCACAO_CARTAS_IGUAIS = 'sem bifurcação: ambas não querem fazer e escolheram a mesma carta';
-export const MOTIVO_SEM_BIFURCACAO_LINHAS_IGUAIS = 'sem bifurcação: linhas fria e quente escolheram a mesma carta';
-export const MOTIVO_SEM_BIFURCACAO_NAO_PODE = 'sem bifurcação: não há condições para bifurcar';
-
 export function formatarMotivoRecusaBifurcacao(motivoRecusa: string): string {
-  return `sem bifurcação: ${motivoRecusa}`;
+  return `linha quente segue fria: ${motivoRecusa}`;
 }
 
 export function cartasIguais(a: Carta, b: Carta): boolean {

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
 import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
 import type { DecisaoJogadaDebug, LoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
-import type { Carta } from '@/core/Carta';
-import type { Jogador } from '@/types/entidades';
-import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
-import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+import { criarCarta } from '../core/rodada-fixtures';
+import {
+  cenarioBifurcacao,
+  cenarioBifurcacaoAntesDoFim,
+  criarEstado,
+  maoBifurcacao,
+  mesaComBaixa,
+  mesaComDois,
+  mesaComQuatro,
+} from './fixtures-jogada-linha-quente';
 
 describe('DecisorJogadaLinhaQuente', () => {
   it('deve escolher linha quente com segurança quando o RNG cai abaixo da temperatura', escolheLinhaQuente);
@@ -81,6 +87,7 @@ async function registraContratoExplicavel(): Promise<void> {
     caminho: ['jogada', 'joga no meio', 'linha fria'],
   });
   expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
+  expect(jogadas[0]).toMatchObject(decisaoSorteadaLinhaQuente());
 }
 
 async function atravessaComCartaBarata(): Promise<void> {
@@ -146,84 +153,12 @@ function criarBot(temperatura: number, valorRng: number, logger?: LoggerDebugBot
   });
 }
 
-function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
-  const jogadores = criarJogadores();
+function decisaoSorteadaLinhaQuente(): Partial<DecisaoJogadaDebug> {
   return {
-    fase: 'aguardandoJogada',
-    jogadorAtual: 3,
-    pontos: {},
-    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
-    cartasPorRodada: 3,
-    manilha: '5',
-    cartaVirada: null,
-    declaracoes: {},
-    mesa: [],
-    cartasReveladas: [],
-    vazas: {},
-    turno: 1,
-    ...config,
+    carta: criarCarta('4', '♦'),
+    linhaFria: criarCarta('3', '♦'),
+    linhaQuente: criarCarta('4', '♦'),
+    sorteio: 0,
+    escolheuQuente: true,
   };
-}
-
-function cenarioBifurcacao(): Partial<EstadoEmJogo> {
-  return {
-    mesa: mesaComQuatro(),
-    declaracoes: { j1: 0, j2: 1, bot: 1 },
-    vazas: { j1: 0, j2: 0, bot: 0 },
-    cartasReveladas: cartasQueGarantemTresDeOuros(),
-  };
-}
-
-function cenarioBifurcacaoAntesDoFim(): Partial<EstadoEmJogo> {
-  return {
-    ...cenarioBifurcacao(),
-    mesa: [
-      { jogadorId: 'j1', carta: criarCarta('4', '♣') },
-      { jogadorId: 'j2', carta: criarCarta('4', '♥') },
-    ],
-  };
-}
-
-function maoBifurcacao(): Carta[] {
-  return [criarCarta('3', '♦'), criarCarta('4', '♦')];
-}
-
-function criarJogadores(): Jogador[] {
-  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
-}
-
-function mesaComBaixa(): MesaItem[] {
-  return [
-    { jogadorId: 'j1', carta: criarCarta('8', '♣') },
-    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
-    { jogadorId: 'j3', carta: criarCarta('6', '♠') },
-  ];
-}
-
-function mesaComDois(): MesaItem[] {
-  return [
-    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
-    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
-    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
-  ];
-}
-
-function mesaComQuatro(): MesaItem[] {
-  return [
-    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
-    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
-    { jogadorId: 'j3', carta: criarCarta('4', '♠') },
-  ];
-}
-
-function cartasQueGarantemTresDeOuros(): Carta[] {
-  return [
-    criarCarta('3', '♣'),
-    criarCarta('3', '♥'),
-    criarCarta('3', '♠'),
-    criarCarta('5', '♣'),
-    criarCarta('5', '♥'),
-    criarCarta('5', '♠'),
-    criarCarta('5', '♦'),
-  ];
 }

--- a/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
@@ -108,8 +108,8 @@ async function registraSemBifurcacaoQuandoConverge(): Promise<void> {
     linhaQuente: criarCarta('8', '♦'),
     motivoLinhaFria: 'precisa fazer; regra G[N-X]',
     motivoLinhaQuente: 'precisa fazer; regra G[N-X]',
-    motivoSemBifurcacao: 'sem bifurcação: linhas fria e quente escolheram a mesma carta',
   });
+  expect(jogadas[0]).not.toHaveProperty('motivoSemBifurcacao');
 }
 
 function jogarContraNove(estado: EstadoEmJogo): Promise<Carta> {

--- a/tests/adapters/fixtures-jogada-linha-quente.ts
+++ b/tests/adapters/fixtures-jogada-linha-quente.ts
@@ -1,0 +1,86 @@
+import type { Carta } from '@/core/Carta';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+export function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = criarJogadores();
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+export function cenarioBifurcacao(): Partial<EstadoEmJogo> {
+  return {
+    mesa: mesaComQuatro(),
+    declaracoes: { j1: 0, j2: 1, bot: 1 },
+    vazas: { j1: 0, j2: 0, bot: 0 },
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+  };
+}
+
+export function cenarioBifurcacaoAntesDoFim(): Partial<EstadoEmJogo> {
+  return {
+    ...cenarioBifurcacao(),
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    ],
+  };
+}
+
+export function maoBifurcacao(): Carta[] {
+  return [criarCarta('3', '♦'), criarCarta('4', '♦')];
+}
+
+export function mesaComBaixa(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('8', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('6', '♠') },
+  ];
+}
+
+export function mesaComDois(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
+  ];
+}
+
+export function mesaComQuatro(): MesaItem[] {
+  return [
+    { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+    { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    { jogadorId: 'j3', carta: criarCarta('4', '♠') },
+  ];
+}
+
+function criarJogadores(): Jogador[] {
+  return [criarJogador('j1', 'J1'), criarJogador('j2', 'J2'), criarJogador('j3', 'J3'), criarJogador('bot', 'Bot')];
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('5', '♣'),
+    criarCarta('5', '♥'),
+    criarCarta('5', '♠'),
+    criarCarta('5', '♦'),
+  ];
+}

--- a/tests/adapters/logger-debug-bot.test.ts
+++ b/tests/adapters/logger-debug-bot.test.ts
@@ -52,7 +52,6 @@ function registrarJogadaDireta(): void {
     linhaQuente: mao[0],
     carta: mao[0],
     escolheuQuente: false,
-    motivoSemBifurcacao: 'sem bifurcação: fuga impossível',
   });
 }
 
@@ -116,13 +115,14 @@ describe('Logger debug das jogadas dos bots', () => {
     expect(log).toHaveBeenCalledWith('Sorteio por temperatura: não ocorreu');
   });
 
-  it('deve registrar bifurcação ausente com motivo em escolhas diretas', () => {
+  it('deve registrar bifurcação ausente sem motivo separado', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
     vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
     registrarJogadaDireta();
 
-    expect(log).toHaveBeenCalledWith('Bifurcação: não ocorreu | sem bifurcação: fuga impossível');
+    expect(log).toHaveBeenCalledWith('Bifurcação: não ocorreu');
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('sem bifurcação:'));
   });
 
   it('deve registrar sorteio por temperatura sem chamar de determinístico', () => {


### PR DESCRIPTION
## Summary
- Removes the extra `motivoSemBifurcacao` field from bot decision logging and direct-choice registration.
- Standardizes non-bifurcation messages to use the existing line-specific refusal reason, or a generic `Bifurcação: não ocorreu` log entry.
- Extracts shared linha quente fixtures for the adapter tests to reduce duplication.
- Updates tests to assert the new logging contract and the absence of the removed field.

## Testing
- `pnpm test tests/adapters/DecisorJogadaLinhaQuente.test.ts`
- `pnpm test tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts`
- `pnpm test tests/adapters/logger-debug-bot.test.ts`
- Not run: full project test suite