### PR TITLE
refactor: extrair escolhas por necessidade dos bots

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -1,9 +1,14 @@
 import { avaliarCartas, type CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { calcularIndiceVencedor, cartaVence, compararForcaReal } from '@/core/comparador-carta';
+import { calcularIndiceVencedor, cartaVence } from '@/core/comparador-carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
 import { decidirAberturaLinhaFria } from './decidirAbertura';
+import {
+  descartePorNecessidade,
+  escolherVencedoraPorNecessidade,
+  ordenarPorForcaReal,
+} from './escolhas-por-necessidade';
 
 export interface DecisaoLinhaFria {
   carta: Carta;
@@ -45,7 +50,7 @@ function buscarVazaNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], n
   const vencedoras = cartasQueVencem(estado, avaliadas);
   if (vencedoras.length > 0) {
     return {
-      carta: escolherGanhadora(vencedoras, estado.manilha, necessidade).carta,
+      carta: escolherVencedoraPorNecessidade(vencedoras, estado.manilha, necessidade).carta,
       motivo: 'precisa fazer; regra G[N-X]',
     };
   }
@@ -53,7 +58,7 @@ function buscarVazaNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], n
   const naoFazem = cartasQueNaoFazem(estado, avaliadas);
   if (naoFazem.length > 0) {
     return {
-      carta: escolherPerdedora(naoFazem, estado.manilha, necessidade).carta,
+      carta: descartePorNecessidade(naoFazem, estado.manilha, necessidade).carta,
       motivo: 'precisa fazer; regra P[N-X]',
     };
   }
@@ -77,13 +82,13 @@ function decidirUltimoQuandoPrecisaFazer(
   const vencedoras = cartasQueVencem(estado, avaliadas);
   if (vencedoras.length > 0) {
     return {
-      carta: escolherGanhadora(vencedoras, estado.manilha, necessidade).carta,
+      carta: escolherVencedoraPorNecessidade(vencedoras, estado.manilha, necessidade).carta,
       motivo: 'precisa fazer; regra G[N-X]',
     };
   }
 
   return {
-    carta: escolherPerdedora(cartasQueNaoFazem(estado, avaliadas), estado.manilha, necessidade).carta,
+    carta: descartePorNecessidade(cartasQueNaoFazem(estado, avaliadas), estado.manilha, necessidade).carta,
     motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
   };
 }
@@ -116,22 +121,6 @@ function cartasQueNaoFazem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Ca
 function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
   if (mesa.length === 0) return null;
   return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
-}
-
-function escolherGanhadora(avaliadas: CartaAvaliada[], manilha: Carta['valor'], necessidade: number): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  const indice = ordenadas.length >= necessidade ? ordenadas.length - necessidade : 0;
-  return ordenadas[indice];
-}
-
-function escolherPerdedora(avaliadas: CartaAvaliada[], manilha: Carta['valor'], necessidade: number): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  const indice = ordenadas.length > necessidade ? ordenadas.length - necessidade : 0;
-  return ordenadas[indice];
-}
-
-function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
-  return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
 }
 
 function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {

--- a/src/adapters/bots/decidirUltimoLinhaQuente.ts
+++ b/src/adapters/bots/decidirUltimoLinhaQuente.ts
@@ -1,7 +1,12 @@
 import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { calcularIndiceVencedor, cartasEmpatam, cartaVence, compararForcaReal } from '@/core/comparador-carta';
+import { calcularIndiceVencedor, cartasEmpatam, cartaVence } from '@/core/comparador-carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
+import {
+  descartePorNecessidade,
+  escolherVencedoraPorNecessidade,
+  ordenarPorForcaReal,
+} from './escolhas-por-necessidade';
 
 export interface ContextoUltimoLinhaQuente {
   necessidade: number;
@@ -35,24 +40,24 @@ function decidirQuandoPrecisaFazer(
 ): DecisaoUltimoLinhaQuente {
   if (contexto.vencedoras.length === 0) {
     return {
-      carta: escolherPerdedora(cartasQueNaoVencem(contexto), estado.manilha, contexto).carta,
+      carta: descartePorNecessidade(cartasQueNaoVencem(contexto), estado.manilha, contexto.necessidade).carta,
       motivo: 'precisa fazer, sem carta que vence; P[N-X]',
     };
   }
   if (deveFazerAgora(estado, contexto)) {
     return {
-      carta: escolherGanhadora(contexto.vencedoras, estado.manilha, contexto).carta,
+      carta: escolherVencedoraPorNecessidade(contexto.vencedoras, estado.manilha, contexto.necessidade).carta,
       motivo: 'precisa fazer; regra G[N-X]',
     };
   }
   if (contexto.perdedoras.length > 0) {
     return {
-      carta: escolherPerdedora(contexto.perdedoras, estado.manilha, contexto).carta,
+      carta: descartePorNecessidade(contexto.perdedoras, estado.manilha, contexto.necessidade).carta,
       motivo: 'precisa fazer; adiou; P[N-X]',
     };
   }
   return {
-    carta: escolherGanhadora(contexto.vencedoras, estado.manilha, contexto).carta,
+    carta: escolherVencedoraPorNecessidade(contexto.vencedoras, estado.manilha, contexto.necessidade).carta,
     motivo: 'precisa fazer; regra G[N-X]',
   };
 }
@@ -111,26 +116,6 @@ function deveFazerAgora(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuent
   return contexto.necessidade / contexto.avaliadas.length >= 0.66;
 }
 
-function escolherGanhadora(
-  avaliadas: CartaAvaliada[],
-  manilha: Carta['valor'],
-  contexto: ContextoUltimoLinhaQuente,
-): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  const indice = ordenadas.length >= contexto.necessidade ? ordenadas.length - contexto.necessidade : 0;
-  return ordenadas[indice];
-}
-
-function escolherPerdedora(
-  avaliadas: CartaAvaliada[],
-  manilha: Carta['valor'],
-  contexto: ContextoUltimoLinhaQuente,
-): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  const indice = ordenadas.length > contexto.necessidade ? ordenadas.length - contexto.necessidade : 0;
-  return ordenadas[indice];
-}
-
 function cartasQueNaoVencem(contexto: ContextoUltimoLinhaQuente): CartaAvaliada[] {
   return [...contexto.perdedoras, ...contexto.empates];
 }
