### PR TITLE
refactor: extrai lógica de atravessia para módulo próprio

### DIFF
--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -206,7 +206,17 @@ e lider jogou carta alta+
 e existe vencedora que nao seja garantida_agora
 ```
 
-Na pratica, `pode atravessar` pode fazer a Linha quente divergir da Linha fria mesmo quando a guarda de posicao bloqueou a tentativa conservadora, desde que a urgencia seja alta e o lider atual tenha jogado alta+ que o bot consiga vencer sem gastar uma garantida_agora.
+`necessidade > 0` aqui nao define o atravessar; so separa este bloco do ramo `necessidade <= 0`, em que a Linha quente tenta **nao** fazer a vaza. Quando `pode atravessar` e verdadeiro, fria e quente **ambas** querem vencer; a divergencia esta na **carta**:
+
+- **Linha fria:** `escolherVencedoraPorNecessidade(vencedoras, necessidade)` — pode gastar `garantida_agora` e escolhe forca proporcional ao quanto ainda falta.
+- **Linha quente:** vencedora mais barata que nao seja `garantida_agora`.
+
+Com urgencia alta, a Guarda de Posicao da Linha fria **ja permite** tentar vencer. O atravessar nao ignora a guarda; escolhe uma carta diferente da fria.
+
+Exemplo: faltam 2 vazas, ha 3 cartas na mao, lider com 2 ainda precisa fazer, mao com `3` (`garantida_agora`) e duas manilhas `4`, todas vencem o lider.
+
+- Linha fria: `G[2-2]` → `3`
+- Linha quente: manilha `4` mais barata (nao e `garantida_agora`)
 
 `pode pressionar e esperar` significa:
 

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -8,12 +8,12 @@ import { criarDecisaoQuente, definirPosicao, type DecisaoQuente } from './debug-
 import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import { decidirNaoUltimoLinhaFria, decidirUltimoLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
+import { escolherTravessia } from './pode-atravessar';
 import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
 import {
   cartasIguais,
   escolherJaCumpriuNoMeio,
   escolherPressao,
-  escolherTravessia,
   formatarMotivoRecusaBifurcacao,
   podeBifurcar,
 } from './regras-linha-quente';
@@ -106,17 +106,20 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   private escolherQuenteDireta(base: BaseJogada): Carta | null {
     if (base.contexto.necessidade <= 0) {
       const jaCumpriu = escolherJaCumpriuNoMeio(base.estadoAtual, base.contexto);
-      if (jaCumpriu) return this.resolverQuenteRecomendada(base, jaCumpriu.carta, jaCumpriu.motivo);
+      if (jaCumpriu) return this.resolverQuenteRecomendada(base, jaCumpriu);
       return this.registrarSeguirFria(base);
     }
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
     if (!travessia) return null;
-    return this.resolverQuenteRecomendada(base, travessia.carta, `linha quente atravessou: ${travessia.motivo}`);
+    return this.resolverQuenteRecomendada(base, { ...travessia, etapa: 'atravessa' });
   }
 
-  private resolverQuenteRecomendada(base: BaseJogada, carta: Carta, motivo: string): Carta {
-    const quente = criarDecisaoQuente({ carta, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente'));
+  private resolverQuenteRecomendada(base: BaseJogada, recomendacao: RecomendacaoQuenteResolve): Carta {
+    const quente = criarDecisaoQuente(
+      { carta: recomendacao.carta, motivo: recomendacao.motivo },
+      criarCaminhoJogadaDebug(base.posicao, 'quente', recomendacao.etapa),
+    );
     return this.resolverBifurcacao(base, quente);
   }
 
@@ -156,6 +159,12 @@ interface BaseJogada {
   fria: Carta;
   motivoLinhaFria: string;
   caminhoLinhaFria: string[];
+}
+
+interface RecomendacaoQuenteResolve {
+  carta: Carta;
+  motivo: string;
+  etapa?: string;
 }
 
 interface ConfigBaseJogada {

--- a/src/adapters/bots/pode-atravessar.ts
+++ b/src/adapters/bots/pode-atravessar.ts
@@ -1,0 +1,39 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { liderQuerVaza, urgenciaAlta } from './contexto-posicao-mesa';
+import type { ContextoJogadaQuente } from './contextoLinhaQuente';
+import { ehAltaOuMelhor } from './predicados-carta-avaliada';
+import type { DecisaoCartaQuente } from './regras-linha-quente';
+
+export function podeAtravessar(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): boolean {
+  return (
+    contexto.necessidade > 0 &&
+    urgenciaAlta(contexto.necessidade, contexto.avaliadas.length) &&
+    liderQuerVaza(estado) &&
+    liderEhAltaPlus(contexto) &&
+    vencedorasSemGarantida(contexto).length > 0
+  );
+}
+
+export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): DecisaoCartaQuente | null {
+  if (!podeAtravessar(estado, contexto)) return null;
+  const escolhida = cartaMaisBarata(vencedorasSemGarantida(contexto));
+  return { carta: escolhida.carta, motivo: montarMotivoTravessia(contexto) };
+}
+
+function liderEhAltaPlus(contexto: ContextoJogadaQuente): boolean {
+  return contexto.lider !== null && ehAltaOuMelhor(contexto.lider);
+}
+
+function vencedorasSemGarantida(contexto: ContextoJogadaQuente): CartaAvaliada[] {
+  return contexto.vencedoras.filter((avaliada) => avaliada.categoria !== 'garantida_agora');
+}
+
+function montarMotivoTravessia(contexto: ContextoJogadaQuente): string {
+  const urgencia = contexto.necessidade / contexto.avaliadas.length;
+  return `atravessa: urgência ${urgencia.toFixed(2)}, líder alta+ precisa, vencedora mais barata sem garantida`;
+}
+
+function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
+}

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -45,20 +45,6 @@ export function escolherPressao(contexto: ContextoJogadaQuente): DecisaoCartaQue
   };
 }
 
-export function escolherTravessia(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): DecisaoCartaQuente | null {
-  if (
-    contexto.necessidade <= 0 ||
-    contexto.folga > 1 ||
-    !liderQuerVaza(estado) ||
-    !temAlvo(estado, contexto.jogadorId)
-  ) {
-    return null;
-  }
-  const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
-  if (candidatas.length === 0) return null;
-  return { carta: cartaMaisBarata(candidatas).carta, motivo: 'travessia: líder alta+ e urgência baixa' };
-}
-
 export function escolherJaCumpriuNoMeio(
   estado: EstadoEmJogo,
   contexto: ContextoJogadaQuente,

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -22,7 +22,6 @@ describe('DecisorJogadaLinhaQuente', () => {
   it('deve preferir perdedora no meio quando líder é média e já cumpriu', perdedoraComLiderMedia);
   it('deve respeitar temperatura zero quando já cumpriu diverge da linha fria', respeitaTemperaturaZeroJaCumpriu);
   it('deve registrar seguir fria quando já cumpriu sem carta que não faz', registraSeguirFriaSemFuga);
-  it('deve atravessar com carta barata quando precisa e tem folga baixa', atravessaComCartaBarata);
   it('deve convergir para linha fria quando não existe pressão agora', convergeSemPressao);
   it('não deve sortear temperatura quando não há bifurcação', naoSorteiaSemBifurcacao);
   it('deve repetir a escolha com RNG determinístico', repeteEscolhaDeterministica);
@@ -90,19 +89,6 @@ async function registraContratoExplicavel(): Promise<void> {
   });
   expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
   expect(jogadas[0]).toMatchObject(decisaoSorteadaLinhaQuente());
-}
-
-async function atravessaComCartaBarata(): Promise<void> {
-  const estado = criarEstado({
-    mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
-    declaracoes: { j1: 1, bot: 1 },
-    vazas: { j1: 0, bot: 0 },
-  });
-  const bot = criarBot(1, 0);
-
-  await expect(bot.decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado)).resolves.toEqual(
-    criarCarta('A', '♦'),
-  );
 }
 
 async function empataAltaCumprido(): Promise<void> {

--- a/tests/adapters/fixtures-atravessia.ts
+++ b/tests/adapters/fixtures-atravessia.ts
@@ -1,0 +1,71 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+import { cartasQueGarantemTresDeOuros } from './fixtures-linha-fria';
+
+export function criarEstadoAtravessia(config: Partial<EstadoEmJogo> = {}): EstadoEmJogo {
+  return criarEstadoBase({
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+    declaracoes: { j1: 1, bot: 3 },
+    vazas: { j1: 0, bot: 0 },
+    manilha: '4',
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+    ...config,
+  });
+}
+
+export function maoAtravessia(): Carta[] {
+  return [criarCarta('3', '♦'), criarCarta('4', '♣'), criarCarta('4', '♦')];
+}
+
+export const cenariosRecusaAtravessia = [
+  {
+    nome: 'não há necessidade',
+    estado: criarEstadoAtravessia({ declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 1 } }),
+    mao: [criarCarta('A', '♦')],
+  },
+  {
+    nome: 'urgência não é alta',
+    estado: criarEstadoAtravessia({ declaracoes: { j1: 1, bot: 1 }, vazas: { j1: 0, bot: 0 } }),
+    mao: [criarCarta('A', '♦'), criarCarta('3', '♦')],
+  },
+  {
+    nome: 'líder já cumpriu',
+    estado: criarEstadoAtravessia({ declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 1, bot: 0 } }),
+    mao: maoAtravessia(),
+  },
+  {
+    nome: 'carta líder não é alta+',
+    estado: criarEstadoAtravessia({ mesa: [{ jogadorId: 'j1', carta: criarCarta('9', '♣') }] }),
+    mao: [criarCarta('Q', '♦'), criarCarta('K', '♦'), criarCarta('6', '♦')],
+  },
+  {
+    nome: 'só há vencedora garantida_agora',
+    estado: criarEstadoAtravessia({ declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } }),
+    mao: [criarCarta('3', '♦'), criarCarta('6', '♦'), criarCarta('7', '♦')],
+  },
+];
+
+function criarEstadoBase(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = [
+    criarJogador('j1', 'J1'),
+    criarJogador('j2', 'J2'),
+    criarJogador('j3', 'J3'),
+    criarJogador('bot', 'Bot'),
+  ];
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}

--- a/tests/adapters/pode-atravessar.test.ts
+++ b/tests/adapters/pode-atravessar.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
+import { decidirNaoUltimoLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { DecisaoJogadaDebug, LoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
+import { podeAtravessar, escolherTravessia } from '@/adapters/bots/pode-atravessar';
+import { criarCarta } from '../core/rodada-fixtures';
+import { criarEstadoAtravessia, cenariosRecusaAtravessia, maoAtravessia } from './fixtures-atravessia';
+
+describe('podeAtravessar recusa', () => {
+  it.each(cenariosRecusaAtravessia)('deve recusar quando $nome', ({ estado, mao }) => {
+    const contexto = criarContextoLinhaQuente(estado, mao);
+    expect(podeAtravessar(estado, contexto)).toBe(false);
+  });
+});
+
+describe('podeAtravessar permite', () => {
+  it('deve permitir quando todos os critérios passam', () => {
+    const estado = criarEstadoAtravessia();
+    const contexto = criarContextoLinhaQuente(estado, maoAtravessia());
+
+    expect(podeAtravessar(estado, contexto)).toBe(true);
+    expect(escolherTravessia(estado, contexto)).toEqual({
+      carta: criarCarta('4', '♦'),
+      motivo: 'atravessa: urgência 1.00, líder alta+ precisa, vencedora mais barata sem garantida',
+    });
+  });
+});
+
+describe('escolherTravessia na linha fria', () => {
+  it('deve divergir da linha fria preservando garantida_agora', () => {
+    const estado = criarEstadoAtravessia();
+    const mao = maoAtravessia();
+
+    expect(escolherTravessia(estado, criarContextoLinhaQuente(estado, mao))?.carta).toEqual(criarCarta('4', '♦'));
+    expect(decidirNaoUltimoLinhaFria(mao, estado).carta).toEqual(criarCarta('3', '♦'));
+  });
+});
+
+describe('DecisorJogadaLinhaQuente atravessia', () => {
+  it('deve atravessar com vencedora mais barata sem garantida', atravessaComCartaBarata);
+  it('deve registrar rastro de atravessia com critérios relevantes', registraRastroAtravessia);
+});
+
+async function atravessaComCartaBarata(): Promise<void> {
+  const bot = criarBot(1, 0);
+  await expect(bot.decidirJogada(maoAtravessia(), criarEstadoAtravessia())).resolves.toEqual(criarCarta('4', '♦'));
+}
+
+async function registraRastroAtravessia(): Promise<void> {
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBot(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await bot.decidirJogada(maoAtravessia(), criarEstadoAtravessia());
+
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'atravessa']);
+  expect(jogadas[0]?.quente?.motivo).toContain('atravessa: urgência 1.00');
+}
+
+function criarBot(temperatura: number, valorRng: number, logger?: LoggerDebugBot): DecisorJogadaLinhaQuente {
+  return new DecisorJogadaLinhaQuente({
+    temperatura,
+    rng: { random: () => valorRng },
+    logger,
+  });
+}

--- a/tests/adapters/regras-linha-quente.test.ts
+++ b/tests/adapters/regras-linha-quente.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
-import {
-  escolherJaCumpriuNoMeio,
-  escolherPressao,
-  escolherTravessia,
-  podeBifurcar,
-} from '@/adapters/bots/regras-linha-quente';
+import { escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from '@/adapters/bots/regras-linha-quente';
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
@@ -100,21 +95,6 @@ describe('escolherJaCumpriuNoMeio', () => {
     const estado = criarEstado(config);
     const contexto = criarContextoLinhaQuente(estado, mao);
     expect(escolherJaCumpriuNoMeio(estado, contexto)).toEqual(esperado);
-  });
-});
-
-describe('escolherTravessia', () => {
-  it('deve retornar carta e motivo quando precisa com folga baixa', () => {
-    const estado = criarEstado({
-      mesa: [{ jogadorId: 'j1', carta: criarCarta('K', '♣') }],
-      declaracoes: { j1: 1, bot: 1 },
-      vazas: { j1: 0, bot: 0 },
-    });
-    const contexto = criarContextoLinhaQuente(estado, [criarCarta('A', '♦'), criarCarta('3', '♦')]);
-
-    const decisao = escolherTravessia(estado, contexto);
-    expect(decisao?.carta).toEqual(criarCarta('A', '♦'));
-    expect(decisao?.motivo).toBe('travessia: líder alta+ e urgência baixa');
   });
 });
 


### PR DESCRIPTION
## Summary

- Extrai as funções `podeAtravessar` e `escolherTravessia` do módulo `regras-linha-quente.ts` para um novo módulo `pode-atravessar.ts`
- Adiciona função `podeAtravessar` que verifica as condições para a travessia (necessidade, urgência, líder, vencedoras sem garantida)
- Atualiza `DecisorJogadaLinhaQuente.ts` para importar do novo módulo e adapta a interface de resolução
- Remove código desnecessário de `regras-linha-quente.ts`
- Adiciona fixtures centralizadas em `tests/adapters/fixtures-atravessia.ts`
- Reorganiza os testes: move testes de travessia para `pode-atravessar.test.ts` com cobertura de cenários de recusa e permissão
- Atualiza documentação da árvore de decisão

## Testing

- Todos os testes unitários existentes passam (`pnpm test`)
- Novos testes para `podeAtravessar` cobrem 5 cenários de recusa (`não há necessidade`, `urgência não é alta`, `líder já cumpriu`, `carta líder não é alta+`, `só há vencedora garantida_agora`)
- Teste de permissão quando todos os critérios são atendidos
- Teste de divergência entre linha quente e linha fria preservando `garantida_agora`
- Teste de integração com `DecisorJogadaLinhaQuente` verificando a carta escolhida e o rastro de debug

Closes #215