### PR TITLE
docs: Leitura da Mesa + limite de arquivo 200→500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ src/
 - **Idioma do código**: Português brasileiro. Nomes de variáveis, funções, classes em PT-BR.
 - **Idioma da interface**: PT-BR, EN, ES (i18n).
 - **Complexidade máxima**: 10 (cyclomatic).
-- **Tamanho máximo**: 200 linhas/arquivo, 30 linhas/função, 3 parâmetros/função.
+- **Tamanho máximo**: 500 linhas/arquivo, 30 linhas/função, 3 parâmetros/função.
 - **Sem any implícito**. TypeScript estrito.
 
 ---

--- a/ARQUITETURA.md
+++ b/ARQUITETURA.md
@@ -139,7 +139,7 @@ Eventos principais:
 
 | Ferramenta                     | Regra / Propósito                                                                          |
 | ------------------------------ | ------------------------------------------------------------------------------------------ |
-| **ESLint + typescript-eslint** | Complexidade máxima: 10, arquivo máx: 200 linhas, função máx: 30 linhas, parâmetros máx: 3 |
+| **ESLint + typescript-eslint** | Complexidade máxima: 10, arquivo máx: 500 linhas, função máx: 30 linhas, parâmetros máx: 3 |
 | **Prettier**                   | Formatação automática                                                                      |
 | **Knip**                       | Detecta dependências e código morto                                                        |
 | **Dependabot**                 | Atualiza dependências automaticamente (PRs)                                                |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: Ordem, vez
 Jogador que ainda não jogou carta no turno atual.
 _Avoid_: Próximo jogador, jogador restante
 
+**Leitura da Mesa**:
+Snapshot dos fatos derivados que uma **Decisão de Jogada do Bot** precisa para escolher a carta: **Feito** ainda necessário, urgência, cartas avaliadas, vencedoras/perdedoras/empates em relação à carta líder, a própria carta líder, **Jogadores por agir** e interessados, e se há alvo na mesa. Calculada uma vez por decisão e consumida igual pela **Linha fria** e pela **Linha quente**.
+_Avoid_: Contexto, estado do bot, ContextoJogadaQuente
+
 **Carta alta+**:
 Carta cuja categoria estratégica é **alta**, **segura** ou **garantida_agora**.
 _Avoid_: Limiar numérico de força, valor alto
@@ -106,6 +110,7 @@ _Avoid_: Lista manual de valores, carta forte absoluta
 - Uma **Árvore de Decisão do Bot** pode ter uma **Linha fria** e uma **Linha quente** para a mesma decisão.
 - Uma **Estratégia de Bot Explicável** inclui **Decisões de Declaração do Bot** e **Decisões de Jogada do Bot**.
 - Uma **Decisão de Jogada do Bot** pode usar **Escolha de vencedora por necessidade** ou **Descarte por necessidade**.
+- Uma **Decisão de Jogada do Bot** parte de uma **Leitura da Mesa** única, compartilhada pela **Linha fria** e pela **Linha quente**.
 - Uma **Decisão de Jogada do Bot** considera a **Posição na Mesa** antes de avaliar a força da carta.
 - Uma **Decisão de Jogada do Bot** no meio da mesa considera se há **Jogadores por agir** que ainda precisam fazer ou já cumpriram.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,7 @@ export default defineConfig(
     },
     rules: {
       complexity: ['error', 10],
-      'max-lines': ['error', { max: 200, skipBlankLines: true, skipComments: true }],
+      'max-lines': ['error', { max: 500, skipBlankLines: true, skipComments: true }],
       'max-lines-per-function': ['error', { max: 30, skipBlankLines: true, skipComments: true }],
       'max-params': ['error', 3],
       'no-console': 'warn',


### PR DESCRIPTION
## O que muda

Mudanças só de documentação e configuração, preparando o deepening da árvore de decisão dos bots (`src/adapters/bots/`).

- **CONTEXT.md** — novo termo de domínio **Leitura da Mesa**: o snapshot único dos fatos derivados que uma Decisão de Jogada do Bot precisa (necessidade, urgência, vencedoras/perdedoras/empates, líder, jogadores por agir/interessados, alvo), consumido igual pela Linha fria e pela Linha quente. Inclui uma relação na seção Relationships.
- **eslint.config.js** — `max-lines` de **200 → 500**.
- **ARQUITETURA.md** — tabela de qualidade atualizada para refletir o novo limite.

## Por quê

A árvore de decisão dos bots está fragmentada em ~22 módulos rasos; consolidá-los em módulos profundos (uma `Leitura da Mesa`, um `decidirLinhaQuente`) exige arquivos maiores que 200 linhas. Subir o limite para 500 viabiliza essa consolidação sem re-split artificial. O termo de domínio nomeia o seam que as duas linhas leem.

Plano de implementação detalhado vem em issue separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)