### PR TITLE
refactor: simplify Quente mid-hand tie logic via ehAltaOuMelhor and remove liderAlta parameter

### DIFF
--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -162,11 +162,11 @@ A Linha quente parte da mesma leitura de necessidade e posicao, mas pode recomen
 ```text
 se necessidade <= 0:
   se lider interessado e lider e alta+ e existe empate:
-    recomendar o empate mais caro
+    recomendar o empate mais forte
   senao se existe perdedora:
     recomendar a perdedora mais forte
   senao se existe empate:
-    recomendar o empate mais caro
+    recomendar o empate mais forte
   senao:
     seguir Linha fria
 

--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -161,7 +161,11 @@ A Linha quente parte da mesma leitura de necessidade e posicao, mas pode recomen
 
 ```text
 se necessidade <= 0:
-  se lider e alta+ e existe empate:
+  se lider interessado e lider e alta+ e existe empate:
+    recomendar o empate mais caro
+  senao se existe perdedora:
+    recomendar a perdedora mais forte
+  senao se existe empate:
     recomendar o empate mais caro
   senao:
     seguir Linha fria
@@ -185,6 +189,12 @@ senao se pode esperar oportunidade:
 senao:
   seguir Linha fria
 ```
+
+Quando `necessidade <= 0`, a Linha quente no meio espelha a prioridade da Linha quente fechando.
+Empate agressivo contra lider interessado so vale com carta lider `alta+`, porque empate nao toma a vaza mas impede o lider de cumprir.
+Com lider `media` ou `baixa`, a Linha quente **nao** empata para punir: prefere perdedora mais forte e deixa o lider seguir na vaza.
+A Linha fria, no mesmo caso, joga a carta mais alta entre perdedoras e empates; quando ha empate na mao, fria e quente costumam divergir aqui.
+`seguir Linha fria` no fim do ramo so ocorre quando nao ha perdedora nem empate (fuga impossivel sem vencer).
 
 `pode atravessar` significa:
 

--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -11,7 +11,6 @@ interface ConfigDecisorJogadaBot {
   temperatura: number;
   rng: Pick<GeradorAleatorio, 'random'>;
   liderBaixa?: number;
-  liderAlta?: number;
   logger?: LoggerDebugBot;
 }
 

--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -6,11 +6,7 @@ import { estadoEmJogo, type EstadoEmJogo, type MesaItem, type EstadoRodada } fro
 import { calcularNecessidade, ehUltimoDaMesa } from './contexto-posicao-mesa';
 import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 import { decidirAberturaLinhaFria } from './decidirAbertura';
-import {
-  descartePorNecessidade,
-  escolherVencedoraPorNecessidade,
-  ordenarPorForcaReal,
-} from './escolhas-por-necessidade';
+import { cartaMaisForte, descartePorNecessidade, escolherVencedoraPorNecessidade } from './escolhas-por-necessidade';
 import { avaliarGuardaDePosicao, type GuardaPosicao } from './guarda-posicao';
 
 export interface DecisaoLinhaFria {
@@ -189,11 +185,6 @@ function cartasQueNaoFazem(estado: EstadoEmJogo, avaliadas: CartaAvaliada[]): Ca
 function melhorCartaMesa(mesa: MesaItem[], manilha: Carta['valor']): Carta | null {
   if (mesa.length === 0) return null;
   return mesa[calcularIndiceVencedor(mesa, manilha)].carta;
-}
-
-function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  return ordenadas[ordenadas.length - 1];
 }
 
 function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -106,29 +106,18 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   private escolherQuenteDireta(base: BaseJogada): Carta | null {
     if (base.contexto.necessidade <= 0) {
       const jaCumpriu = escolherJaCumpriuNoMeio(base.estadoAtual, base.contexto);
-      if (jaCumpriu) return this.registrarQuente(base, jaCumpriu.carta, jaCumpriu.motivo);
+      if (jaCumpriu) return this.resolverQuenteRecomendada(base, jaCumpriu.carta, jaCumpriu.motivo);
       return this.registrarSeguirFria(base);
     }
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
     if (!travessia) return null;
-    return this.registrarQuente(base, travessia.carta, `linha quente atravessou: ${travessia.motivo}`);
+    return this.resolverQuenteRecomendada(base, travessia.carta, `linha quente atravessou: ${travessia.motivo}`);
   }
 
-  private registrarQuente(base: BaseJogada, carta: Carta, motivoLinhaQuente: string): Carta {
-    return registrarEscolhaDireta({
-      logger: this.logger,
-      mao: base.mao,
-      estado: base.estado,
-      carta,
-      linhaFria: base.fria,
-      linhaQuente: carta,
-      motivoLinhaFria: base.motivoLinhaFria,
-      motivoLinhaQuente,
-      caminhoLinhaFria: base.caminhoLinhaFria,
-      caminhoLinhaQuente: criarCaminhoJogadaDebug(base.posicao, 'quente', 'escolha direta'),
-      escolheuQuente: true,
-    });
+  private resolverQuenteRecomendada(base: BaseJogada, carta: Carta, motivo: string): Carta {
+    const quente = criarDecisaoQuente({ carta, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente'));
+    return this.resolverBifurcacao(base, quente);
   }
 
   private registrarSeguirFria(base: BaseJogada): Carta {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -11,7 +11,7 @@ import type { LoggerDebugBot } from './logger-debug-bot';
 import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
 import {
   cartasIguais,
-  escolherEmpate,
+  escolherJaCumpriuNoMeio,
   escolherPressao,
   escolherTravessia,
   formatarMotivoRecusaBifurcacao,
@@ -22,7 +22,6 @@ interface ConfigLinhaQuente {
   temperatura: number;
   rng: Pick<GeradorAleatorio, 'random'>;
   liderBaixa?: number;
-  liderAlta?: number;
   logger?: LoggerDebugBot;
 }
 
@@ -30,14 +29,12 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   private readonly temperatura: number;
   private readonly rng: Pick<GeradorAleatorio, 'random'>;
   private readonly liderBaixa: number;
-  private readonly liderAlta: number;
   private readonly logger?: LoggerDebugBot;
 
   constructor(config: ConfigLinhaQuente) {
     this.temperatura = config.temperatura;
     this.rng = config.rng;
     this.liderBaixa = config.liderBaixa ?? 8;
-    this.liderAlta = config.liderAlta ?? 11;
     this.logger = config.logger;
   }
 
@@ -107,8 +104,11 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private escolherQuenteDireta(base: BaseJogada): Carta | null {
-    const empate = escolherEmpate(base.contexto, this.liderAlta);
-    if (empate) return this.registrarQuente(base, empate.carta, `linha quente empatou: ${empate.motivo}`);
+    if (base.contexto.necessidade <= 0) {
+      const jaCumpriu = escolherJaCumpriuNoMeio(base.estadoAtual, base.contexto);
+      if (jaCumpriu) return this.registrarQuente(base, jaCumpriu.carta, jaCumpriu.motivo);
+      return this.registrarSeguirFria(base);
+    }
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
     if (!travessia) return null;
@@ -129,6 +129,16 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       caminhoLinhaQuente: criarCaminhoJogadaDebug(base.posicao, 'quente', 'escolha direta'),
       escolheuQuente: true,
     });
+  }
+
+  private registrarSeguirFria(base: BaseJogada): Carta {
+    return this.registrarSemBifurcacao(
+      base,
+      criarDecisaoQuente(
+        { carta: base.fria, motivo: 'linha quente segue fria: sem carta que não faz' },
+        criarCaminhoJogadaDebug(base.posicao, 'quente', 'segue fria'),
+      ),
+    );
   }
 
   private registrarSemBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {

--- a/src/adapters/bots/contexto-posicao-mesa.ts
+++ b/src/adapters/bots/contexto-posicao-mesa.ts
@@ -1,3 +1,4 @@
+import { calcularIndiceVencedor } from '@/core/comparador-carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 
 export const LIMIAR_URGENCIA_ALTA = 0.66;
@@ -27,4 +28,10 @@ export function urgenciaAlta(necessidade: number, tamanhoMao: number): boolean {
 
 export function ehUltimoDaMesa(estado: EstadoEmJogo): boolean {
   return estado.mesa.length === estado.maos.length - 1;
+}
+
+export function liderQuerVaza(estado: EstadoEmJogo): boolean {
+  if (estado.mesa.length === 0) return false;
+  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
+  return calcularNecessidade(estado, lider.jogadorId) > 0;
 }

--- a/src/adapters/bots/contextoLinhaQuente.ts
+++ b/src/adapters/bots/contextoLinhaQuente.ts
@@ -5,7 +5,7 @@ import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade } from './contexto-posicao-mesa';
 import { cartaPerde } from './decidirUltimoLinhaQuente';
 
-export { calcularNecessidade, ehUltimoDaMesa } from './contexto-posicao-mesa';
+export { calcularNecessidade, ehUltimoDaMesa, liderQuerVaza } from './contexto-posicao-mesa';
 
 export interface ContextoJogadaQuente {
   jogadorId: string;
@@ -33,12 +33,6 @@ export function criarContextoLinhaQuente(estado: EstadoEmJogo, mao: Carta[]): Co
     empates: lider ? avaliadas.filter((a) => cartasEmpatam(a.carta, lider.carta, estado.manilha)) : [],
     lider,
   };
-}
-
-export function liderQuerVaza(estado: EstadoEmJogo): boolean {
-  if (estado.mesa.length === 0) return false;
-  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
-  return calcularNecessidade(estado, lider.jogadorId) > 0;
 }
 
 function avaliarLider(estado: EstadoEmJogo): CartaAvaliada | null {

--- a/src/adapters/bots/decidirUltimoLinhaQuente.ts
+++ b/src/adapters/bots/decidirUltimoLinhaQuente.ts
@@ -126,7 +126,7 @@ function liderQuerVaza(estado: EstadoEmJogo): boolean {
   return necessidade > 0;
 }
 
-function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
+export function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
   return ['alta', 'segura', 'garantida_agora'].includes(avaliada.categoria);
 }
 

--- a/src/adapters/bots/decidirUltimoLinhaQuente.ts
+++ b/src/adapters/bots/decidirUltimoLinhaQuente.ts
@@ -1,12 +1,11 @@
 import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { calcularIndiceVencedor, cartasEmpatam, cartaVence } from '@/core/comparador-carta';
+import { cartasEmpatam, cartaVence } from '@/core/comparador-carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
-import {
-  descartePorNecessidade,
-  escolherVencedoraPorNecessidade,
-  ordenarPorForcaReal,
-} from './escolhas-por-necessidade';
+import { liderQuerVaza } from './contexto-posicao-mesa';
+import { cartaMaisForte, descartePorNecessidade, escolherVencedoraPorNecessidade } from './escolhas-por-necessidade';
+import { MOTIVOS_FUGA_FECHA, escolherFugaJaCumpriu } from './escolher-fuga-ja-cumpriu';
+import { ehAltaOuMelhor } from './predicados-carta-avaliada';
 
 export interface ContextoUltimoLinhaQuente {
   necessidade: number;
@@ -63,50 +62,16 @@ function decidirQuandoPrecisaFazer(
 }
 
 function decidirQuandoJaCumpriu(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuente): DecisaoUltimoLinhaQuente {
-  if (liderQuerVaza(estado)) return fugirContraLiderQuePrecisa(estado, contexto);
-  if (contexto.perdedoras.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.perdedoras, estado.manilha).carta,
-      motivo: 'já cumpriu; carta mais alta que não faz',
-    };
-  }
-  if (contexto.empates.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.empates, estado.manilha).carta,
-      motivo: 'já cumpriu; carta mais alta que não faz',
-    };
-  }
-  return {
-    carta: cartaMaisForte(contexto.avaliadas, estado.manilha).carta,
-    motivo: 'já cumpriu; fuga impossível',
+  const opcoes = {
+    liderInteressado: liderQuerVaza(estado),
+    fallbackSemFuga: 'mais-forte-mao' as const,
+    motivos: MOTIVOS_FUGA_FECHA,
   };
-}
-
-function fugirContraLiderQuePrecisa(
-  estado: EstadoEmJogo,
-  contexto: ContextoUltimoLinhaQuente,
-): DecisaoUltimoLinhaQuente {
-  if (contexto.lider && ehAltaOuMelhor(contexto.lider) && contexto.empates.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.empates, estado.manilha).carta,
-      motivo: 'já cumpriu; fuga contra líder alta+',
-    };
-  }
-  if (contexto.perdedoras.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.perdedoras, estado.manilha).carta,
-      motivo: 'já cumpriu; carta mais alta que não faz',
-    };
-  }
-  if (contexto.empates.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.empates, estado.manilha).carta,
-      motivo: 'já cumpriu; carta mais alta que não faz',
-    };
-  }
+  const decisao = escolherFugaJaCumpriu(estado, contexto, opcoes);
+  if (decisao) return decisao;
   return {
     carta: cartaMaisForte(contexto.avaliadas, estado.manilha).carta,
-    motivo: 'já cumpriu; fuga impossível',
+    motivo: MOTIVOS_FUGA_FECHA.fugaImpossivel,
   };
 }
 
@@ -118,19 +83,4 @@ function deveFazerAgora(estado: EstadoEmJogo, contexto: ContextoUltimoLinhaQuent
 
 function cartasQueNaoVencem(contexto: ContextoUltimoLinhaQuente): CartaAvaliada[] {
   return [...contexto.perdedoras, ...contexto.empates];
-}
-
-function liderQuerVaza(estado: EstadoEmJogo): boolean {
-  const lider = estado.mesa[calcularIndiceVencedor(estado.mesa, estado.manilha)];
-  const necessidade = (estado.declaracoes[lider.jogadorId] ?? 0) - (estado.vazas[lider.jogadorId] ?? 0);
-  return necessidade > 0;
-}
-
-export function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
-  return ['alta', 'segura', 'garantida_agora'].includes(avaliada.categoria);
-}
-
-function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  return ordenadas[ordenadas.length - 1];
 }

--- a/src/adapters/bots/escolhas-por-necessidade.ts
+++ b/src/adapters/bots/escolhas-por-necessidade.ts
@@ -25,3 +25,8 @@ export function descartePorNecessidade(
 export function ordenarPorForcaReal(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada[] {
   return [...avaliadas].sort((a, b) => compararForcaReal(a.carta, b.carta, manilha));
 }
+
+export function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  return ordenadas[ordenadas.length - 1];
+}

--- a/src/adapters/bots/escolher-fuga-ja-cumpriu.ts
+++ b/src/adapters/bots/escolher-fuga-ja-cumpriu.ts
@@ -1,0 +1,71 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { cartaMaisForte } from './escolhas-por-necessidade';
+import { ehAltaOuMelhor } from './predicados-carta-avaliada';
+
+export interface ContextoFugaJaCumpriu {
+  perdedoras: CartaAvaliada[];
+  empates: CartaAvaliada[];
+  lider: CartaAvaliada | null;
+  avaliadas: CartaAvaliada[];
+}
+
+export interface DecisaoFugaJaCumpriu {
+  carta: Carta;
+  motivo: string;
+}
+
+export interface MotivosFugaJaCumpriu {
+  empateContraLiderAlta: string;
+  perdedoraMaisForte: string;
+  empateMaisForte: string;
+  fugaImpossivel: string;
+}
+
+export const MOTIVOS_FUGA_MEIO: MotivosFugaJaCumpriu = {
+  empateContraLiderAlta: 'já cumpriu; empate contra líder alta+',
+  perdedoraMaisForte: 'já cumpriu; perdedora mais forte',
+  empateMaisForte: 'já cumpriu; empate mais forte',
+  fugaImpossivel: 'já cumpriu; fuga impossível',
+};
+
+export const MOTIVOS_FUGA_FECHA: MotivosFugaJaCumpriu = {
+  empateContraLiderAlta: 'já cumpriu; fuga contra líder alta+',
+  perdedoraMaisForte: 'já cumpriu; carta mais alta que não faz',
+  empateMaisForte: 'já cumpriu; carta mais alta que não faz',
+  fugaImpossivel: 'já cumpriu; fuga impossível',
+};
+
+interface OpcoesEscolherFugaJaCumpriu {
+  liderInteressado: boolean;
+  fallbackSemFuga: 'null' | 'mais-forte-mao';
+  motivos: MotivosFugaJaCumpriu;
+}
+
+export function escolherFugaJaCumpriu(
+  estado: EstadoEmJogo,
+  contexto: ContextoFugaJaCumpriu,
+  opcoes: OpcoesEscolherFugaJaCumpriu,
+): DecisaoFugaJaCumpriu | null {
+  const { motivos, liderInteressado, fallbackSemFuga } = opcoes;
+  const manilha = estado.manilha;
+
+  if (liderInteressado && contexto.lider && ehAltaOuMelhor(contexto.lider) && contexto.empates.length > 0) {
+    return criarDecisao(cartaMaisForte(contexto.empates, manilha), motivos.empateContraLiderAlta);
+  }
+  if (contexto.perdedoras.length > 0) {
+    return criarDecisao(cartaMaisForte(contexto.perdedoras, manilha), motivos.perdedoraMaisForte);
+  }
+  if (contexto.empates.length > 0) {
+    return criarDecisao(cartaMaisForte(contexto.empates, manilha), motivos.empateMaisForte);
+  }
+  if (fallbackSemFuga === 'mais-forte-mao') {
+    return criarDecisao(cartaMaisForte(contexto.avaliadas, manilha), motivos.fugaImpossivel);
+  }
+  return null;
+}
+
+function criarDecisao(avaliada: CartaAvaliada, motivo: string): DecisaoFugaJaCumpriu {
+  return { carta: avaliada.carta, motivo };
+}

--- a/src/adapters/bots/predicados-carta-avaliada.ts
+++ b/src/adapters/bots/predicados-carta-avaliada.ts
@@ -1,0 +1,5 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+
+export function ehAltaOuMelhor(avaliada: CartaAvaliada): boolean {
+  return ['alta', 'segura', 'garantida_agora'].includes(avaliada.categoria);
+}

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -2,8 +2,7 @@ import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade, liderQuerVaza, type ContextoJogadaQuente } from './contextoLinhaQuente';
-import { ehAltaOuMelhor } from './decidirUltimoLinhaQuente';
-import { ordenarPorForcaReal } from './escolhas-por-necessidade';
+import { MOTIVOS_FUGA_MEIO, escolherFugaJaCumpriu } from './escolher-fuga-ja-cumpriu';
 
 export interface ResultadoPodeBifurcar {
   pode: boolean;
@@ -65,22 +64,11 @@ export function escolherJaCumpriuNoMeio(
   contexto: ContextoJogadaQuente,
 ): DecisaoCartaQuente | null {
   if (contexto.necessidade > 0) return null;
-  if (liderQuerVaza(estado) && contexto.lider && ehAltaOuMelhor(contexto.lider) && contexto.empates.length > 0) {
-    return {
-      carta: cartaMaisCara(contexto.empates).carta,
-      motivo: 'já cumpriu; empate contra líder alta+',
-    };
-  }
-  if (contexto.perdedoras.length > 0) {
-    return {
-      carta: cartaMaisForte(contexto.perdedoras, estado.manilha).carta,
-      motivo: 'já cumpriu; perdedora mais forte',
-    };
-  }
-  if (contexto.empates.length > 0) {
-    return { carta: cartaMaisCara(contexto.empates).carta, motivo: 'já cumpriu; empate mais caro' };
-  }
-  return null;
+  return escolherFugaJaCumpriu(estado, contexto, {
+    liderInteressado: liderQuerVaza(estado),
+    fallbackSemFuga: 'null',
+    motivos: MOTIVOS_FUGA_MEIO,
+  });
 }
 
 function mesaPodePunir(estado: EstadoEmJogo, contexto: ContextoJogadaQuente, liderBaixa: number): boolean {
@@ -132,9 +120,4 @@ function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
 
 function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
   return [...avaliadas].sort((a, b) => b.score - a.score)[0];
-}
-
-function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
-  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  return ordenadas[ordenadas.length - 1];
 }

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -2,6 +2,8 @@ import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade, liderQuerVaza, type ContextoJogadaQuente } from './contextoLinhaQuente';
+import { ehAltaOuMelhor } from './decidirUltimoLinhaQuente';
+import { ordenarPorForcaReal } from './escolhas-por-necessidade';
 
 export interface ResultadoPodeBifurcar {
   pode: boolean;
@@ -58,11 +60,25 @@ export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogada
   return { carta: cartaMaisBarata(candidatas).carta, motivo: 'travessia: líder alta+ e urgência baixa' };
 }
 
-export function escolherEmpate(contexto: ContextoJogadaQuente, liderAlta: number): DecisaoCartaQuente | null {
-  const lider = contexto.lider;
-  if (!lider || lider.score <= liderAlta || contexto.empates.length === 0) return null;
-  if (contexto.necessidade <= 0 || contexto.folga >= 2) {
-    return { carta: cartaMaisCara(contexto.empates).carta, motivo: 'empate com líder alta+' };
+export function escolherJaCumpriuNoMeio(
+  estado: EstadoEmJogo,
+  contexto: ContextoJogadaQuente,
+): DecisaoCartaQuente | null {
+  if (contexto.necessidade > 0) return null;
+  if (liderQuerVaza(estado) && contexto.lider && ehAltaOuMelhor(contexto.lider) && contexto.empates.length > 0) {
+    return {
+      carta: cartaMaisCara(contexto.empates).carta,
+      motivo: 'já cumpriu; empate contra líder alta+',
+    };
+  }
+  if (contexto.perdedoras.length > 0) {
+    return {
+      carta: cartaMaisForte(contexto.perdedoras, estado.manilha).carta,
+      motivo: 'já cumpriu; perdedora mais forte',
+    };
+  }
+  if (contexto.empates.length > 0) {
+    return { carta: cartaMaisCara(contexto.empates).carta, motivo: 'já cumpriu; empate mais caro' };
   }
   return null;
 }
@@ -116,4 +132,9 @@ function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
 
 function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
   return [...avaliadas].sort((a, b) => b.score - a.score)[0];
+}
+
+function cartaMaisForte(avaliadas: CartaAvaliada[], manilha: Carta['valor']): CartaAvaliada {
+  const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
+  return ordenadas[ordenadas.length - 1];
 }

--- a/tests/adapters/DecisorJogadaBot.test.ts
+++ b/tests/adapters/DecisorJogadaBot.test.ts
@@ -169,7 +169,7 @@ function deveFalharMaoVaziaAbertura(): void {
 }
 
 function criarBot(temperatura: number, valorRng: number): DecisorJogadaBot {
-  return new DecisorJogadaBot({ temperatura, rng: { random: () => valorRng }, liderBaixa: 8, liderAlta: 11 });
+  return new DecisorJogadaBot({ temperatura, rng: { random: () => valorRng }, liderBaixa: 8 });
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -20,6 +20,7 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve registrar contexto e caminhos auditáveis da decisão', registraContratoExplicavel);
   it('deve empatar quando já cumpriu, líder precisa e carta líder é alta', empataAltaCumprido);
   it('deve preferir perdedora no meio quando líder é média e já cumpriu', perdedoraComLiderMedia);
+  it('deve respeitar temperatura zero quando já cumpriu diverge da linha fria', respeitaTemperaturaZeroJaCumpriu);
   it('deve registrar seguir fria quando já cumpriu sem carta que não faz', registraSeguirFriaSemFuga);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
@@ -135,6 +136,21 @@ async function perdedoraComLiderMedia(): Promise<void> {
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('7', '♦'));
   await expect(fria.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('9', '♦'));
+}
+
+async function respeitaTemperaturaZeroJaCumpriu(): Promise<void> {
+  const estado = criarEstado({
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('9', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('6', '♥') },
+    ],
+    declaracoes: { j1: 1, bot: 1 },
+    vazas: { j1: 0, bot: 1 },
+  });
+  const mao = [criarCarta('9', '♦'), criarCarta('7', '♦')];
+  const bot = criarBot(0, 0);
+
+  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('9', '♦'));
 }
 
 async function registraSeguirFriaSemFuga(): Promise<void> {

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -9,7 +9,6 @@ import {
   criarEstado,
   maoBifurcacao,
   mesaComBaixa,
-  mesaComDois,
   mesaComQuatro,
 } from './fixtures-jogada-linha-quente';
 
@@ -20,6 +19,8 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve registrar posicionamento determinístico quando logger é injetado', registraPosicionamentoDeterministico);
   it('deve registrar contexto e caminhos auditáveis da decisão', registraContratoExplicavel);
   it('deve empatar quando já cumpriu, líder precisa e carta líder é alta', empataAltaCumprido);
+  it('deve preferir perdedora no meio quando líder é média e já cumpriu', perdedoraComLiderMedia);
+  it('deve registrar seguir fria quando já cumpriu sem carta que não faz', registraSeguirFriaSemFuga);
   it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
   it('não deve sortear temperatura quando não há bifurcação', naoSorteiaSemBifurcacao);
@@ -104,12 +105,59 @@ async function atravessaComCartaBarata(): Promise<void> {
 }
 
 async function empataAltaCumprido(): Promise<void> {
-  const estado = criarEstado({ mesa: mesaComDois(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } });
+  const estado = criarEstado({
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('2', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+    ],
+    declaracoes: { j1: 1, bot: 1 },
+    vazas: { j1: 0, bot: 1 },
+  });
   const bot = criarBot(1, 0);
 
   await expect(bot.decidirJogada([criarCarta('2', '♦'), criarCarta('4', '♦')], estado)).resolves.toEqual(
     criarCarta('2', '♦'),
   );
+}
+
+async function perdedoraComLiderMedia(): Promise<void> {
+  const estado = criarEstado({
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('9', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('6', '♥') },
+    ],
+    declaracoes: { j1: 1, bot: 1 },
+    vazas: { j1: 0, bot: 1 },
+  });
+  const mao = [criarCarta('9', '♦'), criarCarta('7', '♦')];
+  const bot = criarBot(1, 0);
+  const fria = new DecisorJogadaLinhaFria();
+
+  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('7', '♦'));
+  await expect(fria.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('9', '♦'));
+}
+
+async function registraSeguirFriaSemFuga(): Promise<void> {
+  const estado = criarEstado({
+    mesa: [
+      { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+      { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+    ],
+    declaracoes: { bot: 1 },
+    vazas: { bot: 1 },
+    manilha: '6',
+  });
+  const mao = [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')];
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBot(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await bot.decidirJogada(mao, estado);
+
+  expect(jogadas[0]?.quente?.motivo).toBe('linha quente segue fria: sem carta que não faz');
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'segue fria']);
 }
 
 async function convergeSemPressao(): Promise<void> {

--- a/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.ultimo.test.ts
@@ -76,7 +76,7 @@ async function jogaMaisForteSemFuga(): Promise<void> {
 async function sorteiaQuandoLinhasDiferem(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComK(), declaracoes: { j1: 0, bot: 1 }, vazas: { j1: 0, bot: 0 } });
   const random = vi.fn(() => 0);
-  const decisor = new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random }, liderBaixa: 8, liderAlta: 11 });
+  const decisor = new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random }, liderBaixa: 8 });
 
   await expect(decisor.decidirJogada([criarCarta('Q', '♦'), criarCarta('A', '♦')], estado)).resolves.toEqual(
     criarCarta('Q', '♦'),
@@ -92,7 +92,6 @@ async function registraSemBifurcacaoQuandoConverge(): Promise<void> {
     temperatura: 1,
     rng: { random },
     liderBaixa: 8,
-    liderAlta: 11,
     logger: {
       registrarDeclaracao: () => undefined,
       registrarJogada: (jogada) => jogadas.push(jogada),
@@ -118,7 +117,7 @@ function jogarContraNove(estado: EstadoEmJogo): Promise<Carta> {
 }
 
 function bot(): DecisorJogadaLinhaQuente {
-  return new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random: () => 0 }, liderBaixa: 8, liderAlta: 11 });
+  return new DecisorJogadaLinhaQuente({ temperatura: 1, rng: { random: () => 0 }, liderBaixa: 8 });
 }
 
 function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {

--- a/tests/adapters/regras-linha-quente.test.ts
+++ b/tests/adapters/regras-linha-quente.test.ts
@@ -83,6 +83,16 @@ const cenariosJaCumpriuNoMeio: {
     mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
     esperado: null,
   },
+  {
+    nome: 'retornar null quando ainda precisa cumprir mesmo com folga alta',
+    estado: {
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+      declaracoes: { j1: 2, bot: 2 },
+      vazas: { j1: 0, bot: 0 },
+    },
+    mao: [criarCarta('2', '♦'), criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('8', '♦')],
+    esperado: null,
+  },
 ];
 
 describe('escolherJaCumpriuNoMeio', () => {

--- a/tests/adapters/regras-linha-quente.test.ts
+++ b/tests/adapters/regras-linha-quente.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
-import { escolherEmpate, escolherPressao, escolherTravessia, podeBifurcar } from '@/adapters/bots/regras-linha-quente';
+import {
+  escolherJaCumpriuNoMeio,
+  escolherPressao,
+  escolherTravessia,
+  podeBifurcar,
+} from '@/adapters/bots/regras-linha-quente';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
@@ -32,14 +37,59 @@ describe('podeBifurcar', () => {
   });
 });
 
-describe('escolherEmpate', () => {
-  it('deve retornar carta e motivo quando já cumpriu e líder é alta+', () => {
-    const estado = criarEstado({ mesa: mesaComDois(), declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } });
-    const contexto = criarContextoLinhaQuente(estado, [criarCarta('2', '♦'), criarCarta('4', '♦')]);
+const cenariosJaCumpriuNoMeio: {
+  nome: string;
+  estado: Partial<EstadoEmJogo>;
+  mao: Carta[];
+  esperado: { carta: Carta; motivo: string } | null;
+}[] = [
+  {
+    nome: 'empatar contra líder interessado alta+',
+    estado: {
+      mesa: [
+        { jogadorId: 'j1', carta: criarCarta('2', '♣') },
+        { jogadorId: 'j2', carta: criarCarta('7', '♥') },
+      ],
+      declaracoes: { j1: 1, bot: 1 },
+      vazas: { j1: 0, bot: 1 },
+    },
+    mao: [criarCarta('2', '♦'), criarCarta('4', '♦')],
+    esperado: { carta: criarCarta('2', '♦'), motivo: 'já cumpriu; empate contra líder alta+' },
+  },
+  {
+    nome: 'preferir perdedora com líder média',
+    estado: {
+      mesa: [
+        { jogadorId: 'j1', carta: criarCarta('9', '♣') },
+        { jogadorId: 'j2', carta: criarCarta('6', '♥') },
+      ],
+      declaracoes: { j1: 1, bot: 1 },
+      vazas: { j1: 0, bot: 1 },
+    },
+    mao: [criarCarta('9', '♦'), criarCarta('7', '♦')],
+    esperado: { carta: criarCarta('7', '♦'), motivo: 'já cumpriu; perdedora mais forte' },
+  },
+  {
+    nome: 'retornar null sem carta que não faz',
+    estado: {
+      mesa: [
+        { jogadorId: 'j1', carta: criarCarta('4', '♣') },
+        { jogadorId: 'j2', carta: criarCarta('4', '♥') },
+      ],
+      declaracoes: { bot: 1 },
+      vazas: { bot: 1 },
+      manilha: '6',
+    },
+    mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
+    esperado: null,
+  },
+];
 
-    const decisao = escolherEmpate(contexto, 11);
-    expect(decisao?.carta).toEqual(criarCarta('2', '♦'));
-    expect(decisao?.motivo).toBe('empate com líder alta+');
+describe('escolherJaCumpriuNoMeio', () => {
+  it.each(cenariosJaCumpriuNoMeio)('deve $nome', ({ estado: config, mao, esperado }) => {
+    const estado = criarEstado(config);
+    const contexto = criarContextoLinhaQuente(estado, mao);
+    expect(escolherJaCumpriuNoMeio(estado, contexto)).toEqual(esperado);
   });
 });
 
@@ -109,14 +159,6 @@ function mesaComBaixa(): MesaItem[] {
     { jogadorId: 'j1', carta: criarCarta('8', '♣') },
     { jogadorId: 'j2', carta: criarCarta('4', '♥') },
     { jogadorId: 'j3', carta: criarCarta('6', '♠') },
-  ];
-}
-
-function mesaComDois(): MesaItem[] {
-  return [
-    { jogadorId: 'j1', carta: criarCarta('2', '♣') },
-    { jogadorId: 'j2', carta: criarCarta('7', '♥') },
-    { jogadorId: 'j3', carta: criarCarta('8', '♠') },
   ];
 }
 


### PR DESCRIPTION
## Summary

- Remove `liderAlta` parameter from `DecisorJogadaLinhaQuente` and `DecisorJogadaBot` constructors, now using shared `ehAltaOuMelhor` predicate from `predicados-carta-avaliada.ts`
- Replace `escolherEmpate` with `escolherJaCumpriuNoMeio` — when need ≤ 0, the Quente line blocks a high+ leader with a tie, otherwise plays the strongest losing card or falls back to the Cold line
- Extract shared `escolherFugaJaCumpriu` so mid-hand and closing Quente reuse the same “já cumpriu” policy (empate/perdedora selection via `cartaMaisForte`)
- Consolidate `cartaMaisForte` and `liderQuerVaza` into canonical helpers (`escolhas-por-necessidade`, `contexto-posicao-mesa`)
- Add `registraSeguirFria` method for explicit auditability when Quente defers to Cold with no viable non-winning card
- **Behavioral note:** remove the old `folga >= 2` empate path when the bot still needs tricks (`necessidade > 0`); empate agressivo só ocorre quando a declaração já foi cumprida
- Update bot decision tree docs to document the new mid-hand tie priority and leader tier distinction

## Testing

- Unit tests for `escolherJaCumpriuNoMeio`: empate against high+ leader, perdedora preference with medium leader, null when no non-winning card available, null when still needs tricks despite high slack
- Integration test in `DecisorJogadaLinhaQuente.test.ts`: perdedora with medium leader (diverges from Cold line) and seguir fria audit log
- Updated existing test fixtures to drop `liderAlta` parameter
- All existing Quente tests pass unchanged

Closes #214