### PR TITLE
feat: implementa abertura da linha fria

### DIFF
--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -13,7 +13,6 @@ interface ConfigDecisorJogadaBot {
   rng: Pick<GeradorAleatorio, 'random'>;
   liderBaixa?: number;
   liderAlta?: number;
-  urgenciaAbrirForte?: number;
   logger?: LoggerDebugBot;
 }
 

--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -3,7 +3,7 @@ import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
-import { decidirAbertura } from './decidirAbertura';
+import { decidirAberturaLinhaFria } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
 import { registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
@@ -19,13 +19,9 @@ interface ConfigDecisorJogadaBot {
 
 export class DecisorJogadaBot implements DecisorJogada {
   private readonly quente: DecisorJogadaLinhaQuente;
-  private readonly temperatura: number;
-  private readonly urgenciaAbrirForte: number;
   private readonly logger?: LoggerDebugBot;
 
   constructor(config: ConfigDecisorJogadaBot) {
-    this.temperatura = config.temperatura;
-    this.urgenciaAbrirForte = config.urgenciaAbrirForte ?? 0.5;
     this.quente = new DecisorJogadaLinhaQuente(config);
     this.logger = config.logger;
   }
@@ -35,20 +31,17 @@ export class DecisorJogadaBot implements DecisorJogada {
 
     const estadoAtual = estadoEmJogo(estado);
     if (estadoAtual.mesa.length === 0) {
-      const carta = decidirAbertura(mao, estadoAtual, {
-        temperatura: this.temperatura,
-        urgenciaAbrirForte: this.urgenciaAbrirForte,
-      });
+      const fria = decidirAberturaLinhaFria(mao, estadoAtual);
       return registrarEscolhaDireta({
         logger: this.logger,
         mao,
         estado,
-        carta,
-        linhaFria: carta,
-        linhaQuente: carta,
-        motivoLinhaFria: 'abertura: árvore de abertura',
+        carta: fria.carta,
+        linhaFria: fria.carta,
+        linhaQuente: fria.carta,
+        motivoLinhaFria: fria.motivo,
         motivoLinhaQuente: 'abertura: segue linha fria',
-        caminhoLinhaFria: criarCaminhoJogadaDebug('abre', 'fria'),
+        caminhoLinhaFria: fria.caminho,
         caminhoLinhaQuente: criarCaminhoJogadaDebug('abre', 'quente'),
         escolheuQuente: false,
       });

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -3,11 +3,12 @@ import type { Carta } from '@/core/Carta';
 import { calcularIndiceVencedor, cartaVence, compararForcaReal } from '@/core/comparador-carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
-import { decidirAbertura } from './decidirAbertura';
+import { decidirAberturaLinhaFria } from './decidirAbertura';
 
 export interface DecisaoLinhaFria {
   carta: Carta;
   motivo: string;
+  caminho?: string[];
 }
 
 export class DecisorJogadaLinhaFria implements DecisorJogada {
@@ -22,10 +23,7 @@ export class DecisorJogadaLinhaFria implements DecisorJogada {
 
 export function decidirNaoUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoLinhaFria {
   if (estado.mesa.length === 0) {
-    return {
-      carta: decidirAbertura(mao, estado, { temperatura: 0 }),
-      motivo: 'abertura: sem referência na mesa',
-    };
+    return decidirAberturaLinhaFria(mao, estado);
   }
 
   const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -164,7 +164,7 @@ interface ConfigBaseJogada {
   estado: EstadoRodada;
   estadoAtual: EstadoEmJogo;
   contexto: ContextoJogadaQuente;
-  decisaoFria: { carta: Carta; motivo: string };
+  decisaoFria: { carta: Carta; motivo: string; caminho?: string[] };
 }
 
 function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
@@ -177,6 +177,6 @@ function criarBaseJogada(config: ConfigBaseJogada): BaseJogada {
     posicao,
     fria: config.decisaoFria.carta,
     motivoLinhaFria: config.decisaoFria.motivo,
-    caminhoLinhaFria: criarCaminhoJogadaDebug(posicao, 'fria'),
+    caminhoLinhaFria: config.decisaoFria.caminho ?? criarCaminhoJogadaDebug(posicao, 'fria'),
   };
 }

--- a/src/adapters/bots/decidirAbertura.ts
+++ b/src/adapters/bots/decidirAbertura.ts
@@ -1,10 +1,7 @@
 import { avaliarCartas, type CategoriaCarta } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
-
-export function decidirAbertura(mao: Carta[], estado: EstadoEmJogo, _params?: unknown): Carta {
-  return decidirAberturaLinhaFria(mao, estado).carta;
-}
+import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 
 export interface DecisaoAberturaLinhaFria {
   carta: Carta;
@@ -54,6 +51,6 @@ function criarDecisaoAbertura(
   return {
     carta,
     motivo: `abertura: ${ramo}; ordem ${ordemCategorias.join('-')}`,
-    caminho: ['jogada', 'abre a mesa', 'linha fria', ramo],
+    caminho: criarCaminhoJogadaDebug('abre', 'fria', ramo),
   };
 }

--- a/src/adapters/bots/decidirAbertura.ts
+++ b/src/adapters/bots/decidirAbertura.ts
@@ -1,39 +1,59 @@
-import { avaliarCartas } from '@/core/avaliador-carta';
+import { avaliarCartas, type CategoriaCarta } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 
-interface ParametrosAbertura {
-  temperatura: number;
-  urgenciaAbrirForte?: number;
+export function decidirAbertura(mao: Carta[], estado: EstadoEmJogo, _params?: unknown): Carta {
+  return decidirAberturaLinhaFria(mao, estado).carta;
 }
 
-export function decidirAbertura(mao: Carta[], estado: EstadoEmJogo, params: ParametrosAbertura): Carta {
+export interface DecisaoAberturaLinhaFria {
+  carta: Carta;
+  motivo: string;
+  caminho: string[];
+}
+
+export function decidirAberturaLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoAberturaLinhaFria {
   if (mao.length === 0) throw new Error('decidirAbertura: mão vazia');
   const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
   const necessidade = (estado.declaracoes[jogadorId] ?? 0) - (estado.vazas[jogadorId] ?? 0);
-  // Garante folga >= 0 para evitar denominadores negativos ou divisão por zero.
-  // Em caso de déficit extremo (necessidade > tamanho da mão), a folga fica em 0,
-  // mantendo a urgência positiva alta para forçar o bot a jogar agressivamente.
-  const folga = Math.max(0, mao.length - necessidade);
-  const urgencia = necessidade / (folga + 1);
-
-  const urgenciaAbrirForte = params.urgenciaAbrirForte ?? 0.5;
-  const limiarAjustado = urgenciaAbrirForte + params.temperatura;
-  const quebraCautela = urgencia >= limiarAjustado;
+  const urgencia = necessidade / mao.length;
+  const urgenciaAlta = urgencia >= 0.66;
+  const ramo = definirRamoAbertura(necessidade, urgenciaAlta);
+  const ordemCategorias = definirOrdemCategorias(ramo);
 
   const avaliadas = avaliarCartas(mao, estado.manilha, estado.cartasReveladas, estado.maos.length);
-
-  const ordemCategorias = quebraCautela
-    ? (['alta', 'média', 'segura', 'baixa', 'garantida_agora'] as const)
-    : (['baixa', 'média', 'alta', 'segura', 'garantida_agora'] as const);
 
   for (const cat of ordemCategorias) {
     const daCategoria = avaliadas.filter((a) => a.categoria === cat);
     if (daCategoria.length > 0) {
-      return [...daCategoria].sort((a, b) => a.score - b.score)[0].carta;
+      return criarDecisaoAbertura([...daCategoria].sort((a, b) => a.score - b.score)[0].carta, ramo, ordemCategorias);
     }
   }
 
-  // Fallback defensivo caso nenhuma categoria seja encontrada (inalcançável teoricamente)
-  return mao[0];
+  return criarDecisaoAbertura(mao[0], ramo, ordemCategorias);
+}
+
+type RamoAbertura = 'já cumpriu' | 'urgência alta' | 'precisa sem urgência alta';
+
+function definirRamoAbertura(necessidade: number, urgenciaAlta: boolean): RamoAbertura {
+  if (necessidade <= 0) return 'já cumpriu';
+  if (urgenciaAlta) return 'urgência alta';
+  return 'precisa sem urgência alta';
+}
+
+function definirOrdemCategorias(ramo: RamoAbertura): readonly CategoriaCarta[] {
+  if (ramo === 'urgência alta') return ['alta', 'média', 'segura', 'baixa', 'garantida_agora'];
+  return ['baixa', 'média', 'alta', 'segura', 'garantida_agora'];
+}
+
+function criarDecisaoAbertura(
+  carta: Carta,
+  ramo: RamoAbertura,
+  ordemCategorias: readonly CategoriaCarta[],
+): DecisaoAberturaLinhaFria {
+  return {
+    carta,
+    motivo: `abertura: ${ramo}; ordem ${ordemCategorias.join('-')}`,
+    caminho: ['jogada', 'abre a mesa', 'linha fria', ramo],
+  };
 }

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -51,14 +51,14 @@ async function abrirUrgenciaBaixa(): Promise<void> {
 async function abrirFrioUrgenciaAlta(): Promise<void> {
   const estado = criarEstado({
     mesa: [],
-    declaracoes: { bot: 1 },
+    declaracoes: { bot: 2 },
     vazas: { bot: 0 },
     cartasReveladas: [],
   });
   const bot = new DecisorJogadaBot({ temperatura: 0, rng: { random: () => 0 }, urgenciaAbrirForte: 0.5 });
-  const mao = [criarCarta('2', '♠'), criarCarta('8', '♦')];
+  const mao = [criarCarta('3', '♠'), criarCarta('8', '♦')];
 
-  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('2', '♠'));
+  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('3', '♠'));
 }
 
 async function abrirQuenteUrgenciaAlta(): Promise<void> {
@@ -132,15 +132,22 @@ async function registraContextoAbertura(): Promise<void> {
 
   await bot.decidirJogada([criarCarta('8', '♦'), criarCarta('4', '♦')], estado);
 
-  expect(jogadas[0]?.contexto).toMatchObject({
+  expect(jogadas[0]?.fria).toMatchObject({
+    motivo: 'abertura: urgência alta; ordem alta-média-segura-baixa-garantida_agora',
+    caminho: ['jogada', 'abre a mesa', 'linha fria', 'urgência alta'],
+  });
+  esperarContextoAbertura(jogadas[0]);
+}
+
+function esperarContextoAbertura(jogada: DecisaoJogadaDebug | undefined): void {
+  expect(jogada?.contexto).toMatchObject({
     posicaoMesa: 'abre',
     necessidade: 2,
     urgencia: 1,
     urgenciaAlta: true,
     jogadoresPorAgir: 3,
   });
-  expect(jogadas[0]?.fria?.caminho).toEqual(['jogada', 'abre a mesa', 'linha fria']);
-  expect(jogadas[0]?.quente).toMatchObject({
+  expect(jogada?.quente).toMatchObject({
     motivo: 'abertura: segue linha fria',
     caminho: ['jogada', 'abre a mesa', 'linha quente'],
   });

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { decidirAbertura } from '@/adapters/bots/decidirAbertura';
+import { decidirAberturaLinhaFria } from '@/adapters/bots/decidirAbertura';
 import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
 import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
 import type { Carta } from '@/core/Carta';
@@ -55,7 +55,7 @@ async function abrirFrioUrgenciaAlta(): Promise<void> {
     vazas: { bot: 0 },
     cartasReveladas: [],
   });
-  const bot = new DecisorJogadaBot({ temperatura: 0, rng: { random: () => 0 }, urgenciaAbrirForte: 0.5 });
+  const bot = new DecisorJogadaBot({ temperatura: 0, rng: { random: () => 0 } });
   const mao = [criarCarta('3', '♠'), criarCarta('8', '♦')];
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('3', '♠'));
@@ -68,7 +68,7 @@ async function abrirQuenteUrgenciaAlta(): Promise<void> {
     vazas: { bot: 0 },
     cartasReveladas: cartasQueGarantemTresDeOuros(),
   });
-  const bot = new DecisorJogadaBot({ temperatura: 0.5, rng: { random: () => 0 }, urgenciaAbrirForte: 0.5 });
+  const bot = new DecisorJogadaBot({ temperatura: 0.5, rng: { random: () => 0 } });
   const mao = [criarCarta('3', '♦'), criarCarta('8', '♦')];
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('8', '♦'));
@@ -107,7 +107,7 @@ async function abrirFolgaNegativa(): Promise<void> {
     vazas: { bot: 0 },
     cartasReveladas: [],
   });
-  const bot = new DecisorJogadaBot({ temperatura: 0.5, rng: { random: () => 0 }, urgenciaAbrirForte: 0.5 });
+  const bot = new DecisorJogadaBot({ temperatura: 0.5, rng: { random: () => 0 } });
   const mao = [criarCarta('2', '♠'), criarCarta('8', '♦'), criarCarta('A', '♣')];
 
   // A urgência deve ser alta (quebra de cautela) e escolher a carta '2' de Espadas (alta)
@@ -160,7 +160,7 @@ function deveFalharMaoVaziaAbertura(): void {
     vazas: { bot: 0 },
   });
 
-  expect(() => decidirAbertura([], estado, { temperatura: 0.5 })).toThrow('decidirAbertura: mão vazia');
+  expect(() => decidirAberturaLinhaFria([], estado)).toThrow('decidirAbertura: mão vazia');
 }
 
 function criarBot(temperatura: number, valorRng: number): DecisorJogadaBot {

--- a/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
+++ b/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
@@ -8,18 +8,42 @@ const cenarios: {
   nome: string;
   mao: Carta[];
   estado: EstadoEmJogo;
-  esperado: { carta: Carta; motivo: string };
+  esperado: { carta: Carta; motivo: string; caminho?: string[] };
 }[] = [
   {
-    nome: 'deve abrir com motivo de sem referência na mesa',
-    mao: [criarCarta('3', '♦'), criarCarta('8', '♦')],
+    nome: 'deve abrir com ordem cautelosa quando já cumpriu',
+    mao: [criarCarta('7', '♦'), criarCarta('8', '♦'), criarCarta('3', '♦')],
     estado: criarEstado({
       mesa: [],
       declaracoes: { bot: 0 },
       vazas: { bot: 0 },
       cartasReveladas: cartasQueGarantemTresDeOuros(),
     }),
-    esperado: { carta: criarCarta('8', '♦'), motivo: 'abertura: sem referência na mesa' },
+    esperado: {
+      carta: criarCarta('7', '♦'),
+      motivo: 'abertura: já cumpriu; ordem baixa-média-alta-segura-garantida_agora',
+      caminho: ['jogada', 'abre a mesa', 'linha fria', 'já cumpriu'],
+    },
+  },
+  {
+    nome: 'deve abrir cautelosamente quando precisa fazer sem urgência alta',
+    mao: [criarCarta('7', '♦'), criarCarta('3', '♦')],
+    estado: criarEstado({ mesa: [], declaracoes: { bot: 1 }, vazas: { bot: 0 } }),
+    esperado: {
+      carta: criarCarta('7', '♦'),
+      motivo: 'abertura: precisa sem urgência alta; ordem baixa-média-alta-segura-garantida_agora',
+      caminho: ['jogada', 'abre a mesa', 'linha fria', 'precisa sem urgência alta'],
+    },
+  },
+  {
+    nome: 'deve abrir forte quando precisa fazer com urgência alta',
+    mao: [criarCarta('7', '♦'), criarCarta('2', '♦'), criarCarta('8', '♦')],
+    estado: criarEstado({ mesa: [], declaracoes: { bot: 2 }, vazas: { bot: 0 } }),
+    esperado: {
+      carta: criarCarta('2', '♦'),
+      motivo: 'abertura: urgência alta; ordem alta-média-segura-baixa-garantida_agora',
+      caminho: ['jogada', 'abre a mesa', 'linha fria', 'urgência alta'],
+    },
   },
   {
     nome: 'deve fugir com carta mais alta que não faz',


### PR DESCRIPTION
## Resumo

- implementa a abertura da Linha fria conforme `docs/arvores-de-decisao-dos-bots.md`
- troca a urgência da abertura para `necessidade / cartasNaMao >= 0.66`, sem influência de temperatura
- registra motivo e rastro específicos para os ramos de abertura
- cobre as três ordens de abertura e atualiza o debug explicável

## Validação

- `pnpm test -- --run tests/adapters/decidirNaoUltimoLinhaFria.test.ts tests/adapters/DecisorJogadaBot.test.ts tests/adapters/DecisorJogadaLinhaFria.test.ts tests/adapters/DecisorJogadaLinhaQuente.test.ts tests/adapters/logger-debug-bot.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- pre-push: `pnpm typecheck` + `vitest run`

Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot opening decisions now include detailed reasoning and decision path information.

* **Refactor**
  * Simplified bot opening decision-making logic by removing temperature parameters.
  * Updated decision objects to optionally include decision path details.
  * Bot may select different opening cards based on revised urgency calculation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->