### PR TITLE
feat: unifica resolução final por temperatura dos bots (#218)

### DIFF
--- a/src/adapters/bots/DecisorJogadaBot.ts
+++ b/src/adapters/bots/DecisorJogadaBot.ts
@@ -5,7 +5,7 @@ import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/esta
 import { decidirAberturaLinhaFria, decidirAberturaLinhaQuente } from './decidirAbertura';
 import { DecisorJogadaLinhaQuente } from './DecisorJogadaLinhaQuente';
 import type { LoggerDebugBot } from './logger-debug-bot';
-import { registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
+import { resolverPorTemperatura } from './resolucao-por-temperatura';
 
 interface ConfigDecisorJogadaBot {
   temperatura: number;
@@ -17,10 +17,14 @@ interface ConfigDecisorJogadaBot {
 export class DecisorJogadaBot implements DecisorJogada {
   private readonly quente: DecisorJogadaLinhaQuente;
   private readonly logger?: LoggerDebugBot;
+  private readonly temperatura: number;
+  private readonly rng: Pick<GeradorAleatorio, 'random'>;
 
   constructor(config: ConfigDecisorJogadaBot) {
     this.quente = new DecisorJogadaLinhaQuente(config);
     this.logger = config.logger;
+    this.temperatura = config.temperatura;
+    this.rng = config.rng;
   }
 
   async decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -37,18 +41,14 @@ export class DecisorJogadaBot implements DecisorJogada {
   private decidirAbertura(mao: Carta[], estado: EstadoRodada, estadoAtual: EstadoEmJogo): Carta {
     const fria = decidirAberturaLinhaFria(mao, estadoAtual);
     const quente = decidirAberturaLinhaQuente(fria);
-    return registrarEscolhaDireta({
+    return resolverPorTemperatura({
       logger: this.logger,
+      temperatura: this.temperatura,
+      rng: this.rng,
       mao,
       estado,
-      carta: fria.carta,
-      linhaFria: fria.carta,
-      linhaQuente: quente.carta,
-      motivoLinhaFria: fria.motivo,
-      motivoLinhaQuente: quente.motivo,
-      caminhoLinhaFria: fria.caminho,
-      caminhoLinhaQuente: quente.caminho,
-      escolheuQuente: false,
+      fria,
+      quente,
     });
   }
 }

--- a/src/adapters/bots/DecisorJogadaLinhaQuente.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaQuente.ts
@@ -11,8 +11,8 @@ import type { LoggerDebugBot } from './logger-debug-bot';
 import { escolherTravessia } from './pode-atravessar';
 import { escolherEsperarOportunidade } from './pode-esperar-oportunidade';
 import { escolherVencedoraSegura } from './pode-vencedora-segura';
-import { registrarBifurcacao, registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
-import { cartasIguais, escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from './regras-linha-quente';
+import { escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from './regras-linha-quente';
+import { resolverPorTemperatura } from './resolucao-por-temperatura';
 
 interface ConfigLinhaQuente {
   temperatura: number;
@@ -85,23 +85,14 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private resolverBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {
-    if (cartasIguais(base.fria, quente.carta)) {
-      return this.registrarSemBifurcacao(base, quente);
-    }
-
-    const sorteio = this.rng.random();
-    return registrarBifurcacao({
+    return resolverPorTemperatura({
       logger: this.logger,
       temperatura: this.temperatura,
+      rng: this.rng,
       mao: base.mao,
       estado: base.estado,
-      fria: base.fria,
-      quente: quente.carta,
-      motivoLinhaFria: base.motivoLinhaFria,
-      motivoLinhaQuente: quente.motivo,
-      caminhoLinhaFria: base.caminhoLinhaFria,
-      caminhoLinhaQuente: quente.caminho,
-      sorteio,
+      fria: { carta: base.fria, motivo: base.motivoLinhaFria, caminho: base.caminhoLinhaFria },
+      quente: { carta: quente.carta, motivo: quente.motivo, caminho: quente.caminho },
     });
   }
 
@@ -126,26 +117,11 @@ export class DecisorJogadaLinhaQuente implements DecisorJogada {
   }
 
   private registrarSeguirFria(base: BaseJogada, motivo: string): Carta {
-    return this.registrarSemBifurcacao(
-      base,
-      criarDecisaoQuente({ carta: base.fria, motivo }, criarCaminhoJogadaDebug(base.posicao, 'quente', 'segue fria')),
+    const quente = criarDecisaoQuente(
+      { carta: base.fria, motivo },
+      criarCaminhoJogadaDebug(base.posicao, 'quente', 'segue fria'),
     );
-  }
-
-  private registrarSemBifurcacao(base: BaseJogada, quente: DecisaoQuente): Carta {
-    return registrarEscolhaDireta({
-      logger: this.logger,
-      mao: base.mao,
-      estado: base.estado,
-      carta: quente.carta,
-      linhaFria: base.fria,
-      linhaQuente: quente.carta,
-      motivoLinhaFria: base.motivoLinhaFria,
-      motivoLinhaQuente: quente.motivo,
-      caminhoLinhaFria: base.caminhoLinhaFria,
-      caminhoLinhaQuente: quente.caminho,
-      escolheuQuente: false,
-    });
+    return this.resolverBifurcacao(base, quente);
   }
 }
 

--- a/src/adapters/bots/registrar-decisao-jogada-bot.ts
+++ b/src/adapters/bots/registrar-decisao-jogada-bot.ts
@@ -15,20 +15,7 @@ interface EscolhaDireta {
   caminhoLinhaFria: string[];
   caminhoLinhaQuente: string[];
   escolheuQuente: boolean;
-}
-
-interface Bifurcacao {
-  logger?: LoggerDebugBot;
-  temperatura: number;
-  mao: Carta[];
-  estado: EstadoRodada;
-  fria: Carta;
-  quente: Carta;
-  motivoLinhaFria?: string;
-  motivoLinhaQuente?: string;
-  caminhoLinhaFria: string[];
-  caminhoLinhaQuente: string[];
-  sorteio: number;
+  sorteio?: number;
 }
 
 export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
@@ -48,26 +35,7 @@ export function registrarEscolhaDireta(config: EscolhaDireta): Carta {
     motivoLinhaQuente: config.motivoLinhaQuente,
     carta: config.carta,
     escolheuQuente: config.escolheuQuente,
-  });
-  return config.carta;
-}
-
-export function registrarBifurcacao(config: Bifurcacao): Carta {
-  const escolheuQuente = config.sorteio < config.temperatura;
-  const carta = escolheuQuente ? config.quente : config.fria;
-  config.logger?.registrarJogada({
-    mao: config.mao,
-    estado: config.estado,
-    linhaFria: config.fria,
-    linhaQuente: config.quente,
-    contexto: criarContextoJogadaDebug(config.estado, config.mao.length),
-    fria: criarLinhaJogadaDebug(config.fria, config.motivoLinhaFria, config.caminhoLinhaFria),
-    quente: criarLinhaJogadaDebug(config.quente, config.motivoLinhaQuente, config.caminhoLinhaQuente),
-    motivoLinhaFria: config.motivoLinhaFria,
-    motivoLinhaQuente: config.motivoLinhaQuente,
-    carta,
-    escolheuQuente,
     sorteio: config.sorteio,
   });
-  return carta;
+  return config.carta;
 }

--- a/src/adapters/bots/resolucao-por-temperatura.ts
+++ b/src/adapters/bots/resolucao-por-temperatura.ts
@@ -1,0 +1,49 @@
+import type { Carta } from '@/core/Carta';
+import type { GeradorAleatorio } from '@/core/RngComSeed';
+import type { EstadoRodada } from '@/types/estado-rodada';
+import type { LoggerDebugBot } from './logger-debug-bot';
+import { registrarEscolhaDireta } from './registrar-decisao-jogada-bot';
+import { cartasIguais } from './regras-linha-quente';
+
+export interface RecomendacaoLinha {
+  carta: Carta;
+  motivo: string;
+  caminho: string[];
+}
+
+export interface ConfigResolucao {
+  logger?: LoggerDebugBot;
+  temperatura: number;
+  rng: Pick<GeradorAleatorio, 'random'>;
+  mao: Carta[];
+  estado: EstadoRodada;
+  fria: RecomendacaoLinha;
+  quente: RecomendacaoLinha;
+}
+
+export function resolverPorTemperatura(config: ConfigResolucao): Carta {
+  if (cartasIguais(config.fria.carta, config.quente.carta)) {
+    return registrarEscolhaDireta(criarRegistro(config, config.fria.carta, false));
+  }
+
+  const sorteio = config.rng.random();
+  const escolheuQuente = sorteio < config.temperatura;
+  const carta = escolheuQuente ? config.quente.carta : config.fria.carta;
+  return registrarEscolhaDireta({ ...criarRegistro(config, carta, escolheuQuente), sorteio });
+}
+
+function criarRegistro(config: ConfigResolucao, carta: Carta, escolheuQuente: boolean) {
+  return {
+    logger: config.logger,
+    mao: config.mao,
+    estado: config.estado,
+    carta,
+    linhaFria: config.fria.carta,
+    linhaQuente: config.quente.carta,
+    motivoLinhaFria: config.fria.motivo,
+    motivoLinhaQuente: config.quente.motivo,
+    caminhoLinhaFria: config.fria.caminho,
+    caminhoLinhaQuente: config.quente.caminho,
+    escolheuQuente,
+  };
+}

--- a/tests/adapters/resolucao-por-temperatura.test.ts
+++ b/tests/adapters/resolucao-por-temperatura.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DecisaoJogadaDebug } from '@/adapters/bots/logger-debug-bot';
+import { resolverPorTemperatura } from '@/adapters/bots/resolucao-por-temperatura';
+import type { Carta } from '@/core/Carta';
+import type { EstadoRodada } from '@/types/estado-rodada';
+import { criarCarta } from '../core/rodada-fixtures';
+
+describe('resolucao-por-temperatura', () => {
+  it('deve jogar a carta sem sortear quando as linhas convergem', linhasIguais);
+  it('deve jogar linha quente quando sorteio cai abaixo da temperatura', sorteioEscolheQuente);
+  it('deve jogar linha fria quando sorteio não cai abaixo da temperatura', sorteioEscolheFria);
+  it('deve manter a recomendação da linha quente independente da temperatura', temperaturaNaoAlteraQuente);
+});
+
+function linhasIguais(): void {
+  const carta = criarCarta('4', '♦');
+  const random = vi.fn(() => 0);
+  const jogadas: DecisaoJogadaDebug[] = [];
+
+  const resultado = resolverPorTemperatura({
+    temperatura: 1,
+    rng: { random },
+    mao: [carta],
+    estado: criarEstado(),
+    fria: recomendacao(carta, 'fria'),
+    quente: recomendacao(carta, 'quente'),
+    logger: loggerCapturador(jogadas),
+  });
+
+  expect(resultado).toEqual(carta);
+  expect(random).not.toHaveBeenCalled();
+  expect(jogadas[0]).toMatchObject({ carta, escolheuQuente: false });
+  expect(jogadas[0]?.sorteio).toBeUndefined();
+}
+
+function sorteioEscolheQuente(): void {
+  const fria = criarCarta('3', '♦');
+  const quente = criarCarta('4', '♦');
+  const jogadas: DecisaoJogadaDebug[] = [];
+
+  const resultado = resolverPorTemperatura({
+    temperatura: 0.5,
+    rng: { random: () => 0.2 },
+    mao: [fria, quente],
+    estado: criarEstado(),
+    fria: recomendacao(fria, 'fria'),
+    quente: recomendacao(quente, 'quente'),
+    logger: loggerCapturador(jogadas),
+  });
+
+  expect(resultado).toEqual(quente);
+  expect(jogadas[0]).toMatchObject({ carta: quente, escolheuQuente: true, sorteio: 0.2 });
+}
+
+function sorteioEscolheFria(): void {
+  const fria = criarCarta('3', '♦');
+  const quente = criarCarta('4', '♦');
+  const jogadas: DecisaoJogadaDebug[] = [];
+
+  const resultado = resolverPorTemperatura({
+    temperatura: 0.5,
+    rng: { random: () => 0.8 },
+    mao: [fria, quente],
+    estado: criarEstado(),
+    fria: recomendacao(fria, 'fria'),
+    quente: recomendacao(quente, 'quente'),
+    logger: loggerCapturador(jogadas),
+  });
+
+  expect(resultado).toEqual(fria);
+  expect(jogadas[0]).toMatchObject({ carta: fria, escolheuQuente: false, sorteio: 0.8 });
+}
+
+function temperaturaNaoAlteraQuente(): void {
+  const fria = criarCarta('3', '♦');
+  const quente = criarCarta('4', '♦');
+  const recomendacaoQuente = recomendacao(quente, 'pressão: vencedora barata');
+  const configBase = {
+    mao: [fria, quente],
+    estado: criarEstado(),
+    fria: recomendacao(fria, 'fria'),
+    quente: recomendacaoQuente,
+  };
+
+  const comTemperaturaZero = resolverComTemperatura(0, 0.5, configBase);
+  const comTemperaturaUm = resolverComTemperatura(1, 0.5, configBase);
+
+  expect(comTemperaturaZero.jogadas[0]?.quente).toEqual(comTemperaturaUm.jogadas[0]?.quente);
+  expect(comTemperaturaZero.jogadas[0]?.motivoLinhaQuente).toBe(comTemperaturaUm.jogadas[0]?.motivoLinhaQuente);
+}
+
+function resolverComTemperatura(
+  temperatura: number,
+  sorteio: number,
+  config: Omit<Parameters<typeof resolverPorTemperatura>[0], 'temperatura' | 'rng' | 'logger'>,
+) {
+  const jogadas: DecisaoJogadaDebug[] = [];
+  const carta = resolverPorTemperatura({
+    ...config,
+    temperatura,
+    rng: { random: () => sorteio },
+    logger: loggerCapturador(jogadas),
+  });
+  return { carta, jogadas };
+}
+
+function recomendacao(carta: Carta, motivo: string) {
+  return { carta, motivo, caminho: ['jogada', motivo] };
+}
+
+function loggerCapturador(jogadas: DecisaoJogadaDebug[]) {
+  return {
+    registrarDeclaracao: () => undefined,
+    registrarJogada: (jogada: DecisaoJogadaDebug) => jogadas.push(jogada),
+  };
+}
+
+function criarEstado(): EstadoRodada {
+  return {
+    fase: 'aguardandoJogada',
+    pontos: { bot: 5 },
+    cartasPorRodada: 2,
+    jogadorAtual: 0,
+    cartaVirada: null,
+    manilha: '5',
+    maos: [{ jogador: { id: 'bot', nome: 'Bot', pontos: 5 }, cartas: [], visivel: true }],
+    mesa: [],
+    declaracoes: { bot: 1 },
+    vazas: { bot: 0 },
+    cartasReveladas: [],
+    turno: 1,
+  };
+}


### PR DESCRIPTION
## Summary

- Extrai `resolverPorTemperatura` como passo único de resolução entre Linha fria e Linha quente.
- Roteia abertura (`DecisorJogadaBot`) e reação (`DecisorJogadaLinhaQuente`) pelo mesmo módulo; remove `registrarBifurcacao`.
- Adiciona testes Vitest com os quatro cenários de aceite da issue #218.

## Test plan

- [x] `pnpm test` — 731 testes passando
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Validar no deploy preview que o debug de jogada continua exibindo bifurcação e sorteio corretamente

Closes #218


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temperature-based resolution system for bot card selection decisions
  * Enhanced decision logging with optional random draw tracking

* **Refactor**
  * Consolidated decision-making logic across bot adapters to use centralized temperature resolver

* **Tests**
  * Added test suite covering temperature-based resolution scenarios and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dhinihan/fdp-online/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->