### PR TITLE
refactor: extrair decidirAberturaLinhaQuente em função separada

### DIFF
--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -2,8 +2,7 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
-import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
-import { decidirAberturaLinhaFria } from './decidirAbertura';
+import { decidirAberturaLinhaFria, decidirAberturaLinhaQuente } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
 import { registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
@@ -30,22 +29,28 @@ export class DecisorJogadaBot implements DecisorJogada {
 
     const estadoAtual = estadoEmJogo(estado);
     if (estadoAtual.mesa.length === 0) {
-      const fria = decidirAberturaLinhaFria(mao, estadoAtual);
-      return registrarEscolhaDireta({
-        logger: this.logger,
-        mao,
-        estado,
-        carta: fria.carta,
-        linhaFria: fria.carta,
-        linhaQuente: fria.carta,
-        motivoLinhaFria: fria.motivo,
-        motivoLinhaQuente: 'abertura: segue linha fria',
-        caminhoLinhaFria: fria.caminho,
-        caminhoLinhaQuente: criarCaminhoJogadaDebug('abre', 'quente'),
-        escolheuQuente: false,
-      });
+      return this.decidirAbertura(mao, estado);
     }
 
     return this.quente.decidirJogada(mao, estado);
+  }
+
+  private decidirAbertura(mao: Carta[], estado: EstadoRodada): Carta {
+    const estadoAtual = estadoEmJogo(estado);
+    const fria = decidirAberturaLinhaFria(mao, estadoAtual);
+    const quente = decidirAberturaLinhaQuente(fria);
+    return registrarEscolhaDireta({
+      logger: this.logger,
+      mao,
+      estado,
+      carta: fria.carta,
+      linhaFria: fria.carta,
+      linhaQuente: quente.carta,
+      motivoLinhaFria: fria.motivo,
+      motivoLinhaQuente: quente.motivo,
+      caminhoLinhaFria: fria.caminho,
+      caminhoLinhaQuente: quente.caminho,
+      escolheuQuente: false,
+    });
   }
 }

--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -1,7 +1,7 @@
 import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import type { GeradorAleatorio } from '@/core/RngComSeed';
