### PR TITLE
feat: linha quente no meio — vencedora segura, espera e docs

### DIFF
--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -226,27 +226,42 @@ e existe vencedora
 e urgencia < 0.66
 e existe jogador interessado
 e existe garantida_agora para depois
-e existe carta de fuga util agora
-  ou existe vencedora barata que preserva garantida_agora para depois
+e (
+    existe carta de fuga util agora
+    ou existe vencedora barata que preserva garantida_agora para depois
+  )
 ```
+
+O ultimo `e (... ou ...)` e avaliado como um bloco unico: as quatro primeiras condicoes precisam ser verdadeiras **e** pelo menos uma das duas alternativas finais tambem. Se as quatro primeiras forem verdadeiras mas **nenhuma** das duas alternativas existir, `pode pressionar e esperar` e **falso** e a Linha quente desce para o proximo ramo (`pode tentar com vencedora segura`). Em particular, ter `garantida_agora para depois` nao basta sozinho para entrar neste ramo.
 
 `existe carta de fuga util agora` significa que ha perdedora ou empate que nao seja segura nem garantida_agora.
 
 `existe vencedora barata que preserva garantida_agora para depois` significa que ha vencedora nao garantida_agora e ainda sobra carta garantida_agora para sustentar os turnos seguintes.
 
+A escolha da carta dentro do ramo segue a ordem do pseudocodigo: se `existe carta de fuga util agora`, joga a fuga mais cara; senao, joga a vencedora barata preservando a garantida_agora.
+
 `pode tentar com vencedora segura` significa:
 
 ```text
 necessidade > 0
+e existe vencedora
 e urgencia < 0.66
 e existe jogador interessado
+e nao existe garantida_agora para depois
 e lider atual ainda precisa fazer
 e lider jogou carta alta+
 e existe vencedora segura
-e nao existe garantida_agora para depois
 ```
 
 `existe vencedora segura` significa que ha carta segura que vence a carta lider atual. Referencias praticas: 2, 3 ou manilha.
+
+A condicao `nao existe garantida_agora para depois` e o **eixo unico** que separa este ramo de `pode pressionar e esperar`: as duas leem o mesmo fato (`existe garantida_agora para depois`) com sinal oposto. Como `pode pressionar e esperar` e avaliado primeiro:
+
+- Se **ha** garantida_agora para depois e existe fuga util ou vencedora barata, a Linha quente ja parou em `pode pressionar e esperar`; este ramo nem e alcancado.
+- Se **ha** garantida_agora para depois mas nao ha fuga util nem vencedora barata, `pode pressionar e esperar` falhou no fim; este ramo tambem falha aqui (em `nao existe garantida_agora para depois`) e a decisao desce para `pode esperar oportunidade`.
+- Se **nao ha** garantida_agora para depois, `pode pressionar e esperar` ja havia falhado nessa condicao; este ramo segue avaliando lider e vencedora segura.
+
+A ordem de avaliacao tambem importa: confirma-se primeiro `existe jogador interessado` (interesse generico) e so depois se especializa para o lider (`lider atual ainda precisa fazer` e `lider jogou carta alta+`).
 
 `pode esperar oportunidade` significa:
 
@@ -257,6 +272,10 @@ e existe carta que nao faz a vaza
 ```
 
 Esse ramo existe para a Linha quente tambem poder escolher espera ativa quando nao ha motivo suficiente para atravessar, pressionar ou gastar vencedora segura. A decisao relativa e `descartePorNecessidade(perdedoras + empates, necessidade)`.
+
+E o **coletor** dos ramos de `necessidade > 0`: tem as condicoes menos exigentes (so urgencia baixa e ao menos uma carta que nao faz a vaza). Recebe os casos em que atravessar, pressionar e vencedora segura ja falharam mas ainda sobra carta de fuga para descartar.
+
+Por consequencia, o `seguir Linha fria` final (fallback) so e alcancado quando **nao existe carta que nao faz a vaza** — ou seja, toda carta da mao vence o lider e nao ha como esperar sem fazer a vaza.
 
 ## Arvore: Fecha a Mesa
 

--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -246,12 +246,13 @@ A escolha da carta dentro do ramo segue a ordem do pseudocodigo: se `existe cart
 necessidade > 0
 e existe vencedora
 e urgencia < 0.66
-e existe jogador interessado
 e nao existe garantida_agora para depois
 e lider atual ainda precisa fazer
 e lider jogou carta alta+
 e existe vencedora segura
 ```
+
+A condicao "existe jogador interessado" (comum aos ramos da Linha quente) nao aparece aqui porque `lider atual ainda precisa fazer` ja a garante: se o lider precisa fazer, existe um jogador interessado na mesa. O ramo nao exige um jogador interessado **por agir** alem do lider.
 
 `existe vencedora segura` significa que ha carta segura que vence a carta lider atual. Referencias praticas: 2, 3 ou manilha.
 
@@ -260,8 +261,6 @@ A condicao `nao existe garantida_agora para depois` e o **eixo unico** que separ
 - Se **ha** garantida_agora para depois e existe fuga util ou vencedora barata, a Linha quente ja parou em `pode pressionar e esperar`; este ramo nem e alcancado.
 - Se **ha** garantida_agora para depois mas nao ha fuga util nem vencedora barata, `pode pressionar e esperar` falhou no fim; este ramo tambem falha aqui (em `nao existe garantida_agora para depois`) e a decisao desce para `pode esperar oportunidade`.
 - Se **nao ha** garantida_agora para depois, `pode pressionar e esperar` ja havia falhado nessa condicao; este ramo segue avaliando lider e vencedora segura.
-
-A ordem de avaliacao tambem importa: confirma-se primeiro `existe jogador interessado` (interesse generico) e so depois se especializa para o lider (`lider atual ainda precisa fazer` e `lider jogou carta alta+`).
 
 `pode esperar oportunidade` significa:
 

