### PR TITLE
feat: linha fria já cumpriu no meio e fechamento (#211, #212)

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -4,6 +4,7 @@ import { calcularIndiceVencedor, cartaVence } from '@/core/comparador-carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } from '@/types/estado-rodada';
 import { calcularNecessidade, ehUltimoDaMesa } from './contexto-posicao-mesa';
+import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 import { decidirAberturaLinhaFria } from './decidirAbertura';
 import {
   descartePorNecessidade,
@@ -19,6 +20,7 @@ export interface DecisaoLinhaFria {
 }
 
 const CAMINHO_MEIO = ['jogada', 'joga no meio', 'linha fria'] as const;
+const CAMINHO_JA_CUMPRIU = [...CAMINHO_MEIO, 'já cumpriu'] as const;
 
 export class DecisorJogadaLinhaFria implements DecisorJogada {
   decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -43,11 +45,12 @@ export function decidirNaoUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): D
 }
 
 function fugirNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): DecisaoLinhaFria {
+  const caminho = [...CAMINHO_JA_CUMPRIU];
   const naoFazem = cartasQueNaoFazem(estado, avaliadas);
   if (naoFazem.length === 0) {
-    return { carta: cartaMaisBarata(avaliadas).carta, motivo: 'não quer fazer; fuga impossível' };
+    return { carta: cartaMaisBarata(avaliadas).carta, motivo: 'já cumpriu; fuga impossível', caminho };
   }
-  return { carta: cartaMaisCara(naoFazem).carta, motivo: 'não quer fazer; carta mais alta que não faz' };
+  return { carta: cartaMaisCara(naoFazem).carta, motivo: 'já cumpriu; carta mais alta que não faz', caminho };
 }
 
 function buscarVazaNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[], necessidade: number): DecisaoLinhaFria {
@@ -141,27 +144,35 @@ function decidirUltimoQuandoPrecisaFazer(
   avaliadas: CartaAvaliada[],
   necessidade: number,
 ): DecisaoLinhaFria {
+  const caminho = criarCaminhoJogadaDebug('fecha', 'fria', 'precisa fazer');
   const vencedoras = cartasQueVencem(estado, avaliadas);
   if (vencedoras.length > 0) {
     return {
       carta: escolherVencedoraPorNecessidade(vencedoras, estado.manilha, necessidade).carta,
       motivo: 'precisa fazer; regra G[N-X]',
+      caminho,
     };
   }
 
   return {
     carta: descartePorNecessidade(cartasQueNaoFazem(estado, avaliadas), estado.manilha, necessidade).carta,
     motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
+    caminho,
   };
 }
 
 function decidirUltimoQuandoJaCumpriu(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): DecisaoLinhaFria {
+  const caminho = criarCaminhoJogadaDebug('fecha', 'fria', 'já cumpriu');
   const naoFazem = cartasQueNaoFazem(estado, avaliadas);
   if (naoFazem.length > 0) {
-    return { carta: cartaMaisForte(naoFazem, estado.manilha).carta, motivo: 'já cumpriu; carta mais alta que não faz' };
+    return {
+      carta: cartaMaisForte(naoFazem, estado.manilha).carta,
+      motivo: 'já cumpriu; carta mais alta que não faz',
+      caminho,
+    };
   }
 
-  return { carta: cartaMaisForte(avaliadas, estado.manilha).carta, motivo: 'já cumpriu; fuga impossível' };
+  return { carta: cartaMaisForte(avaliadas, estado.manilha).carta, motivo: 'já cumpriu; fuga impossível', caminho };
 }
 
 function cartasQueVencem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): CartaAvaliada[] {

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -20,7 +20,6 @@ export interface DecisaoLinhaFria {
 }
 
 const CAMINHO_MEIO = ['jogada', 'joga no meio', 'linha fria'] as const;
-const CAMINHO_JA_CUMPRIU = [...CAMINHO_MEIO, 'já cumpriu'] as const;
 
 export class DecisorJogadaLinhaFria implements DecisorJogada {
   decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -45,7 +44,7 @@ export function decidirNaoUltimoLinhaFria(mao: Carta[], estado: EstadoEmJogo): D
 }
 
 function fugirNaoUltimo(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): DecisaoLinhaFria {
-  const caminho = [...CAMINHO_JA_CUMPRIU];
+  const caminho = criarCaminhoJogadaDebug('meio', 'fria', 'já cumpriu');
   const naoFazem = cartasQueNaoFazem(estado, avaliadas);
   if (naoFazem.length === 0) {
     return { carta: cartaMaisBarata(avaliadas).carta, motivo: 'já cumpriu; fuga impossível', caminho };
@@ -167,7 +166,7 @@ function decidirUltimoQuandoJaCumpriu(estado: EstadoEmJogo, avaliadas: CartaAval
   if (naoFazem.length > 0) {
     return {
       carta: cartaMaisForte(naoFazem, estado.manilha).carta,
-      motivo: 'já cumpriu; carta mais alta que não faz',
+      motivo: 'já cumpriu; carta mais forte que não faz',
       caminho,
     };
   }

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -39,12 +39,12 @@ const cenariosDeUltimo: {
     },
   },
   {
-    nome: 'deve fugir no último com a carta mais alta que não faz quando já cumpriu',
+    nome: 'deve fugir no último com a carta mais forte que não faz quando já cumpriu',
     mao: [criarCarta('Q', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' }),
     esperado: {
       carta: criarCarta('K', '♦'),
-      motivo: 'já cumpriu; carta mais alta que não faz',
+      motivo: 'já cumpriu; carta mais forte que não faz',
       caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
     },
   },
@@ -58,7 +58,7 @@ const cenariosDeUltimo: {
     }),
     esperado: {
       carta: criarCarta('K', '♦'),
-      motivo: 'já cumpriu; carta mais alta que não faz',
+      motivo: 'já cumpriu; carta mais forte que não faz',
       caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
     },
   },

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -3,31 +3,50 @@ import { DecisorJogadaLinhaFria, decidirUltimoLinhaFria } from '@/adapters/bots/
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
-import { cartasQueGarantemTresDeOuros, criarEstadoLinhaFria, mesaComK, mesaComQuatro } from './fixtures-linha-fria';
+import {
+  CAMINHO_FECHA_JA_CUMPRIU,
+  CAMINHO_FECHA_PRECISA,
+  cartasQueGarantemTresDeOuros,
+  criarEstadoLinhaFria,
+  mesaComK,
+  mesaComQuatro,
+} from './fixtures-linha-fria';
 
 const cenariosDeUltimo: {
   nome: string;
   mao: Carta[];
   estado: EstadoEmJogo;
-  esperado: { carta: Carta; motivo: string };
+  esperado: { carta: Carta; motivo: string; caminho: string[] };
 }[] = [
   {
     nome: 'deve escolher G[N-X] no último quando precisa fazer e tem ganhadoras',
     mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComQuatro(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '6' }),
-    esperado: { carta: criarCarta('8', '♦'), motivo: 'precisa fazer; regra G[N-X]' },
+    esperado: {
+      carta: criarCarta('8', '♦'),
+      motivo: 'precisa fazer; regra G[N-X]',
+      caminho: [...CAMINHO_FECHA_PRECISA],
+    },
   },
   {
     nome: 'deve escolher P[N-X] no último quando precisa fazer sem carta que vence',
     mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' }),
-    esperado: { carta: criarCarta('9', '♦'), motivo: 'precisa fazer sem carta que vence; regra P[N-X]' },
+    esperado: {
+      carta: criarCarta('9', '♦'),
+      motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
+      caminho: [...CAMINHO_FECHA_PRECISA],
+    },
   },
   {
     nome: 'deve fugir no último com a carta mais alta que não faz quando já cumpriu',
     mao: [criarCarta('Q', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' }),
-    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; carta mais alta que não faz' },
+    esperado: {
+      carta: criarCarta('K', '♦'),
+      motivo: 'já cumpriu; carta mais alta que não faz',
+      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+    },
   },
   {
     nome: 'deve tratar empate como carta que não faz no último quando já cumpriu',
@@ -37,13 +56,21 @@ const cenariosDeUltimo: {
       declaracoes: { bot: 1 },
       vazas: { bot: 1 },
     }),
-    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; carta mais alta que não faz' },
+    esperado: {
+      carta: criarCarta('K', '♦'),
+      motivo: 'já cumpriu; carta mais alta que não faz',
+      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+    },
   },
   {
     nome: 'deve jogar a carta mais alta no último quando fuga é impossível',
     mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' }),
-    esperado: { carta: criarCarta('K', '♦'), motivo: 'já cumpriu; fuga impossível' },
+    esperado: {
+      carta: criarCarta('K', '♦'),
+      motivo: 'já cumpriu; fuga impossível',
+      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+    },
   },
 ];
 

--- a/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
+++ b/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
@@ -5,6 +5,7 @@ import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
 import {
   CAMINHO_GUARDA_PERMITIU,
+  CAMINHO_JA_CUMPRIU,
   cartasQueGarantemTresDeOuros,
   criarEstadoLinhaFria,
   mesaComK,
@@ -53,16 +54,38 @@ const cenarios: {
     },
   },
   {
-    nome: 'deve fugir com carta mais alta que não faz',
+    nome: 'deve fugir com carta mais alta que não faz quando já cumpriu',
     mao: [criarCarta('Q', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '5' }),
-    esperado: { carta: criarCarta('K', '♦'), motivo: 'não quer fazer; carta mais alta que não faz' },
+    esperado: {
+      carta: criarCarta('K', '♦'),
+      motivo: 'já cumpriu; carta mais alta que não faz',
+      caminho: [...CAMINHO_JA_CUMPRIU],
+    },
   },
   {
-    nome: 'deve indicar fuga impossível quando todas fazem',
+    nome: 'deve tratar empate como carta que não faz quando já cumpriu no meio',
+    mao: [criarCarta('K', '♦'), criarCarta('A', '♦')],
+    estado: criarEstadoLinhaFria({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
+      declaracoes: { bot: 1 },
+      vazas: { bot: 1 },
+    }),
+    esperado: {
+      carta: criarCarta('K', '♦'),
+      motivo: 'já cumpriu; carta mais alta que não faz',
+      caminho: [...CAMINHO_JA_CUMPRIU],
+    },
+  },
+  {
+    nome: 'deve indicar fuga impossível com carta mais barata quando já cumpriu',
     mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComQuatro(), declaracoes: { bot: 1 }, vazas: { bot: 1 }, manilha: '6' }),
-    esperado: { carta: criarCarta('5', '♦'), motivo: 'não quer fazer; fuga impossível' },
+    esperado: {
+      carta: criarCarta('5', '♦'),
+      motivo: 'já cumpriu; fuga impossível',
+      caminho: [...CAMINHO_JA_CUMPRIU],
+    },
   },
   {
     nome: 'deve buscar vaza com G[N-X] quando precisa fazer e tem vencedoras',

--- a/tests/adapters/fixtures-linha-fria.ts
+++ b/tests/adapters/fixtures-linha-fria.ts
@@ -73,3 +73,9 @@ export function cartasQueGarantemTresDeOuros(): Carta[] {
 export const CAMINHO_GUARDA_BLOQUEOU = ['jogada', 'joga no meio', 'linha fria', 'guarda de posição bloqueou'] as const;
 
 export const CAMINHO_GUARDA_PERMITIU = ['jogada', 'joga no meio', 'linha fria', 'guarda de posição permitiu'] as const;
+
+export const CAMINHO_JA_CUMPRIU = ['jogada', 'joga no meio', 'linha fria', 'já cumpriu'] as const;
+
+export const CAMINHO_FECHA_PRECISA = ['jogada', 'fecha a mesa', 'linha fria', 'precisa fazer'] as const;
+
+export const CAMINHO_FECHA_JA_CUMPRIU = ['jogada', 'fecha a mesa', 'linha fria', 'já cumpriu'] as const;


### PR DESCRIPTION
## Summary

- **#211:** No meio com `necessidade <= 0`, motivo passa a `já cumpriu` e rastro `['jogada', 'joga no meio', 'linha fria', 'já cumpriu']` em `fugirNaoUltimo()` (lógica G/P inalterada: mais alta entre perdedoras/empates; mais barata se fuga impossível).
- **#212:** No fechamento, `caminho` explícito via `criarCaminhoJogadaDebug('fecha', 'fria', 'precisa fazer' | 'já cumpriu')` em todos os ramos de `decidirUltimoLinhaFria`.

## Validação vs critérios de aceite

| Issue | Critério | Cobertura |
|-------|----------|-----------|
| #211 | Perdedoras/empates como não fazem | `cartasQueNaoFazem` + teste perdedoras |
| #211 | Mais alta entre candidatas | `cartaMaisCara` + teste Q/K |
| #211 | Mais barata se fuga impossível | `cartaMaisBarata` + teste 5/8/K |
| #211 | Empate explícito | teste K empata K♣ |
| #211 | Motivo e rastro | `já cumpriu` + `CAMINHO_JA_CUMPRIU` |
| #212 | G[N-X] / P[N-X] quando precisa | testes fechamento precisa fazer |
| #212 | Mais forte entre não fazem / mão | `cartaMaisForte` + testes último |
| #212 | Empate | teste K empata |
| #212 | Motivo e rastro fechamento | `CAMINHO_FECHA_*` |

Closes #211
Closes #212

## Test plan

- [x] `pnpm test` (695 testes)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Preview Vercel: conferir debug de jogada nos ramos meio/fecha com declaração cumprida


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced debugging and tracing capabilities for bot decision-making logic in late-round card play scenarios.

* **Tests**
  * Expanded test coverage to validate bot decision paths and reasoning across multiple game situations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->