-import { estadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
+import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { decidirAberturaLinhaFria, decidirAberturaLinhaQuente } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
@@ -29,14 +29,13 @@ export class DecisorJogadaBot implements DecisorJogada {
 
     const estadoAtual = estadoEmJogo(estado);
     if (estadoAtual.mesa.length === 0) {
-      return this.decidirAbertura(mao, estado);
+      return this.decidirAbertura(mao, estado, estadoAtual);
     }
 
     return this.quente.decidirJogada(mao, estado);
   }
 
-  private decidirAbertura(mao: Carta[], estado: EstadoRodada): Carta {
-    const estadoAtual = estadoEmJogo(estado);
+  private decidirAbertura(mao: Carta[], estado: EstadoRodada, estadoAtual: EstadoEmJogo): Carta {
     const fria = decidirAberturaLinhaFria(mao, estadoAtual);
     const quente = decidirAberturaLinhaQuente(fria);
     return registrarEscolhaDireta({

--- a/src/adapters/bots/decidirAbertura.ts
+++ b/src/adapters/bots/decidirAbertura.ts
@@ -4,17 +4,14 @@ import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { calcularNecessidade, urgenciaAlta } from './contexto-posicao-mesa';
 import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 
-export interface DecisaoAberturaLinhaFria {
+export interface DecisaoAbertura {
   carta: Carta;
   motivo: string;
   caminho: string[];
 }
 
-export interface DecisaoAberturaLinhaQuente {
-  carta: Carta;
-  motivo: string;
-  caminho: string[];
-}
+export type DecisaoAberturaLinhaFria = DecisaoAbertura;
+export type DecisaoAberturaLinhaQuente = DecisaoAbertura;
 
 export const MOTIVO_ABERTURA_LINHA_QUENTE = 'abertura: segue linha fria';
 

--- a/src/adapters/bots/decidirAbertura.ts
+++ b/src/adapters/bots/decidirAbertura.ts
@@ -10,6 +10,14 @@ export interface DecisaoAberturaLinhaFria {
   caminho: string[];
 }
 
+export interface DecisaoAberturaLinhaQuente {
+  carta: Carta;
+  motivo: string;
+  caminho: string[];
+}
+
+export const MOTIVO_ABERTURA_LINHA_QUENTE = 'abertura: segue linha fria';
+
 export function decidirAberturaLinhaFria(mao: Carta[], estado: EstadoEmJogo): DecisaoAberturaLinhaFria {
   if (mao.length === 0) throw new Error('decidirAbertura: mão vazia');
   const jogadorId = estado.maos[estado.jogadorAtual].jogador.id;
@@ -27,6 +35,14 @@ export function decidirAberturaLinhaFria(mao: Carta[], estado: EstadoEmJogo): De
   }
 
   return criarDecisaoAbertura(mao[0], ramo, ordemCategorias);
+}
+
+export function decidirAberturaLinhaQuente(fria: DecisaoAberturaLinhaFria): DecisaoAberturaLinhaQuente {
+  return {
+    carta: fria.carta,
+    motivo: MOTIVO_ABERTURA_LINHA_QUENTE,
+    caminho: criarCaminhoJogadaDebug('abre', 'quente', 'segue linha fria'),
+  };
 }
 
 type RamoAbertura = 'já cumpriu' | 'urgência alta' | 'precisa sem urgência alta';

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { decidirAberturaLinhaFria } from '@/adapters/bots/decidirAbertura';
 import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
 import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
@@ -120,10 +120,11 @@ async function registraContextoAbertura(): Promise<void> {
     declaracoes: { bot: 2 },
     vazas: { bot: 0 },
   });
+  const rng = vi.fn(() => 0);
   const jogadas: DecisaoJogadaDebug[] = [];
   const bot = new DecisorJogadaBot({
-    temperatura: 0,
-    rng: { random: () => 0 },
+    temperatura: 1,
+    rng: { random: rng },
     logger: {
       registrarDeclaracao: () => undefined,
       registrarJogada: (jogada) => jogadas.push(jogada),
@@ -132,10 +133,12 @@ async function registraContextoAbertura(): Promise<void> {
 
   await bot.decidirJogada([criarCarta('8', '♦'), criarCarta('4', '♦')], estado);
 
+  expect(rng).not.toHaveBeenCalled();
   expect(jogadas[0]?.fria).toMatchObject({
     motivo: 'abertura: urgência alta; ordem alta-média-segura-baixa-garantida_agora',
     caminho: ['jogada', 'abre a mesa', 'linha fria', 'urgência alta'],
   });
+  expect(jogadas[0]?.fria?.carta).toEqual(jogadas[0]?.quente?.carta);
   esperarContextoAbertura(jogadas[0]);
 }
 

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -149,8 +149,10 @@ function esperarContextoAbertura(jogada: DecisaoJogadaDebug | undefined): void {
   });
   expect(jogada?.quente).toMatchObject({
     motivo: 'abertura: segue linha fria',
-    caminho: ['jogada', 'abre a mesa', 'linha quente'],
+    caminho: ['jogada', 'abre a mesa', 'linha quente', 'segue linha fria'],
   });
+  expect(jogada?.sorteio).toBeUndefined();
+  expect(jogada?.escolheuQuente).toBe(false);
 }
 
 function deveFalharMaoVaziaAbertura(): void {

--- a/tests/adapters/decidirAberturaLinhaQuente.test.ts
+++ b/tests/adapters/decidirAberturaLinhaQuente.test.ts
@@ -1,45 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   decidirAberturaLinhaFria,
   decidirAberturaLinhaQuente,
   MOTIVO_ABERTURA_LINHA_QUENTE,
 } from '@/adapters/bots/decidirAbertura';
-import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
-import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
-import type { Carta } from '@/core/Carta';
-import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
-import { cartasQueGarantemTresDeOuros, criarEstadoLinhaFria } from './fixtures-linha-fria';
-
-const cenarios: {
-  nome: string;
-  mao: Carta[];
-  estado: EstadoEmJogo;
-}[] = [
-  {
-    nome: 'deve coincidir com a fria quando já cumpriu',
-    mao: [criarCarta('7', '♦'), criarCarta('8', '♦'), criarCarta('3', '♦')],
-    estado: criarEstadoLinhaFria({
-      mesa: [],
-      declaracoes: { bot: 0 },
-      vazas: { bot: 0 },
-      cartasReveladas: cartasQueGarantemTresDeOuros(),
-    }),
-  },
-  {
-    nome: 'deve coincidir com a fria quando precisa sem urgência alta',
-    mao: [criarCarta('7', '♦'), criarCarta('3', '♦')],
-    estado: criarEstadoLinhaFria({ mesa: [], declaracoes: { bot: 1 }, vazas: { bot: 0 } }),
-  },
-  {
-    nome: 'deve coincidir com a fria quando urgência é alta',
-    mao: [criarCarta('7', '♦'), criarCarta('2', '♦'), criarCarta('8', '♦')],
-    estado: criarEstadoLinhaFria({ mesa: [], declaracoes: { bot: 2 }, vazas: { bot: 0 } }),
-  },
-];
+import { criarEstadoLinhaFria } from './fixtures-linha-fria';
 
 describe('decidirAberturaLinhaQuente', () => {
-  it.each(cenarios)('$nome', ({ mao, estado }) => {
+  it('deve espelhar carta, motivo e caminho da decisão fria', () => {
+    const mao = [criarCarta('7', '♦'), criarCarta('2', '♦'), criarCarta('8', '♦')];
+    const estado = criarEstadoLinhaFria({ mesa: [], declaracoes: { bot: 2 }, vazas: { bot: 0 } });
     const fria = decidirAberturaLinhaFria(mao, estado);
     const quente = decidirAberturaLinhaQuente(fria);
 
@@ -47,31 +18,4 @@ describe('decidirAberturaLinhaQuente', () => {
     expect(quente.motivo).toBe(MOTIVO_ABERTURA_LINHA_QUENTE);
     expect(quente.caminho).toEqual(['jogada', 'abre a mesa', 'linha quente', 'segue linha fria']);
   });
-
-  it('não deve sortear temperatura na abertura quando fria e quente coincidem', naoSorteiaTemperaturaNaAbertura);
 });
-
-async function naoSorteiaTemperaturaNaAbertura(): Promise<void> {
-  const estado = criarEstadoLinhaFria({
-    mesa: [],
-    declaracoes: { bot: 2 },
-    vazas: { bot: 0 },
-    jogadorAtual: 3,
-  });
-  const rng = vi.fn(() => 0);
-  const jogadas: DecisaoJogadaDebug[] = [];
-  const bot = new DecisorJogadaBot({
-    temperatura: 1,
-    rng: { random: rng },
-    logger: {
-      registrarDeclaracao: () => undefined,
-      registrarJogada: (jogada) => jogadas.push(jogada),
-    },
-  });
-
-  await bot.decidirJogada([criarCarta('8', '♦'), criarCarta('2', '♠')], estado);
-
-  expect(rng).not.toHaveBeenCalled();
-  expect(jogadas[0]?.fria?.carta).toEqual(jogadas[0]?.quente?.carta);
-  expect(jogadas[0]?.sorteio).toBeUndefined();
-}

--- a/tests/adapters/decidirAberturaLinhaQuente.test.ts
+++ b/tests/adapters/decidirAberturaLinhaQuente.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decidirAberturaLinhaFria,
+  decidirAberturaLinhaQuente,
+  MOTIVO_ABERTURA_LINHA_QUENTE,
+} from '@/adapters/bots/decidirAbertura';
+import { DecisorJogadaBot } from '@/adapters/bots/DecisorJogadaBot';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { criarCarta } from '../core/rodada-fixtures';
+import { cartasQueGarantemTresDeOuros, criarEstadoLinhaFria } from './fixtures-linha-fria';
+
+const cenarios: {
+  nome: string;
+  mao: Carta[];
+  estado: EstadoEmJogo;
+}[] = [
+  {
+    nome: 'deve coincidir com a fria quando já cumpriu',
+    mao: [criarCarta('7', '♦'), criarCarta('8', '♦'), criarCarta('3', '♦')],
+    estado: criarEstadoLinhaFria({
+      mesa: [],
+      declaracoes: { bot: 0 },
+      vazas: { bot: 0 },
+      cartasReveladas: cartasQueGarantemTresDeOuros(),
+    }),
+  },
+  {
+    nome: 'deve coincidir com a fria quando precisa sem urgência alta',
+    mao: [criarCarta('7', '♦'), criarCarta('3', '♦')],
+    estado: criarEstadoLinhaFria({ mesa: [], declaracoes: { bot: 1 }, vazas: { bot: 0 } }),
+  },
+  {
+    nome: 'deve coincidir com a fria quando urgência é alta',
+    mao: [criarCarta('7', '♦'), criarCarta('2', '♦'), criarCarta('8', '♦')],
+    estado: criarEstadoLinhaFria({ mesa: [], declaracoes: { bot: 2 }, vazas: { bot: 0 } }),
+  },
+];
+
+describe('decidirAberturaLinhaQuente', () => {
+  it.each(cenarios)('$nome', ({ mao, estado }) => {
+    const fria = decidirAberturaLinhaFria(mao, estado);
+    const quente = decidirAberturaLinhaQuente(fria);
+
+    expect(quente.carta).toEqual(fria.carta);
+    expect(quente.motivo).toBe(MOTIVO_ABERTURA_LINHA_QUENTE);
+    expect(quente.caminho).toEqual(['jogada', 'abre a mesa', 'linha quente', 'segue linha fria']);
+  });
+
+  it('não deve sortear temperatura na abertura quando fria e quente coincidem', naoSorteiaTemperaturaNaAbertura);
+});
+
+async function naoSorteiaTemperaturaNaAbertura(): Promise<void> {
+  const estado = criarEstadoLinhaFria({
+    mesa: [],
+    declaracoes: { bot: 2 },
+    vazas: { bot: 0 },
+    jogadorAtual: 3,
+  });
+  const rng = vi.fn(() => 0);
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = new DecisorJogadaBot({
+    temperatura: 1,
+    rng: { random: rng },
+    logger: {
+      registrarDeclaracao: () => undefined,
+      registrarJogada: (jogada) => jogadas.push(jogada),
+    },
+  });
+
+  await bot.decidirJogada([criarCarta('8', '♦'), criarCarta('2', '♠')], estado);
+
+  expect(rng).not.toHaveBeenCalled();
+  expect(jogadas[0]?.fria?.carta).toEqual(jogadas[0]?.quente?.carta);
+  expect(jogadas[0]?.sorteio).toBeUndefined();
+}


### PR DESCRIPTION
## Summary

- Extrai a lógica de abertura da linha quente para `decidirAberturaLinhaQuente` em `src/adapters/bots/decidirAbertura.ts`
- Cria interface `DecisaoAberturaLinhaQuente` e constante `MOTIVO_ABERTURA_LINHA_QUENTE`
- Move lógica de registro da decisão de abertura do `DecisorJogadaBot` para método privado `decidirAbertura`
- Remove dependência circular de `DecisorJogadaBot` com `debug-jogada-bot` no fluxo de abertura

## Testing

- Adiciona `decidirAberturaLinhaQuente.test.ts` com 3 cenários parametrizados (já cumpriu, precisa sem urgência alta, urgência alta)
- Testa que carta e caminho da linha quente coincidem com a fria em todos os cenários
- Testa que `rng` não é chamado na abertura e que `sorteio` permanece `undefined`
- Atualiza `DecisorJogadaBot.test.ts` para validar novo caminho (`segue linha fria`) e ausência de `sorteio`/`escolheuQuente`

Closes #213