### PR TITLE
refactor(bots): trilha de debug centralizada (issue #234 — slice 4)

### DIFF
--- a/src/adapters/bots/DecisorJogadaLinhaFria.ts
+++ b/src/adapters/bots/DecisorJogadaLinhaFria.ts
@@ -3,7 +3,6 @@ import type { Carta } from '@/core/Carta';
 import type { DecisorJogada } from '@/core/portas/DecisorJogada';
 import { estadoEmJogo, type EstadoEmJogo, type EstadoRodada } from '@/types/estado-rodada';
 import { ehUltimoDaMesa } from './contexto-posicao-mesa';
-import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 import { decidirAberturaLinhaFria } from './decidirAbertura';
 import { cartaMaisForte, descartePorNecessidade, escolherVencedoraPorNecessidade } from './escolhas-por-necessidade';
 import { avaliarGuardaDePosicao, type GuardaPosicao } from './guarda-posicao';
@@ -12,10 +11,8 @@ import { cartasQueNaoFazemVaza, lerMesa, type LeituraDaMesa } from './ler-mesa';
 export interface DecisaoLinhaFria {
   carta: Carta;
   motivo: string;
-  caminho?: string[];
+  etapa: string;
 }
-
-const CAMINHO_MEIO = ['jogada', 'joga no meio', 'linha fria'] as const;
 
 export class DecisorJogadaLinhaFria implements DecisorJogada {
   decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
@@ -38,12 +35,19 @@ export function decidirNaoUltimoLinhaFria(leitura: LeituraDaMesa, estado: Estado
 }
 
 function fugirNaoUltimo(leitura: LeituraDaMesa): DecisaoLinhaFria {
-  const caminho = criarCaminhoJogadaDebug('meio', 'fria', 'já cumpriu');
   const naoFazem = cartasQueNaoFazemVaza(leitura);
   if (naoFazem.length === 0) {
-    return { carta: cartaMaisBarata(leitura.avaliadas).carta, motivo: 'já cumpriu; fuga impossível', caminho };
+    return {
+      carta: cartaMaisBarata(leitura.avaliadas).carta,
+      motivo: 'já cumpriu; fuga impossível',
+      etapa: 'já cumpriu',
+    };
   }
-  return { carta: cartaMaisCara(naoFazem).carta, motivo: 'já cumpriu; carta mais alta que não faz', caminho };
+  return {
+    carta: cartaMaisCara(naoFazem).carta,
+    motivo: 'já cumpriu; carta mais alta que não faz',
+    etapa: 'já cumpriu',
+  };
 }
 
 function buscarVazaNaoUltimo(leitura: LeituraDaMesa, estado: EstadoEmJogo): DecisaoLinhaFria {
@@ -61,12 +65,12 @@ interface ContextoBuscaVaza {
 
 function decidirComGuardaPermitida(contexto: ContextoBuscaVaza): DecisaoLinhaFria {
   const { estado, leitura, guarda } = contexto;
-  const caminho = [...CAMINHO_MEIO, 'guarda de posição permitiu'];
+  const etapa = 'guarda de posição permitiu';
   if (leitura.vencedoras.length > 0) {
     return {
       carta: escolherVencedoraPorNecessidade(leitura.vencedoras, estado.manilha, leitura.necessidade).carta,
       motivo: motivoGuardaPermitiu(guarda.motivo, 'precisa fazer; regra G[N-X]'),
-      caminho,
+      etapa,
     };
   }
 
@@ -75,31 +79,31 @@ function decidirComGuardaPermitida(contexto: ContextoBuscaVaza): DecisaoLinhaFri
     return {
       carta: descartePorNecessidade(naoFazem, estado.manilha, leitura.necessidade).carta,
       motivo: motivoGuardaPermitiu(guarda.motivo, 'precisa fazer; regra P[N-X]'),
-      caminho,
+      etapa,
     };
   }
   return {
     carta: cartaMaisBarata(leitura.avaliadas).carta,
     motivo: motivoGuardaPermitiu(guarda.motivo, 'precisa fazer; carta mais barata'),
-    caminho,
+    etapa,
   };
 }
 
 function descartarComGuardaBloqueada(contexto: ContextoBuscaVaza): DecisaoLinhaFria {
   const { estado, leitura, guarda } = contexto;
-  const caminho = [...CAMINHO_MEIO, 'guarda de posição bloqueou'];
+  const etapa = 'guarda de posição bloqueou';
   const naoFazem = cartasQueNaoFazemVaza(leitura);
   if (naoFazem.length > 0) {
     return {
       carta: descartePorNecessidade(naoFazem, estado.manilha, leitura.necessidade).carta,
       motivo: motivoGuardaBloqueou(guarda.motivo),
-      caminho,
+      etapa,
     };
   }
   return {
     carta: cartaMaisBarata(leitura.avaliadas).carta,
     motivo: `${motivoGuardaBloqueou(guarda.motivo)}; fuga impossível`,
-    caminho,
+    etapa,
   };
 }
 
@@ -117,37 +121,35 @@ export function decidirUltimoLinhaFria(leitura: LeituraDaMesa, estado: EstadoEmJ
 }
 
 function decidirUltimoQuandoPrecisaFazer(leitura: LeituraDaMesa, estado: EstadoEmJogo): DecisaoLinhaFria {
-  const caminho = criarCaminhoJogadaDebug('fecha', 'fria', 'precisa fazer');
   if (leitura.vencedoras.length > 0) {
     return {
       carta: escolherVencedoraPorNecessidade(leitura.vencedoras, estado.manilha, leitura.necessidade).carta,
       motivo: 'precisa fazer; regra G[N-X]',
-      caminho,
+      etapa: 'precisa fazer',
     };
   }
 
   return {
     carta: descartePorNecessidade(cartasQueNaoFazemVaza(leitura), estado.manilha, leitura.necessidade).carta,
     motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
-    caminho,
+    etapa: 'precisa fazer',
   };
 }
 
 function decidirUltimoQuandoJaCumpriu(leitura: LeituraDaMesa, estado: EstadoEmJogo): DecisaoLinhaFria {
-  const caminho = criarCaminhoJogadaDebug('fecha', 'fria', 'já cumpriu');
   const naoFazem = cartasQueNaoFazemVaza(leitura);
   if (naoFazem.length > 0) {
     return {
       carta: cartaMaisForte(naoFazem, estado.manilha).carta,
       motivo: 'já cumpriu; carta mais forte que não faz',
-      caminho,
+      etapa: 'já cumpriu',
     };
   }
 
   return {
     carta: cartaMaisForte(leitura.avaliadas, estado.manilha).carta,
     motivo: 'já cumpriu; fuga impossível',
-    caminho,
+    etapa: 'já cumpriu',
   };
 }
 

--- a/src/adapters/bots/DecisorJogadaPorTemperatura.ts
+++ b/src/adapters/bots/DecisorJogadaPorTemperatura.ts
@@ -38,7 +38,7 @@ export class DecisorJogadaPorTemperatura implements DecisorJogada {
     const leitura = lerMesa(estadoAtual, mao);
     const posicao = definirPosicao(estadoAtual);
     const fria = decidirLinhaFriaPorPosicao(posicao, leitura, estadoAtual);
-    const recomendacaoFria = montarRecomendacaoFria(posicao, fria);
+    const recomendacaoFria = montarRecomendacaoLinha(posicao, 'fria', fria);
     const quente = montarRecomendacaoQuente(
       posicao,
       decidirLinhaQuente({ posicao, estado: estadoAtual, leitura, liderBaixa: this.liderBaixa }),
@@ -69,11 +69,15 @@ function decidirLinhaFriaPorPosicao(
   return decidirNaoUltimoLinhaFria(leitura, estadoAtual);
 }
 
-function montarRecomendacaoFria(posicao: PosicaoMesaJogadaDebug, fria: DecisaoLinhaFria): RecomendacaoLinha {
+function montarRecomendacaoLinha(
+  posicao: PosicaoMesaJogadaDebug,
+  linha: 'fria' | 'quente',
+  decisao: { carta: Carta; motivo: string; etapa: string },
+): RecomendacaoLinha {
   return {
-    carta: fria.carta,
-    motivo: fria.motivo,
-    caminho: fria.caminho ?? criarCaminhoJogadaDebug(posicao, 'fria'),
+    carta: decisao.carta,
+    motivo: decisao.motivo,
+    caminho: criarCaminhoJogadaDebug(posicao, linha, etapaOpcional(decisao.etapa)),
   };
 }
 
@@ -83,18 +87,16 @@ function montarRecomendacaoQuente(
   fria: RecomendacaoLinha,
 ): RecomendacaoLinha {
   if (resultado.tipo === 'segue-fria') {
-    const etapaAbertura = posicao === 'abre' ? 'segue linha fria' : 'segue fria';
-    return {
+    return montarRecomendacaoLinha(posicao, 'quente', {
       carta: fria.carta,
       motivo: resultado.motivo,
-      caminho: criarCaminhoJogadaDebug(posicao, 'quente', etapaAbertura),
-    };
+      etapa: resultado.etapa,
+    });
   }
 
-  const etapa = resultado.etapa || undefined;
-  return {
-    carta: resultado.carta,
-    motivo: resultado.motivo,
-    caminho: criarCaminhoJogadaDebug(posicao, 'quente', etapa),
-  };
+  return montarRecomendacaoLinha(posicao, 'quente', resultado);
+}
+
+function etapaOpcional(etapa: string): string | undefined {
+  return etapa || undefined;
 }

--- a/src/adapters/bots/DecisorJogadaPorTemperatura.ts
+++ b/src/adapters/bots/DecisorJogadaPorTemperatura.ts
@@ -31,8 +31,8 @@ export class DecisorJogadaPorTemperatura implements DecisorJogada {
     this.logger = config.logger;
   }
 
-  async decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
-    if (mao.length === 0) throw new Error('Mão vazia');
+  decidirJogada(mao: Carta[], estado: EstadoRodada): Promise<Carta> {
+    if (mao.length === 0) return Promise.reject(new Error('Mão vazia'));
 
     const estadoAtual = estadoEmJogo(estado);
     const leitura = lerMesa(estadoAtual, mao);
@@ -45,7 +45,7 @@ export class DecisorJogadaPorTemperatura implements DecisorJogada {
       recomendacaoFria,
     );
 
-    return await Promise.resolve(
+    return Promise.resolve(
       resolverPorTemperatura({
         logger: this.logger,
         temperatura: this.temperatura,
@@ -72,12 +72,12 @@ function decidirLinhaFriaPorPosicao(
 function montarRecomendacaoLinha(
   posicao: PosicaoMesaJogadaDebug,
   linha: 'fria' | 'quente',
-  decisao: { carta: Carta; motivo: string; etapa: string },
+  decisao: { carta: Carta; motivo: string; etapa?: string },
 ): RecomendacaoLinha {
   return {
     carta: decisao.carta,
     motivo: decisao.motivo,
-    caminho: criarCaminhoJogadaDebug(posicao, linha, etapaOpcional(decisao.etapa)),
+    caminho: criarCaminhoJogadaDebug(posicao, linha, decisao.etapa),
   };
 }
 
@@ -95,8 +95,4 @@ function montarRecomendacaoQuente(
   }
 
   return montarRecomendacaoLinha(posicao, 'quente', resultado);
-}
-
-function etapaOpcional(etapa: string): string | undefined {
-  return etapa || undefined;
 }

--- a/src/adapters/bots/debug-linha-quente.ts
+++ b/src/adapters/bots/debug-linha-quente.ts
@@ -1,20 +1,9 @@
-import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { ehUltimoDaMesa } from './contexto-posicao-mesa';
 import type { PosicaoMesaJogadaDebug } from './debug-jogada-bot';
-
-export interface DecisaoQuente {
-  carta: Carta;
-  motivo: string;
-  caminho: string[];
-}
 
 export function definirPosicao(estado: EstadoEmJogo): PosicaoMesaJogadaDebug {
   if (estado.mesa.length === 0) return 'abre';
   if (ehUltimoDaMesa(estado)) return 'fecha';
   return 'meio';
-}
-
-export function criarDecisaoQuente(decisao: { carta: Carta; motivo: string }, caminho: string[]): DecisaoQuente {
-  return { ...decisao, caminho };
 }

--- a/src/adapters/bots/decidir-linha-quente.ts
+++ b/src/adapters/bots/decidir-linha-quente.ts
@@ -1,7 +1,7 @@
 import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import type { PosicaoMesaJogadaDebug } from './debug-jogada-bot';
-import { MOTIVO_ABERTURA_LINHA_QUENTE } from './decidirAbertura';
+import { ETAPA_ABERTURA_SEGUE_FRIA, MOTIVO_ABERTURA_LINHA_QUENTE } from './decidirAbertura';
 import { decidirUltimoLinhaQuente } from './decidirUltimoLinhaQuente';
 import type { LeituraDaMesa } from './ler-mesa';
 import { escolherTravessia } from './pode-atravessar';
@@ -9,9 +9,11 @@ import { escolherEsperarOportunidade } from './pode-esperar-oportunidade';
 import { escolherVencedoraSegura } from './pode-vencedora-segura';
 import { escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from './regras-linha-quente';
 
+export const ETAPA_SEGUE_FRIA = 'segue fria';
+
 export type ResultadoQuente =
   | { tipo: 'recomenda'; carta: Carta; motivo: string; etapa: string }
-  | { tipo: 'segue-fria'; motivo: string };
+  | { tipo: 'segue-fria'; motivo: string; etapa: string };
 
 export interface EntradaDecidirLinhaQuente {
   posicao: PosicaoMesaJogadaDebug;
@@ -21,7 +23,9 @@ export interface EntradaDecidirLinhaQuente {
 }
 
 export function decidirLinhaQuente(entrada: EntradaDecidirLinhaQuente): ResultadoQuente {
-  if (entrada.posicao === 'abre') return { tipo: 'segue-fria', motivo: MOTIVO_ABERTURA_LINHA_QUENTE };
+  if (entrada.posicao === 'abre') {
+    return { tipo: 'segue-fria', motivo: MOTIVO_ABERTURA_LINHA_QUENTE, etapa: ETAPA_ABERTURA_SEGUE_FRIA };
+  }
   if (entrada.posicao === 'fecha') return decidirFecha(entrada.estado, entrada.leitura);
   return decidirMeio(entrada.estado, entrada.leitura, entrada.liderBaixa);
 }
@@ -51,7 +55,7 @@ function decidirMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa, liderBaixa: n
     return { tipo: 'recomenda', ...espera, etapa: 'espera oportunidade' };
   }
 
-  return { tipo: 'segue-fria', motivo: 'linha quente segue fria: nenhum ramo se aplica' };
+  return { tipo: 'segue-fria', motivo: 'linha quente segue fria: nenhum ramo se aplica', etapa: ETAPA_SEGUE_FRIA };
 }
 
 function tentarRamoDiretoMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa): ResultadoQuente | null {
@@ -64,5 +68,5 @@ function tentarRamoDiretoMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa): Res
 function tentarJaCumpriuNoMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa): ResultadoQuente {
   const jaCumpriu = escolherJaCumpriuNoMeio(estado, leitura);
   if (jaCumpriu) return { tipo: 'recomenda', ...jaCumpriu, etapa: '' };
-  return { tipo: 'segue-fria', motivo: 'linha quente segue fria: sem carta que não faz' };
+  return { tipo: 'segue-fria', motivo: 'linha quente segue fria: sem carta que não faz', etapa: ETAPA_SEGUE_FRIA };
 }

--- a/src/adapters/bots/decidir-linha-quente.ts
+++ b/src/adapters/bots/decidir-linha-quente.ts
@@ -12,7 +12,7 @@ import { escolherJaCumpriuNoMeio, escolherPressao, podeBifurcar } from './regras
 export const ETAPA_SEGUE_FRIA = 'segue fria';
 
 export type ResultadoQuente =
-  | { tipo: 'recomenda'; carta: Carta; motivo: string; etapa: string }
+  | { tipo: 'recomenda'; carta: Carta; motivo: string; etapa?: string }
   | { tipo: 'segue-fria'; motivo: string; etapa: string };
 
 export interface EntradaDecidirLinhaQuente {
@@ -32,7 +32,7 @@ export function decidirLinhaQuente(entrada: EntradaDecidirLinhaQuente): Resultad
 
 function decidirFecha(estado: EstadoEmJogo, leitura: LeituraDaMesa): ResultadoQuente {
   const decisao = decidirUltimoLinhaQuente(estado, leitura);
-  return { tipo: 'recomenda', carta: decisao.carta, motivo: decisao.motivo, etapa: '' };
+  return { tipo: 'recomenda', carta: decisao.carta, motivo: decisao.motivo };
 }
 
 function decidirMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa, liderBaixa: number): ResultadoQuente {
@@ -67,6 +67,6 @@ function tentarRamoDiretoMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa): Res
 
 function tentarJaCumpriuNoMeio(estado: EstadoEmJogo, leitura: LeituraDaMesa): ResultadoQuente {
   const jaCumpriu = escolherJaCumpriuNoMeio(estado, leitura);
-  if (jaCumpriu) return { tipo: 'recomenda', ...jaCumpriu, etapa: '' };
+  if (jaCumpriu) return { tipo: 'recomenda', ...jaCumpriu };
   return { tipo: 'segue-fria', motivo: 'linha quente segue fria: sem carta que não faz', etapa: ETAPA_SEGUE_FRIA };
 }

--- a/src/adapters/bots/decidirAbertura.ts
+++ b/src/adapters/bots/decidirAbertura.ts
@@ -1,17 +1,17 @@
 import type { CategoriaCarta } from '@/core/avaliador-carta';
 import type { Carta } from '@/core/Carta';
-import { criarCaminhoJogadaDebug } from './debug-jogada-bot';
 import type { LeituraDaMesa } from './ler-mesa';
 
 export interface DecisaoAbertura {
   carta: Carta;
   motivo: string;
-  caminho: string[];
+  etapa: string;
 }
 
 export type DecisaoAberturaLinhaFria = DecisaoAbertura;
 
 export const MOTIVO_ABERTURA_LINHA_QUENTE = 'abertura: segue linha fria';
+export const ETAPA_ABERTURA_SEGUE_FRIA = 'segue linha fria';
 
 export function decidirAberturaLinhaFria(leitura: LeituraDaMesa): DecisaoAberturaLinhaFria {
   if (leitura.avaliadas.length === 0) throw new Error('decidirAbertura: mão vazia');
@@ -49,6 +49,6 @@ function criarDecisaoAbertura(
   return {
     carta,
     motivo: `abertura: ${ramo}; ordem ${ordemCategorias.join('-')}`,
-    caminho: criarCaminhoJogadaDebug('abre', 'fria', ramo),
+    etapa: ramo,
   };
 }

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -5,10 +5,10 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
 import {
-  CAMINHO_FECHA_JA_CUMPRIU,
-  CAMINHO_FECHA_PRECISA,
   cartasQueGarantemTresDeOuros,
   criarEstadoLinhaFria,
+  ETAPA_FECHA_JA_CUMPRIU,
+  ETAPA_FECHA_PRECISA,
   mesaComK,
   mesaComQuatro,
 } from './fixtures-linha-fria';
@@ -17,7 +17,7 @@ const cenariosDeUltimo: {
   nome: string;
   mao: Carta[];
   estado: EstadoEmJogo;
-  esperado: { carta: Carta; motivo: string; caminho: string[] };
+  esperado: { carta: Carta; motivo: string; etapa: string };
 }[] = [
   {
     nome: 'deve escolher G[N-X] no último quando precisa fazer e tem ganhadoras',
@@ -26,7 +26,7 @@ const cenariosDeUltimo: {
     esperado: {
       carta: criarCarta('8', '♦'),
       motivo: 'precisa fazer; regra G[N-X]',
-      caminho: [...CAMINHO_FECHA_PRECISA],
+      etapa: ETAPA_FECHA_PRECISA,
     },
   },
   {
@@ -36,7 +36,7 @@ const cenariosDeUltimo: {
     esperado: {
       carta: criarCarta('9', '♦'),
       motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
-      caminho: [...CAMINHO_FECHA_PRECISA],
+      etapa: ETAPA_FECHA_PRECISA,
     },
   },
   {
@@ -46,7 +46,7 @@ const cenariosDeUltimo: {
     esperado: {
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; carta mais forte que não faz',
-      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+      etapa: ETAPA_FECHA_JA_CUMPRIU,
     },
   },
   {
@@ -60,7 +60,7 @@ const cenariosDeUltimo: {
     esperado: {
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; carta mais forte que não faz',
-      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+      etapa: ETAPA_FECHA_JA_CUMPRIU,
     },
   },
   {
@@ -70,7 +70,7 @@ const cenariosDeUltimo: {
     esperado: {
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; fuga impossível',
-      caminho: [...CAMINHO_FECHA_JA_CUMPRIU],
+      etapa: ETAPA_FECHA_JA_CUMPRIU,
     },
   },
 ];

--- a/tests/adapters/decidir-linha-quente.test.ts
+++ b/tests/adapters/decidir-linha-quente.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { decidirLinhaQuente, type ResultadoQuente } from '@/adapters/bots/decidir-linha-quente';
-import { MOTIVO_ABERTURA_LINHA_QUENTE } from '@/adapters/bots/decidirAbertura';
+import { ETAPA_SEGUE_FRIA } from '@/adapters/bots/decidir-linha-quente';
+import { ETAPA_ABERTURA_SEGUE_FRIA, MOTIVO_ABERTURA_LINHA_QUENTE } from '@/adapters/bots/decidirAbertura';
 import { DecisorJogadaPorTemperatura } from '@/adapters/bots/DecisorJogadaPorTemperatura';
 import { existeGarantidaParaDepois } from '@/adapters/bots/garantida-para-depois';
 import { lerMesa } from '@/adapters/bots/ler-mesa';
@@ -33,6 +34,7 @@ describe('decidirLinhaQuente na abertura', () => {
     expect(decidirLinhaQuente({ posicao: 'abre', estado, leitura, liderBaixa: LIDER_BAIXA })).toEqual({
       tipo: 'segue-fria',
       motivo: MOTIVO_ABERTURA_LINHA_QUENTE,
+      etapa: ETAPA_ABERTURA_SEGUE_FRIA,
     });
   });
 
@@ -197,7 +199,7 @@ const cenariosMeio: {
       manilha: '6',
     },
     mao: [criarCarta('5', '♦'), criarCarta('8', '♦'), criarCarta('K', '♦')],
-    esperado: { tipo: 'segue-fria', motivo: 'linha quente segue fria: sem carta que não faz' },
+    esperado: { tipo: 'segue-fria', motivo: 'linha quente segue fria: sem carta que não faz', etapa: ETAPA_SEGUE_FRIA },
   },
   {
     nome: 'deve seguir fria com urgência alta e nenhum ramo aplicável',
@@ -207,7 +209,7 @@ const cenariosMeio: {
       vazas: { j1: 0, bot: 0 },
     },
     mao: [criarCarta('7', '♦'), criarCarta('K', '♦')],
-    esperado: { tipo: 'segue-fria', motivo: 'linha quente segue fria: nenhum ramo se aplica' },
+    esperado: { tipo: 'segue-fria', motivo: 'linha quente segue fria: nenhum ramo se aplica', etapa: ETAPA_SEGUE_FRIA },
   },
 ];
 

--- a/tests/adapters/decidir-linha-quente.test.ts
+++ b/tests/adapters/decidir-linha-quente.test.ts
@@ -166,7 +166,6 @@ const cenariosMeio: {
       tipo: 'recomenda',
       carta: criarCarta('2', '♦'),
       motivo: 'já cumpriu; empate contra líder alta+',
-      etapa: '',
     },
   },
   {
@@ -184,7 +183,6 @@ const cenariosMeio: {
       tipo: 'recomenda',
       carta: criarCarta('7', '♦'),
       motivo: 'já cumpriu; perdedora mais forte',
-      etapa: '',
     },
   },
   {
@@ -227,7 +225,6 @@ const cenariosFecha: {
       tipo: 'recomenda',
       carta: criarCarta('8', '♦'),
       motivo: 'precisa fazer; regra G[N-X]',
-      etapa: '',
     },
   },
   {
@@ -238,7 +235,6 @@ const cenariosFecha: {
       tipo: 'recomenda',
       carta: criarCarta('9', '♦'),
       motivo: 'precisa fazer, sem carta que vence; P[N-X]',
-      etapa: '',
     },
   },
   {
@@ -249,7 +245,6 @@ const cenariosFecha: {
       tipo: 'recomenda',
       carta: criarCarta('6', '♦'),
       motivo: 'precisa fazer; adiou; P[N-X]',
-      etapa: '',
     },
   },
   {
@@ -264,7 +259,6 @@ const cenariosFecha: {
       tipo: 'recomenda',
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; carta mais alta que não faz',
-      etapa: '',
     },
   },
 ];

--- a/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
+++ b/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
@@ -5,10 +5,10 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
 import {
-  CAMINHO_GUARDA_PERMITIU,
-  CAMINHO_JA_CUMPRIU,
   cartasQueGarantemTresDeOuros,
   criarEstadoLinhaFria,
+  ETAPA_GUARDA_PERMITIU,
+  ETAPA_JA_CUMPRIU,
   mesaComK,
   mesaComQuatro,
 } from './fixtures-linha-fria';
@@ -17,7 +17,7 @@ const cenarios: {
   nome: string;
   mao: Carta[];
   estado: EstadoEmJogo;
-  esperado: { carta: Carta; motivo: string; caminho?: string[] };
+  esperado: { carta: Carta; motivo: string; etapa: string };
 }[] = [
   {
     nome: 'deve abrir com ordem cautelosa quando já cumpriu',
@@ -31,7 +31,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('7', '♦'),
       motivo: 'abertura: já cumpriu; ordem baixa-média-alta-segura-garantida_agora',
-      caminho: ['jogada', 'abre a mesa', 'linha fria', 'já cumpriu'],
+      etapa: 'já cumpriu',
     },
   },
   {
@@ -41,7 +41,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('7', '♦'),
       motivo: 'abertura: precisa sem urgência alta; ordem baixa-média-alta-segura-garantida_agora',
-      caminho: ['jogada', 'abre a mesa', 'linha fria', 'precisa sem urgência alta'],
+      etapa: 'precisa sem urgência alta',
     },
   },
   {
@@ -51,7 +51,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('2', '♦'),
       motivo: 'abertura: urgência alta; ordem alta-média-segura-baixa-garantida_agora',
-      caminho: ['jogada', 'abre a mesa', 'linha fria', 'urgência alta'],
+      etapa: 'urgência alta',
     },
   },
   {
@@ -61,7 +61,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; carta mais alta que não faz',
-      caminho: [...CAMINHO_JA_CUMPRIU],
+      etapa: ETAPA_JA_CUMPRIU,
     },
   },
   {
@@ -75,7 +75,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('K', '♦'),
       motivo: 'já cumpriu; carta mais alta que não faz',
-      caminho: [...CAMINHO_JA_CUMPRIU],
+      etapa: ETAPA_JA_CUMPRIU,
     },
   },
   {
@@ -85,7 +85,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('5', '♦'),
       motivo: 'já cumpriu; fuga impossível',
-      caminho: [...CAMINHO_JA_CUMPRIU],
+      etapa: ETAPA_JA_CUMPRIU,
     },
   },
   {
@@ -95,7 +95,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('8', '♦'),
       motivo: 'guarda de posição permitiu; urgência alta; precisa fazer; regra G[N-X]',
-      caminho: [...CAMINHO_GUARDA_PERMITIU],
+      etapa: ETAPA_GUARDA_PERMITIU,
     },
   },
   {
@@ -105,7 +105,7 @@ const cenarios: {
     esperado: {
       carta: criarCarta('9', '♦'),
       motivo: 'guarda de posição permitiu; jogadores por agir já cumpriram; precisa fazer; regra P[N-X]',
-      caminho: [...CAMINHO_GUARDA_PERMITIU],
+      etapa: ETAPA_GUARDA_PERMITIU,
     },
   },
 ];

--- a/tests/adapters/fixtures-linha-fria.ts
+++ b/tests/adapters/fixtures-linha-fria.ts
@@ -70,12 +70,23 @@ export function cartasQueGarantemTresDeOuros(): Carta[] {
   ];
 }
 
-export const CAMINHO_GUARDA_BLOQUEOU = ['jogada', 'joga no meio', 'linha fria', 'guarda de posição bloqueou'] as const;
+export const ETAPA_GUARDA_BLOQUEOU = 'guarda de posição bloqueou';
 
-export const CAMINHO_GUARDA_PERMITIU = ['jogada', 'joga no meio', 'linha fria', 'guarda de posição permitiu'] as const;
+export const ETAPA_GUARDA_PERMITIU = 'guarda de posição permitiu';
 
-export const CAMINHO_JA_CUMPRIU = ['jogada', 'joga no meio', 'linha fria', 'já cumpriu'] as const;
+export const ETAPA_JA_CUMPRIU = 'já cumpriu';
 
-export const CAMINHO_FECHA_PRECISA = ['jogada', 'fecha a mesa', 'linha fria', 'precisa fazer'] as const;
+export const ETAPA_FECHA_PRECISA = 'precisa fazer';
 
-export const CAMINHO_FECHA_JA_CUMPRIU = ['jogada', 'fecha a mesa', 'linha fria', 'já cumpriu'] as const;
+export const ETAPA_FECHA_JA_CUMPRIU = 'já cumpriu';
+
+/** Caminhos completos para testes de integração via DecisorJogadaPorTemperatura. */
+export const CAMINHO_GUARDA_BLOQUEOU = ['jogada', 'joga no meio', 'linha fria', ETAPA_GUARDA_BLOQUEOU] as const;
+
+export const CAMINHO_GUARDA_PERMITIU = ['jogada', 'joga no meio', 'linha fria', ETAPA_GUARDA_PERMITIU] as const;
+
+export const CAMINHO_JA_CUMPRIU = ['jogada', 'joga no meio', 'linha fria', ETAPA_JA_CUMPRIU] as const;
+
+export const CAMINHO_FECHA_PRECISA = ['jogada', 'fecha a mesa', 'linha fria', ETAPA_FECHA_PRECISA] as const;
+
+export const CAMINHO_FECHA_JA_CUMPRIU = ['jogada', 'fecha a mesa', 'linha fria', ETAPA_FECHA_JA_CUMPRIU] as const;

--- a/tests/adapters/guarda-posicao-linha-fria.test.ts
+++ b/tests/adapters/guarda-posicao-linha-fria.test.ts
@@ -5,18 +5,18 @@ import type { Carta } from '@/core/Carta';
 import type { EstadoEmJogo } from '@/types/estado-rodada';
 import { criarCarta } from '../core/rodada-fixtures';
 import {
-  CAMINHO_GUARDA_BLOQUEOU,
-  CAMINHO_GUARDA_PERMITIU,
   cartasQueGarantemTresDeOuros,
   criarEstadoComDoisPorAgir,
   criarEstadoComUmPorAgir,
+  ETAPA_GUARDA_BLOQUEOU,
+  ETAPA_GUARDA_PERMITIU,
 } from './fixtures-linha-fria';
 
 interface CenarioGuarda {
   nome: string;
   mao: Carta[];
   estado: EstadoEmJogo;
-  esperado: { carta: Carta; motivo: string; caminho?: string[] };
+  esperado: { carta: Carta; motivo: string; etapa: string };
 }
 
 const cenarios: CenarioGuarda[] = [
@@ -88,7 +88,7 @@ function decisaoBloqueada(carta: Carta): CenarioGuarda['esperado'] {
   return {
     carta,
     motivo: 'guarda de posição bloqueou; jogador por agir ainda precisa',
-    caminho: [...CAMINHO_GUARDA_BLOQUEOU],
+    etapa: ETAPA_GUARDA_BLOQUEOU,
   };
 }
 
@@ -96,6 +96,6 @@ function decisaoGanhadora(carta: Carta, motivoGuarda: string): CenarioGuarda['es
   return {
     carta,
     motivo: `guarda de posição permitiu; ${motivoGuarda}; precisa fazer; regra G[N-X]`,
-    caminho: [...CAMINHO_GUARDA_PERMITIU],
+    etapa: ETAPA_GUARDA_PERMITIU,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fecha o slice 4 da issue #234: a montagem do `caminho` de debug passa a acontecer só em `DecisorJogadaPorTemperatura`.

## O que mudou

- **Linha fria** (`DecisorJogadaLinhaFria`, `decidirAbertura`) devolve `{ carta, motivo, etapa }` em vez de montar `caminho` localmente.
- **Linha quente** (`decidirLinhaQuente`): `segue-fria` carrega `etapa`; `recomenda` usa `etapa?` opcional quando não há passo extra no caminho (fecha, já-cumpriu no meio).
- **`DecisorJogadaPorTemperatura`** monta os dois caminhos via `montarRecomendacaoLinha` + `criarCaminhoJogadaDebug`.
- Removidos `criarCaminhoJogadaDebug` / `CAMINHO_MEIO` espalhados e o helper morto `criarDecisaoQuente`.

## Revisão

- `etapa?: string` no ramo `recomenda` de `ResultadoQuente` (sem sentinela `''`).
- `decidirJogada` deixa de ser `async` com `await` fake; retorna `Promise.resolve` como os demais decisores.

## Verificação

- `pnpm test` — 730 testes
- `pnpm lint` + `pnpm typecheck` — ok

Relacionado: #234
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-307c6403-4af6-4cf9-8aae-228fe1971b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-307c6403-4af6-4cf9-8aae-228fe1971b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