@@ -143,10 +128,6 @@ function liderQuerVaza(estado: EstadoEmJogo): boolean {
 
 function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
   return ['alta', 'segura', 'garantida_agora'].includes(avaliada.categoria);
-}
-
-function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
-  return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
 }
 
 function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {

--- a/src/adapters/bots/escolhas-por-necessidade.ts
+++ b/src/adapters/bots/escolhas-por-necessidade.ts
@@ -1,0 +1,27 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { compararForcaReal } from '@/core/comparador-carta';
+
+export function escolherVencedoraPorNecessidade(
+  avaliadas: CartaAvaliada[],
+  manilha: Carta['valor'],
+  necessidade: number,
+): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length >= necessidade ? ordenadas.length - necessidade : 0;
+  return ordenadas[indice];
+}
+
+export function descartePorNecessidade(
+  avaliadas: CartaAvaliada[],
+  manilha: Carta['valor'],
+  necessidade: number,
+): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  const indice = ordenadas.length > necessidade ? ordenadas.length - necessidade : 0;
+  return ordenadas[indice];
+}
+
+export function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
+  return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
+}

--- a/tests/adapters/escolhas-por-necessidade.test.ts
+++ b/tests/adapters/escolhas-por-necessidade.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  descartePorNecessidade,
+  escolherVencedoraPorNecessidade,
+  ordenarPorForcaReal,
+} from '@/adapters/bots/escolhas-por-necessidade';
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import { criarCarta } from '../core/rodada-fixtures';
+
+describe('escolhas por necessidade', () => {
+  it('deve escolher vencedora pelo índice canônico quando há cartas suficientes', deveEscolherVencedoraPorIndice);
+  it('deve escolher a vencedora mais fraca quando vencedoras são escassas', deveEscolherVencedoraEscassa);
+  it('deve descartar pelo índice canônico quando há folga sobre a necessidade', deveDescartarPorIndice);
+  it('deve descartar a carta mais fraca quando candidatas não excedem a necessidade', deveDescartarEscassa);
+  it('deve ordenar por força real considerando manilha e desempate por naipe', deveOrdenarPorForcaReal);
+});
+
+function deveEscolherVencedoraPorIndice(): void {
+  const vencedoras = avaliar([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')]);
+
+  expect(escolherVencedoraPorNecessidade(vencedoras, '6', 2).carta).toEqual(criarCarta('8', '♦'));
+}
+
+function deveEscolherVencedoraEscassa(): void {
+  const vencedoras = avaliar([criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')]);
+
+  expect(escolherVencedoraPorNecessidade(vencedoras, '6', 4).carta).toEqual(criarCarta('5', '♦'));
+}
+
+function deveDescartarPorIndice(): void {
+  const candidatas = avaliar([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')]);
+
+  expect(descartePorNecessidade(candidatas, '5', 2).carta).toEqual(criarCarta('9', '♦'));
+}
+
+function deveDescartarEscassa(): void {
+  const candidatas = avaliar([criarCarta('4', '♦'), criarCarta('6', '♦')]);
+
+  expect(descartePorNecessidade(candidatas, '5', 2).carta).toEqual(criarCarta('4', '♦'));
+}
+
+function deveOrdenarPorForcaReal(): void {
+  const cartas = avaliar([criarCarta('5', '♦'), criarCarta('5', '♣'), criarCarta('3', '♦')]);
+
+  expect(ordenarPorForcaReal(cartas, '5').map((avaliada) => avaliada.carta)).toEqual([
+    criarCarta('3', '♦'),
+    criarCarta('5', '♦'),
+    criarCarta('5', '♣'),
+  ]);
+}
+
+function avaliar(cartas: Carta[]): CartaAvaliada[] {
+  return cartas.map((carta, indice) => ({ carta, score: indice, categoria: 'baixa' }));
+}


### PR DESCRIPTION
## Summary
- Extraiu a lógica de seleção por necessidade para `src/adapters/bots/escolhas-por-necessidade.ts`.
- Removeu duplicação entre `DecisorJogadaLinhaFria` e `decidirUltimoLinhaQuente`, centralizando ordenação por força real e a escolha de vencedoras/descartes.
- Adicionou testes cobrindo ordenação por força real e os cenários de escolha por necessidade.

## Testing
- Not run (não executei a suíte nesta sessão).
- Cobertura adicionada em `tests/adapters/escolhas-por-necessidade.test.ts` para:
  - seleção de vencedora quando há cartas suficientes;
  - seleção de vencedora quando há poucas candidatas;
  - descarte quando há folga sobre a necessidade;
  - descarte quando as candidatas não excedem a necessidade;
  - ordenação por força real com desempate por naipe.