--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -232,7 +232,7 @@ e (
   )
 ```
 
-O ultimo `e (... ou ...)` e avaliado como um bloco unico: as quatro primeiras condicoes precisam ser verdadeiras **e** pelo menos uma das duas alternativas finais tambem. Se as quatro primeiras forem verdadeiras mas **nenhuma** das duas alternativas existir, `pode pressionar e esperar` e **falso** e a Linha quente desce para o proximo ramo (`pode tentar com vencedora segura`). Em particular, ter `garantida_agora para depois` nao basta sozinho para entrar neste ramo.
+O ultimo `e (... ou ...)` e avaliado como um bloco unico: as cinco condicoes anteriores precisam ser verdadeiras **e** pelo menos uma das duas alternativas finais tambem. Se as cinco condicoes anteriores forem verdadeiras, mas **nenhuma** das duas alternativas existir, `pode pressionar e esperar` e **falso** e a Linha quente desce para o proximo ramo (`pode tentar com vencedora segura`). Em particular, ter `garantida_agora para depois` nao basta sozinho para entrar neste ramo.
 
 `existe carta de fuga util agora` significa que ha perdedora ou empate que nao seja segura nem garantida_agora.
 
@@ -275,7 +275,7 @@ Esse ramo existe para a Linha quente tambem poder escolher espera ativa quando n
 
 E o **coletor** dos ramos de `necessidade > 0`: tem as condicoes menos exigentes (so urgencia baixa e ao menos uma carta que nao faz a vaza). Recebe os casos em que atravessar, pressionar e vencedora segura ja falharam mas ainda sobra carta de fuga para descartar.
 
-Por consequencia, o `seguir Linha fria` final (fallback) so e alcancado quando **nao existe carta que nao faz a vaza** — ou seja, toda carta da mao vence o lider e nao ha como esperar sem fazer a vaza.
+Por consequencia, o `seguir Linha fria` final (fallback) ocorre quando **nenhum** dos ramos anteriores (`pode atravessar`, `pode pressionar e esperar`, `pode tentar com vencedora segura`, `pode esperar oportunidade`) foi satisfeito. Um caso comum e `urgencia >= 0.66` com `pode atravessar` falso (por exemplo, sem vencedora que nao seja `garantida_agora`): pressionar, vencedora segura e espera exigem `urgencia < 0.66` e tambem falham, e o fallback e alcancado **mesmo** havendo perdedora ou empate na mao. Outro caso e urgencia baixa em que toda carta vence o lider (`nao existe carta que nao faz a vaza`), de modo que `pode esperar oportunidade` tambem falha.
 
 ## Arvore: Fecha a Mesa
 

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -9,14 +9,10 @@ import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import { decidirNaoUltimoLinhaFria, decidirUltimoLinhaFria } from './DecisorJogadaLinhaFria';
 import type { LoggerDebugBot } from './logger-debug-bot';
 import { escolherTravessia } from './pode-atravessar';
+import { escolherEsperarOportunidade } from './pode-esperar-oportunidade';
+import { escolherVencedoraSegura } from './pode-vencedora-segura';
 import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
-import {
-  cartasIguais,
-  escolherJaCumpriuNoMeio,
-  escolherPressao,
-  formatarMotivoRecusaBifurcacao,
-  podeBifurcar,
-} from './regras-linha-quente';
+import { cartasIguais, escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from './regras-linha-quente';
 
 interface ConfigLinhaQuente {
   temperatura: number;
@@ -68,18 +64,24 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     if (direta) return direta;
 
     const bifurcacao = podeBifurcar(base.estadoAtual, base.contexto, this.liderBaixa);
-    if (!bifurcacao.pode) {
-      const motivo = bifurcacao.motivoRecusa
-        ? formatarMotivoRecusaBifurcacao(bifurcacao.motivoRecusa)
-        : base.motivoLinhaFria;
-      return this.registrarSemBifurcacao(
-        base,
-        criarDecisaoQuente({ carta: base.fria, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente')),
-      );
+    if (bifurcacao.pode) {
+      return this.resolverQuenteRecomendada(base, {
+        ...escolherPressao(base.contexto),
+        etapa: 'pressiona',
+      });
     }
 
-    const quente = criarDecisaoQuente(escolherPressao(base.contexto), criarCaminhoJogadaDebug(base.posicao, 'quente'));
-    return this.resolverBifurcacao(base, quente);
+    const vencedoraSegura = escolherVencedoraSegura(base.estadoAtual, base.contexto);
+    if (vencedoraSegura) {
+      return this.resolverQuenteRecomendada(base, { ...vencedoraSegura, etapa: 'vencedora segura' });
+    }
+
+    const espera = escolherEsperarOportunidade(base.estadoAtual, base.contexto);
+    if (espera) {
+      return this.resolverQuenteRecomendada(base, { ...espera, etapa: 'espera oportunidade' });
+    }
+
+    return this.registrarSeguirFria(base);
   }
 
   private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -81,7 +81,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
       return this.resolverQuenteRecomendada(base, { ...espera, etapa: 'espera oportunidade' });
     }
 
-    return this.registrarSeguirFria(base);
+    return this.registrarSeguirFria(base, 'linha quente segue fria: nenhum ramo se aplica');
   }
 
   private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {
@@ -109,7 +109,7 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     if (base.contexto.necessidade <= 0) {
       const jaCumpriu = escolherJaCumpriuNoMeio(base.estadoAtual, base.contexto);
       if (jaCumpriu) return this.resolverQuenteRecomendada(base, jaCumpriu);
-      return this.registrarSeguirFria(base);
+      return this.registrarSeguirFria(base, 'linha quente segue fria: sem carta que não faz');
     }
 
     const travessia = escolherTravessia(base.estadoAtual, base.contexto);
@@ -125,13 +125,10 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
     return this.resolverBifurcacao(base, quente);
   }
 
-  private registrarSeguirFria(base: BaseJogada): Carta {
+  private registrarSeguirFria(base: BaseJogada, motivo: string): Carta {
     return this.registrarSemBifurcacao(
       base,
-      criarDecisaoQuente(
-        { carta: base.fria, motivo: 'linha quente segue fria: sem carta que não faz' },
-        criarCaminhoJogadaDebug(base.posicao, 'quente', 'segue fria'),
-      ),
+      criarDecisaoQuente({ carta: base.fria, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente', 'segue fria')),
     );
   }
 

--- a/src/adapters/bots/garantida-para-depois.ts
+++ b/src/adapters/bots/garantida-para-depois.ts
@@ -1,0 +1,5 @@
+import type { ContextoJogadaQuente } from './contextoLinhaQuente';
+
+export function existeGarantidaParaDepois(contexto: ContextoJogadaQuente): boolean {
+  return contexto.avaliadas.some((avaliada) => avaliada.categoria === 'garantida_agora');
+}

--- a/src/adapters/bots/pode-atravessar.ts
+++ b/src/adapters/bots/pode-atravessar.ts
@@ -4,6 +4,7 @@ import { liderQuerVaza, urgenciaAlta } from './contexto-posicao-mesa';
 import type { ContextoJogadaQuente } from './contextoLinhaQuente';
 import { ehAltaOuMelhor } from './predicados-carta-avaliada';
 import type { DecisaoCartaQuente } from './regras-linha-quente';
+import { cartaMaisBarata } from './selecao-por-score';
 
 export function podeAtravessar(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): boolean {
   return (
@@ -32,8 +33,4 @@ function vencedorasSemGarantida(contexto: ContextoJogadaQuente): CartaAvaliada[]
 function montarMotivoTravessia(contexto: ContextoJogadaQuente): string {
   const urgencia = contexto.necessidade / contexto.avaliadas.length;
   return `atravessa: urgência ${urgencia.toFixed(2)}, líder alta+ precisa, vencedora mais barata sem garantida`;
-}
-
-function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
-  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
 }

--- a/src/adapters/bots/pode-esperar-oportunidade.ts
+++ b/src/adapters/bots/pode-esperar-oportunidade.ts
@@ -1,0 +1,28 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { urgenciaAlta } from './contexto-posicao-mesa';
+import type { ContextoJogadaQuente } from './contextoLinhaQuente';
+import { descartePorNecessidade } from './escolhas-por-necessidade';
+import type { DecisaoCartaQuente } from './regras-linha-quente';
+
+export function podeEsperarOportunidade(contexto: ContextoJogadaQuente): boolean {
+  return (
+    contexto.necessidade > 0 &&
+    !urgenciaAlta(contexto.necessidade, contexto.avaliadas.length) &&
+    cartasQueNaoFazemVaza(contexto).length > 0
+  );
+}
+
+export function escolherEsperarOportunidade(
+  estado: EstadoEmJogo,
+  contexto: ContextoJogadaQuente,
+): DecisaoCartaQuente | null {
+  if (!podeEsperarOportunidade(contexto)) return null;
+  const candidatas = cartasQueNaoFazemVaza(contexto);
+  const escolhida = descartePorNecessidade(candidatas, estado.manilha, contexto.necessidade);
+  return { carta: escolhida.carta, motivo: 'espera oportunidade: descarte por necessidade' };
+}
+
+function cartasQueNaoFazemVaza(contexto: ContextoJogadaQuente): CartaAvaliada[] {
+  return [...contexto.perdedoras, ...contexto.empates];
+}

--- a/src/adapters/bots/pode-vencedora-segura.ts
+++ b/src/adapters/bots/pode-vencedora-segura.ts
@@ -1,0 +1,44 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { jogadoresInteressadosPorAgir, liderQuerVaza, urgenciaAlta } from './contexto-posicao-mesa';
+import type { ContextoJogadaQuente } from './contextoLinhaQuente';
+import { existeGarantidaParaDepois } from './garantida-para-depois';
+import { ehAltaOuMelhor } from './predicados-carta-avaliada';
+import type { DecisaoCartaQuente } from './regras-linha-quente';
+
+export function podeTentarComVencedoraSegura(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): boolean {
+  return (
+    contexto.necessidade > 0 &&
+    contexto.vencedoras.length > 0 &&
+    !urgenciaAlta(contexto.necessidade, contexto.avaliadas.length) &&
+    jogadoresInteressadosPorAgir(estado).length > 0 &&
+    !existeGarantidaParaDepois(contexto) &&
+    liderQuerVaza(estado) &&
+    liderEhAltaPlus(contexto) &&
+    vencedorasSeguras(contexto).length > 0
+  );
+}
+
+export function escolherVencedoraSegura(
+  estado: EstadoEmJogo,
+  contexto: ContextoJogadaQuente,
+): DecisaoCartaQuente | null {
+  if (!podeTentarComVencedoraSegura(estado, contexto)) return null;
+  const escolhida = cartaMaisBarata(vencedorasSeguras(contexto));
+  return {
+    carta: escolhida.carta,
+    motivo: 'vencedora segura: líder alta+ precisa, sem garantida para depois',
+  };
+}
+
+function liderEhAltaPlus(contexto: ContextoJogadaQuente): boolean {
+  return contexto.lider !== null && ehAltaOuMelhor(contexto.lider);
+}
+
+function vencedorasSeguras(contexto: ContextoJogadaQuente): CartaAvaliada[] {
+  return contexto.vencedoras.filter((avaliada) => avaliada.categoria === 'segura');
+}
+
+function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
+}

--- a/src/adapters/bots/pode-vencedora-segura.ts
+++ b/src/adapters/bots/pode-vencedora-segura.ts
@@ -1,17 +1,19 @@
 import type { CartaAvaliada } from '@/core/avaliador-carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
-import { jogadoresInteressadosPorAgir, liderQuerVaza, urgenciaAlta } from './contexto-posicao-mesa';
+import { liderQuerVaza, urgenciaAlta } from './contexto-posicao-mesa';
 import type { ContextoJogadaQuente } from './contextoLinhaQuente';
 import { existeGarantidaParaDepois } from './garantida-para-depois';
 import { ehAltaOuMelhor } from './predicados-carta-avaliada';
 import type { DecisaoCartaQuente } from './regras-linha-quente';
+import { cartaMaisBarata } from './selecao-por-score';
 
 export function podeTentarComVencedoraSegura(estado: EstadoEmJogo, contexto: ContextoJogadaQuente): boolean {
+  // "existe jogador interessado" (doc) é subsumido por liderQuerVaza: se o líder
+  // ainda precisa fazer, já existe um jogador interessado na mesa.
   return (
     contexto.necessidade > 0 &&
     contexto.vencedoras.length > 0 &&
     !urgenciaAlta(contexto.necessidade, contexto.avaliadas.length) &&
-    jogadoresInteressadosPorAgir(estado).length > 0 &&
     !existeGarantidaParaDepois(contexto) &&
     liderQuerVaza(estado) &&
     liderEhAltaPlus(contexto) &&
@@ -37,8 +39,4 @@ function liderEhAltaPlus(contexto: ContextoJogadaQuente): boolean {
 
 function vencedorasSeguras(contexto: ContextoJogadaQuente): CartaAvaliada[] {
   return contexto.vencedoras.filter((avaliada) => avaliada.categoria === 'segura');
-}
-
-function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
-  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
 }

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -3,6 +3,7 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade, liderQuerVaza, type ContextoJogadaQuente } from './contextoLinhaQuente';
 import { MOTIVOS_FUGA_MEIO, escolherFugaJaCumpriu } from './escolher-fuga-ja-cumpriu';
+import { existeGarantidaParaDepois } from './garantida-para-depois';
 
 export interface ResultadoPodeBifurcar {
   pode: boolean;
@@ -78,10 +79,8 @@ function cartasDeFuga(contexto: ContextoJogadaQuente): CartaAvaliada[] {
 }
 
 function vencedorasBaratasSemGarantida(contexto: ContextoJogadaQuente): CartaAvaliada[] {
-  const candidatas = contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
-  return candidatas.filter((carta) =>
-    contexto.avaliadas.some((avaliada) => avaliada !== carta && ehGarantida(avaliada)),
-  );
+  if (!existeGarantidaParaDepois(contexto)) return [];
+  return contexto.vencedoras.filter((avaliada) => !ehGarantida(avaliada));
 }
 
 function temAlvo(estado: EstadoEmJogo, jogadorId: string): boolean {

--- a/src/adapters/bots/regras-linha-quente.ts
+++ b/src/adapters/bots/regras-linha-quente.ts
@@ -4,6 +4,7 @@ import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { calcularNecessidade, liderQuerVaza, type ContextoJogadaQuente } from './contextoLinhaQuente';
 import { MOTIVOS_FUGA_MEIO, escolherFugaJaCumpriu } from './escolher-fuga-ja-cumpriu';
 import { existeGarantidaParaDepois } from './garantida-para-depois';
+import { cartaMaisBarata, cartaMaisCara } from './selecao-por-score';
 
 export interface ResultadoPodeBifurcar {
   pode: boolean;
@@ -27,10 +28,6 @@ export function podeBifurcar(
   if (!temPressaoAgora(contexto)) return { pode: false, motivoRecusa: 'sem pressão agora' };
   if (!temAlvo(estado, contexto.jogadorId)) return { pode: false, motivoRecusa: 'sem alvo na mesa' };
   return { pode: true };
-}
-
-export function formatarMotivoRecusaBifurcacao(motivoRecusa: string): string {
-  return `linha quente segue fria: ${motivoRecusa}`;
 }
 
 export function cartasIguais(a: Carta, b: Carta): boolean {
@@ -97,12 +94,4 @@ function ehSeguraOuGarantida(avaliada: CartaAvaliada): boolean {
 
 function ehGarantida(avaliada: CartaAvaliada): boolean {
   return avaliada.categoria === 'garantida_agora';
-}
-
-function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
-  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
-}
-
-function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
-  return [...avaliadas].sort((a, b) => b.score - a.score)[0];
 }

--- a/src/adapters/bots/selecao-por-score.ts
+++ b/src/adapters/bots/selecao-por-score.ts
@@ -1,0 +1,9 @@
+import type { CartaAvaliada } from '@/core/avaliador-carta';
+
+export function cartaMaisBarata(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => a.score - b.score)[0];
+}
+
+export function cartaMaisCara(avaliadas: CartaAvaliada[]): CartaAvaliada {
+  return [...avaliadas].sort((a, b) => b.score - a.score)[0];
+}

--- a/tests/adapters/DecisorJogadaLinhaQuente.meio.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.meio.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
 import { cenarioEsperaOportunidade, maoEsperaOportunidade } from './fixtures-espera-oportunidade';
 import { criarBotLinhaQuente, criarEstado } from './fixtures-jogada-linha-quente';
@@ -9,7 +10,16 @@ describe('DecisorJogadaLinhaQuente no meio', () => {
   it('deve escolher vencedora segura quando pressão não casa', escolheVencedoraSegura);
   it('deve esperar oportunidade quando pressão e vencedora segura falham', esperaOportunidade);
   it('deve descer para espera quando há garantida mas pressão falha', pressaoFalhaDesceParaEspera);
+  it('deve seguir fria com urgência alta e nenhum ramo aplicável mesmo havendo fuga', seguirFriaUrgenciaAlta);
 });
+
+function cenarioFallbackUrgenciaAlta(): Partial<EstadoEmJogo> {
+  return {
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('9', '♣') }],
+    declaracoes: { j1: 1, bot: 2 },
+    vazas: { j1: 0, bot: 0 },
+  };
+}
 
 async function escolheVencedoraSegura(): Promise<void> {
   const bot = criarBotLinhaQuente(1, 0);
@@ -38,4 +48,19 @@ async function pressaoFalhaDesceParaEspera(): Promise<void> {
 
   expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'espera oportunidade']);
   expect(jogadas[0]?.quente?.motivo).toBe('espera oportunidade: descarte por necessidade');
+}
+
+async function seguirFriaUrgenciaAlta(): Promise<void> {
+  const estado = criarEstado(cenarioFallbackUrgenciaAlta());
+  const mao = [criarCarta('7', '♦'), criarCarta('K', '♦')];
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBotLinhaQuente(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('K', '♦'));
+
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'segue fria']);
+  expect(jogadas[0]?.quente?.motivo).toBe('linha quente segue fria: nenhum ramo se aplica');
 }

--- a/tests/adapters/DecisorJogadaLinhaQuente.meio.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.meio.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
+import { criarCarta } from '../core/rodada-fixtures';
+import { cenarioEsperaOportunidade, maoEsperaOportunidade } from './fixtures-espera-oportunidade';
+import { criarBotLinhaQuente, criarEstado } from './fixtures-jogada-linha-quente';
+import { cenarioVencedoraSegura, maoVencedoraSegura } from './fixtures-vencedora-segura';
+
+describe('DecisorJogadaLinhaQuente no meio', () => {
+  it('deve escolher vencedora segura quando pressão não casa', escolheVencedoraSegura);
+  it('deve esperar oportunidade quando pressão e vencedora segura falham', esperaOportunidade);
+  it('deve descer para espera quando há garantida mas pressão falha', pressaoFalhaDesceParaEspera);
+});
+
+async function escolheVencedoraSegura(): Promise<void> {
+  const bot = criarBotLinhaQuente(1, 0);
+
+  await expect(bot.decidirJogada(maoVencedoraSegura(), criarEstado(cenarioVencedoraSegura()))).resolves.toEqual(
+    criarCarta('3', '♦'),
+  );
+}
+
+async function esperaOportunidade(): Promise<void> {
+  const estado = criarEstado(cenarioEsperaOportunidade());
+  const bot = criarBotLinhaQuente(1, 0);
+
+  await expect(bot.decidirJogada(maoEsperaOportunidade(), estado)).resolves.toEqual(criarCarta('7', '♦'));
+}
+
+async function pressaoFalhaDesceParaEspera(): Promise<void> {
+  const estado = criarEstado(cenarioEsperaOportunidade());
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const bot = criarBotLinhaQuente(1, 0, {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada) => jogadas.push(jogada),
+  });
+
+  await bot.decidirJogada(maoEsperaOportunidade(), estado);
+
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'espera oportunidade']);
+  expect(jogadas[0]?.quente?.motivo).toBe('espera oportunidade: descarte por necessidade');
+}

--- a/tests/adapters/DecisorJogadaLinhaQuente.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaQuente.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DecisorJogadaLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
 import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
-import type { DecisaoJogadaDebug, LoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
 import { criarCarta } from '../core/rodada-fixtures';
 import {
   cenarioBifurcacao,
   cenarioBifurcacaoAntesDoFim,
+  criarBotLinhaQuente,
   criarEstado,
+  decisaoSorteadaLinhaQuente,
   maoBifurcacao,
   mesaComBaixa,
   mesaComQuatro,
@@ -29,19 +31,19 @@ describe('DecisorJogadaLinhaQuente', () => {
 
 async function escolheLinhaQuente(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacaoAntesDoFim());
-  const bot = criarBot(1, 0);
+  const bot = criarBotLinhaQuente(1, 0);
 
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('4', '♦'));
 }
 async function escolheLinhaFria(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacao());
-  const bot = criarBot(0, 0);
+  const bot = criarBotLinhaQuente(0, 0);
 
   await expect(bot.decidirJogada(maoBifurcacao(), estado)).resolves.toEqual(criarCarta('3', '♦'));
 }
 async function usaPosicionamentoDeterministico(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
-  const bot = criarBot(1, 0);
+  const bot = criarBotLinhaQuente(1, 0);
 
   await expect(
     bot.decidirJogada([criarCarta('6', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')], estado),
@@ -50,7 +52,7 @@ async function usaPosicionamentoDeterministico(): Promise<void> {
 async function registraPosicionamentoDeterministico(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComQuatro(), declaracoes: { j1: 1, bot: 2 }, vazas: { j1: 0, bot: 0 } });
   const jogadas: DecisaoJogadaDebug[] = [];
-  const bot = criarBot(1, 0, {
+  const bot = criarBotLinhaQuente(1, 0, {
     registrarDeclaracao: () => undefined,
     registrarJogada: (jogada) => jogadas.push(jogada),
   });
@@ -64,7 +66,7 @@ async function registraPosicionamentoDeterministico(): Promise<void> {
 async function registraContratoExplicavel(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacaoAntesDoFim());
   const jogadas: DecisaoJogadaDebug[] = [];
-  const bot = criarBot(1, 0, {
+  const bot = criarBotLinhaQuente(1, 0, {
     registrarDeclaracao: () => undefined,
     registrarJogada: (jogada) => jogadas.push(jogada),
   });
@@ -87,7 +89,7 @@ async function registraContratoExplicavel(): Promise<void> {
     motivo: 'guarda de posição permitiu; jogadores por agir já cumpriram; precisa fazer; regra G[N-X]',
     caminho: ['jogada', 'joga no meio', 'linha fria', 'guarda de posição permitiu'],
   });
-  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'pressiona']);
   expect(jogadas[0]).toMatchObject(decisaoSorteadaLinhaQuente());
 }
 
@@ -100,7 +102,7 @@ async function empataAltaCumprido(): Promise<void> {
     declaracoes: { j1: 1, bot: 1 },
     vazas: { j1: 0, bot: 1 },
   });
-  const bot = criarBot(1, 0);
+  const bot = criarBotLinhaQuente(1, 0);
 
   await expect(bot.decidirJogada([criarCarta('2', '♦'), criarCarta('4', '♦')], estado)).resolves.toEqual(
     criarCarta('2', '♦'),
@@ -117,7 +119,7 @@ async function perdedoraComLiderMedia(): Promise<void> {
     vazas: { j1: 0, bot: 1 },
   });
   const mao = [criarCarta('9', '♦'), criarCarta('7', '♦')];
-  const bot = criarBot(1, 0);
+  const bot = criarBotLinhaQuente(1, 0);
   const fria = new DecisorJogadaLinhaFria();
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('7', '♦'));
@@ -134,7 +136,7 @@ async function respeitaTemperaturaZeroJaCumpriu(): Promise<void> {
     vazas: { j1: 0, bot: 1 },
   });
   const mao = [criarCarta('9', '♦'), criarCarta('7', '♦')];
-  const bot = criarBot(0, 0);
+  const bot = criarBotLinhaQuente(0, 0);
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(criarCarta('9', '♦'));
 }
@@ -151,7 +153,7 @@ async function registraSeguirFriaSemFuga(): Promise<void> {
   });
   const mao = [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')];
   const jogadas: DecisaoJogadaDebug[] = [];
-  const bot = criarBot(1, 0, {
+  const bot = criarBotLinhaQuente(1, 0, {
     registrarDeclaracao: () => undefined,
     registrarJogada: (jogada) => jogadas.push(jogada),
   });
@@ -165,7 +167,7 @@ async function registraSeguirFriaSemFuga(): Promise<void> {
 async function convergeSemPressao(): Promise<void> {
   const estado = criarEstado({ mesa: mesaComBaixa(), declaracoes: { j2: 1, bot: 1 }, vazas: { j2: 0, bot: 0 } });
   const mao = [criarCarta('A', '♦'), criarCarta('3', '♦')];
-  const bot = criarBot(1, 0);
+  const bot = criarBotLinhaQuente(1, 0);
   const fria = new DecisorJogadaLinhaFria();
 
   await expect(bot.decidirJogada(mao, estado)).resolves.toEqual(await fria.decidirJogada(mao, estado));
@@ -184,31 +186,13 @@ async function naoSorteiaSemBifurcacao(): Promise<void> {
   await bot.decidirJogada([criarCarta('A', '♦'), criarCarta('3', '♦')], estado);
 
   expect(random).not.toHaveBeenCalled();
-  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente']);
+  expect(jogadas[0]?.quente?.caminho).toEqual(['jogada', 'joga no meio', 'linha quente', 'segue fria']);
 }
 
 async function repeteEscolhaDeterministica(): Promise<void> {
   const estado = criarEstado(cenarioBifurcacao());
-  const primeiro = await criarBot(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
-  const segundo = await criarBot(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
+  const primeiro = await criarBotLinhaQuente(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
+  const segundo = await criarBotLinhaQuente(0.5, 0.4).decidirJogada(maoBifurcacao(), estado);
 
   expect(primeiro).toEqual(segundo);
-}
-
-function criarBot(temperatura: number, valorRng: number, logger?: LoggerDebugBot): DecisorJogadaLinhaQuente {
-  return new DecisorJogadaLinhaQuente({
-    temperatura,
-    rng: { random: () => valorRng },
-    logger,
-  });
-}
-
-function decisaoSorteadaLinhaQuente(): Partial<DecisaoJogadaDebug> {
-  return {
-    carta: criarCarta('4', '♦'),
-    linhaFria: criarCarta('3', '♦'),
-    linhaQuente: criarCarta('4', '♦'),
-    sorteio: 0,
-    escolheuQuente: true,
-  };
 }

--- a/tests/adapters/fixtures-espera-oportunidade.ts
+++ b/tests/adapters/fixtures-espera-oportunidade.ts
@@ -1,0 +1,83 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+export function cenarioEsperaOportunidade(): EstadoEmJogo {
+  return criarEstadoEspera({
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+    declaracoes: { j1: 1, j2: 1, bot: 1 },
+    vazas: { j1: 0, j2: 0, bot: 0 },
+    cartasReveladas: cartasQueGarantemTresDeOuros(),
+  });
+}
+
+export function maoEsperaOportunidade(): Carta[] {
+  return [criarCarta('3', '♦'), criarCarta('7', '♦')];
+}
+
+export const cenarioRecusaEsperaOportunidade = [
+  {
+    nome: 'não há necessidade',
+    estado: criarEstadoEspera({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+      declaracoes: { bot: 1 },
+      vazas: { bot: 1 },
+    }),
+    mao: [criarCarta('7', '♦'), criarCarta('9', '♦')],
+  },
+  {
+    nome: 'urgência é alta',
+    estado: criarEstadoEspera({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+      declaracoes: { bot: 2 },
+      vazas: { bot: 0 },
+    }),
+    mao: [criarCarta('7', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
+  },
+  {
+    nome: 'toda carta vence o líder',
+    estado: criarEstadoEspera({
+      mesa: [{ jogadorId: 'j1', carta: criarCarta('4', '♣') }],
+      declaracoes: { bot: 1 },
+      vazas: { bot: 0 },
+      manilha: '5',
+    }),
+    mao: [criarCarta('3', '♦'), criarCarta('6', '♦')],
+  },
+];
+
+function criarEstadoEspera(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = [
+    criarJogador('j1', 'J1'),
+    criarJogador('j2', 'J2'),
+    criarJogador('j3', 'J3'),
+    criarJogador('bot', 'Bot'),
+  ];
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}
+
+function cartasQueGarantemTresDeOuros(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('5', '♣'),
+    criarCarta('5', '♥'),
+    criarCarta('5', '♠'),
+    criarCarta('5', '♦'),
+  ];
+}

--- a/tests/adapters/fixtures-jogada-linha-quente.ts
+++ b/tests/adapters/fixtures-jogada-linha-quente.ts
@@ -1,7 +1,31 @@
+import { DecisorJogadaLinhaQuente } from '@/adapters/bots/DecisorJogadaLinhaQuente';
+import type { DecisaoJogadaDebug, LoggerDebugBot } from '@/adapters/bots/logger-debug-bot';
 import type { Carta } from '@/core/Carta';
 import type { Jogador } from '@/types/entidades';
 import type { EstadoEmJogo, MesaItem } from '@/types/estado-rodada';
 import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+export function criarBotLinhaQuente(
+  temperatura: number,
+  valorRng: number,
+  logger?: LoggerDebugBot,
+): DecisorJogadaLinhaQuente {
+  return new DecisorJogadaLinhaQuente({
+    temperatura,
+    rng: { random: () => valorRng },
+    logger,
+  });
+}
+
+export function decisaoSorteadaLinhaQuente(): Partial<DecisaoJogadaDebug> {
+  return {
+    carta: criarCarta('4', '♦'),
+    linhaFria: criarCarta('3', '♦'),
+    linhaQuente: criarCarta('4', '♦'),
+    sorteio: 0,
+    escolheuQuente: true,
+  };
+}
 
 export function criarEstado(config: Partial<EstadoEmJogo>): EstadoEmJogo {
   const jogadores = criarJogadores();

--- a/tests/adapters/fixtures-vencedora-segura.ts
+++ b/tests/adapters/fixtures-vencedora-segura.ts
@@ -1,0 +1,103 @@
+import type { Carta } from '@/core/Carta';
+import type { EstadoEmJogo } from '@/types/estado-rodada';
+import { criarCarta, criarJogador } from '../core/rodada-fixtures';
+
+export function criarEstadoVencedoraSegura(config: Partial<EstadoEmJogo> = {}): EstadoEmJogo {
+  return criarEstadoBase({
+    mesa: [{ jogadorId: 'j1', carta: criarCarta('2', '♣') }],
+    declaracoes: { j1: 1, j2: 1, bot: 1 },
+    vazas: { j1: 0, j2: 0, bot: 0 },
+    manilha: '8',
+    cartasReveladas: [],
+    ...config,
+  });
+}
+
+export function cenarioVencedoraSegura(): EstadoEmJogo {
+  return criarEstadoVencedoraSegura();
+}
+
+export function maoVencedoraSegura(): Carta[] {
+  return [criarCarta('3', '♦'), criarCarta('7', '♦')];
+}
+
+export function cartasReveladasGarantidaTres(): Carta[] {
+  return [
+    criarCarta('3', '♣'),
+    criarCarta('3', '♥'),
+    criarCarta('3', '♠'),
+    criarCarta('8', '♣'),
+    criarCarta('8', '♥'),
+    criarCarta('8', '♠'),
+    criarCarta('8', '♦'),
+  ];
+}
+
+export const cenarioRecusaVencedoraSegura = [
+  {
+    nome: 'não há necessidade',
+    estado: criarEstadoVencedoraSegura({ declaracoes: { j1: 1, j2: 1, bot: 1 }, vazas: { bot: 1 } }),
+    mao: maoVencedoraSegura(),
+  },
+  {
+    nome: 'urgência é alta',
+    estado: criarEstadoVencedoraSegura({ declaracoes: { j1: 1, j2: 1, bot: 2 }, vazas: { bot: 0 } }),
+    mao: [criarCarta('3', '♦'), criarCarta('7', '♦'), criarCarta('9', '♦')],
+  },
+  {
+    nome: 'existe garantida para depois',
+    estado: criarEstadoVencedoraSegura({
+      manilha: '8',
+      cartasReveladas: cartasReveladasGarantidaTres(),
+    }),
+    mao: [criarCarta('3', '♦'), criarCarta('7', '♦')],
+  },
+  {
+    nome: 'líder já cumpriu',
+    estado: criarEstadoVencedoraSegura({ vazas: { j1: 1 } }),
+    mao: maoVencedoraSegura(),
+  },
+  {
+    nome: 'líder não é alta+',
+    estado: criarEstadoVencedoraSegura({ mesa: [{ jogadorId: 'j1', carta: criarCarta('9', '♣') }] }),
+    mao: [criarCarta('Q', '♦'), criarCarta('7', '♦')],
+  },
+  {
+    nome: 'não há vencedora segura',
+    estado: criarEstadoVencedoraSegura({ cartasPorRodada: 8 }),
+    mao: [
+      criarCarta('3', '♦'),
+      criarCarta('7', '♦'),
+      criarCarta('6', '♦'),
+      criarCarta('5', '♠'),
+      criarCarta('4', '♥'),
+      criarCarta('9', '♣'),
+      criarCarta('J', '♠'),
+      criarCarta('Q', '♥'),
+    ],
+  },
+];
+
+function criarEstadoBase(config: Partial<EstadoEmJogo>): EstadoEmJogo {
+  const jogadores = [
+    criarJogador('j1', 'J1'),
+    criarJogador('j2', 'J2'),
+    criarJogador('j3', 'J3'),
+    criarJogador('bot', 'Bot'),
+  ];
+  return {
+    fase: 'aguardandoJogada',
+    jogadorAtual: 3,
+    pontos: {},
+    maos: jogadores.map((jogador) => ({ jogador, cartas: [], visivel: true })),
+    cartasPorRodada: 3,
+    manilha: '5',
+    cartaVirada: null,
+    declaracoes: {},
+    mesa: [],
+    cartasReveladas: [],
+    vazas: {},
+    turno: 1,
+    ...config,
+  };
+}

--- a/tests/adapters/pode-esperar-oportunidade.test.ts
+++ b/tests/adapters/pode-esperar-oportunidade.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
+import { decidirNaoUltimoLinhaFria } from '@/adapters/bots/DecisorJogadaLinhaFria';
+import { escolherEsperarOportunidade, podeEsperarOportunidade } from '@/adapters/bots/pode-esperar-oportunidade';
+import { criarCarta } from '../core/rodada-fixtures';
+import {
+  cenarioEsperaOportunidade,
+  cenarioRecusaEsperaOportunidade,
+  maoEsperaOportunidade,
+} from './fixtures-espera-oportunidade';
+
+describe('podeEsperarOportunidade recusa', () => {
+  it.each(cenarioRecusaEsperaOportunidade)('deve recusar quando $nome', ({ estado, mao }) => {
+    expect(podeEsperarOportunidade(criarContextoLinhaQuente(estado, mao))).toBe(false);
+  });
+});
+
+describe('podeEsperarOportunidade permite', () => {
+  it('deve permitir quando há carta que não faz a vaza', () => {
+    const estado = cenarioEsperaOportunidade();
+    const contexto = criarContextoLinhaQuente(estado, maoEsperaOportunidade());
+
+    expect(podeEsperarOportunidade(contexto)).toBe(true);
+    expect(escolherEsperarOportunidade(estado, contexto)).toEqual({
+      carta: criarCarta('7', '♦'),
+      motivo: 'espera oportunidade: descarte por necessidade',
+    });
+  });
+});
+
+describe('escolherEsperarOportunidade na linha fria', () => {
+  it('deve convergir com descarte por necessidade da linha fria', () => {
+    const estado = cenarioEsperaOportunidade();
+    const mao = maoEsperaOportunidade();
+
+    expect(escolherEsperarOportunidade(estado, criarContextoLinhaQuente(estado, mao))?.carta).toEqual(
+      criarCarta('7', '♦'),
+    );
+    expect(decidirNaoUltimoLinhaFria(mao, estado).carta).toEqual(criarCarta('7', '♦'));
+  });
+});

--- a/tests/adapters/pode-vencedora-segura.test.ts
+++ b/tests/adapters/pode-vencedora-segura.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { criarContextoLinhaQuente } from '@/adapters/bots/contextoLinhaQuente';
+import { existeGarantidaParaDepois } from '@/adapters/bots/garantida-para-depois';
+import { escolherVencedoraSegura, podeTentarComVencedoraSegura } from '@/adapters/bots/pode-vencedora-segura';
+import { criarCarta } from '../core/rodada-fixtures';
+import {
+  cenarioRecusaVencedoraSegura,
+  cenarioVencedoraSegura,
+  cartasReveladasGarantidaTres,
+  criarEstadoVencedoraSegura,
+  maoVencedoraSegura,
+} from './fixtures-vencedora-segura';
+
+describe('existeGarantidaParaDepois', () => {
+  it('deve detectar garantida_agora na mão', () => {
+    const estado = criarEstadoVencedoraSegura({
+      manilha: '8',
+      cartasReveladas: cartasReveladasGarantidaTres(),
+    });
+    const contexto = criarContextoLinhaQuente(estado, [criarCarta('3', '♦'), criarCarta('7', '♦')]);
+
+    expect(existeGarantidaParaDepois(contexto)).toBe(true);
+  });
+
+  it('deve retornar false sem garantida_agora na mão', () => {
+    const estado = criarEstadoVencedoraSegura({ cartasReveladas: [] });
+    const contexto = criarContextoLinhaQuente(estado, maoVencedoraSegura());
+
+    expect(existeGarantidaParaDepois(contexto)).toBe(false);
+  });
+});
+
+describe('podeTentarComVencedoraSegura recusa', () => {
+  it.each(cenarioRecusaVencedoraSegura)('deve recusar quando $nome', ({ estado, mao }) => {
+    expect(podeTentarComVencedoraSegura(estado, criarContextoLinhaQuente(estado, mao))).toBe(false);
+  });
+});
+
+describe('podeTentarComVencedoraSegura permite', () => {
+  it('deve permitir quando todos os critérios passam', () => {
+    const estado = cenarioVencedoraSegura();
+    const contexto = criarContextoLinhaQuente(estado, maoVencedoraSegura());
+
+    expect(podeTentarComVencedoraSegura(estado, contexto)).toBe(true);
+    expect(escolherVencedoraSegura(estado, contexto)).toEqual({
+      carta: criarCarta('3', '♦'),
+      motivo: 'vencedora segura: líder alta+ precisa, sem garantida para depois',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implementa os ramos `pode tentar com vencedora segura` e `pode esperar oportunidade` na cascata da Linha quente no meio, entre pressão e o fallback que segue a Linha fria.
- Extrai `existeGarantidaParaDepois` como helper compartilhado entre pressão e vencedora segura (mesmo fato, sinal invertido).
- Esclarece na documentação canônica (`docs/arvores-de-decisao-dos-bots.md`) a avaliação de `pode pressionar e esperar`, o eixo garantida para depois e quando o fallback `segue Linha fria` é alcançado.

Closes #216

## Correções pós-review

- **Alinha `vencedora segura` ao doc/protótipo:** removida a exigência de um jogador interessado *por agir* além do líder. `liderQuerVaza` já garante "existe jogador interessado", então a condição extra tornava o ramo mais estrito que a árvore canônica.
- **Corrige motivo de debug do fallback:** `segue fria` com `necessidade > 0` sob urgência alta não é "sem carta que não faz" (pode haver fuga). Agora registra `nenhum ramo se aplica`; o caso `necessidade <= 0` mantém "sem carta que não faz".
- **Remove código morto** `formatarMotivoRecusaBifurcacao` (sem chamadores após a nova cascata).
- **Deduplica** `cartaMaisBarata`/`cartaMaisCara` (por score) em `selecao-por-score.ts`, usados por `pode-atravessar`, `pode-vencedora-segura` e `regras-linha-quente`.
- **Cobertura nova:** teste do fallback `segue fria` sob urgência alta com carta de fuga presente.
- Doc atualizado: "existe jogador interessado" é subsumido por "líder atual ainda precisa fazer".

## Test plan

- [x] `pnpm test` — 727 testes passando
- [x] `pnpm typecheck` e `pnpm lint`
- [x] Revisar no deploy preview se o bot no meio escolhe pressão, vencedora segura ou espera conforme a mesa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot now evaluates "waiting for opportunity" as a decision strategy when conditions permit.
  * Bot now attempts "safe winner" moves with improved conditions evaluation.

* **Improvements**
  * Enhanced "hot line" bot decision-making flow with refined branching logic.
  * Consolidated card selection logic for consistency across decision modules.

* **Documentation**
  * Clarified "hot line" documentation regarding decision conditions and implicit constraints.

* **Tests**
  * Added comprehensive test coverage for new decision strategies and improved scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->