### PR TITLE
feat(ui): badges de declaração na 1ª rodada (turno 0)

### DIFF
--- a/src/adapters/phaser/renderers/declarado-turno0-renderer.ts
+++ b/src/adapters/phaser/renderers/declarado-turno0-renderer.ts
@@ -1,0 +1,119 @@
+import type { Scene } from 'phaser';
+import type { Jogador } from '@/types/entidades';
+import { escalar, escalarFonte } from '../escala';
+import type { Retangulo } from '../layout';
+import { limparObjetos } from './limpar-objetos';
+
+const COR_FUNDO = 0x16213e;
+const COR_BORDA = 0xf1c40f;
+const COR_NUMERO = '#f1c40f';
+const PROFUNDIDADE_BADGE = 25;
+
+export interface ConfigDeclaradoTurno0 {
+  cena: Scene;
+  jogadores: Jogador[];
+  declaracoes: Record<string, number>;
+  centrosMaos: { x: number; y: number }[];
+  objetos: Phaser.GameObjects.GameObject[];
+  gameArea: Retangulo;
+  jogadorIdAnimar?: string;
+}
+
+export function renderizarBadgesDeclaradoTurno0(config: ConfigDeclaradoTurno0): void {
+  const { cena, jogadores, declaracoes, centrosMaos, objetos, gameArea, jogadorIdAnimar } = config;
+  limparObjetos(objetos);
+  Object.entries(declaracoes).forEach(([jogadorId, valor]) => {
+    const animar = jogadorIdAnimar !== undefined && jogadorId === jogadorIdAnimar;
+    adicionarBadge({ cena, jogadores, jogadorId, valor, centrosMaos, objetos, gameArea, animar });
+  });
+}
+
+interface ConfigBadge {
+  cena: Scene;
+  jogadores: Jogador[];
+  jogadorId: string;
+  valor: number;
+  centrosMaos: { x: number; y: number }[];
+  objetos: Phaser.GameObjects.GameObject[];
+  gameArea: Retangulo;
+  animar: boolean;
+}
+
+function adicionarBadge(config: ConfigBadge): void {
+  const { cena, jogadores, jogadorId, valor, centrosMaos, objetos, gameArea, animar } = config;
+  const indice = jogadores.findIndex((j) => j.id === jogadorId);
+  if (indice < 0 || indice >= centrosMaos.length) return;
+  const posicao = posicaoBadgeSobreCartas({ cena, centro: centrosMaos[indice], gameArea });
+  const badge = criarBadge({ cena, x: posicao.x, y: posicao.y, valor });
+  objetos.push(badge);
+  if (animar) animarEntradaBadge(cena, badge);
+}
+
+interface ConfigPosicaoBadge {
+  cena: Scene;
+  centro: { x: number; y: number };
+  gameArea: Retangulo;
+}
+
+function posicaoBadgeSobreCartas(config: ConfigPosicaoBadge): { x: number; y: number } {
+  const { cena, centro, gameArea } = config;
+  const raio = escalar(13, cena);
+  return limitarDentroGameArea({ posicao: centro, raio, area: gameArea, margem: escalar(8, cena) });
+}
+
+interface ConfigLimitarArea {
+  posicao: { x: number; y: number };
+  raio: number;
+  area: Retangulo;
+  margem: number;
+}
+
+function limitarDentroGameArea(config: ConfigLimitarArea): { x: number; y: number } {
+  const { posicao, raio, area, margem } = config;
+  const minX = area.x + margem + raio;
+  const maxX = area.x + area.largura - margem - raio;
+  const minY = area.y + margem + raio;
+  const maxY = area.y + area.altura - margem - raio;
+  return {
+    x: Math.min(maxX, Math.max(minX, posicao.x)),
+    y: Math.min(maxY, Math.max(minY, posicao.y)),
+  };
+}
+
+interface ConfigCriarBadge {
+  cena: Scene;
+  x: number;
+  y: number;
+  valor: number;
+}
+
+function criarBadge(config: ConfigCriarBadge): Phaser.GameObjects.Container {
+  const { cena, x, y, valor } = config;
+  const raio = escalar(13, cena);
+  const container = cena.add.container(x, y).setDepth(PROFUNDIDADE_BADGE);
+  const sombra = cena.add.circle(0, escalar(1, cena), raio, 0x000000, 0.4);
+  const fundo = cena.add.circle(0, 0, raio, COR_FUNDO);
+  const borda = cena.add.graphics();
+  borda.lineStyle(escalar(2, cena), COR_BORDA, 1);
+  borda.strokeCircle(0, 0, raio);
+  const numero = cena.add
+    .text(0, 0, String(valor), {
+      fontSize: escalarFonte(15, cena),
+      color: COR_NUMERO,
+      fontFamily: 'Arial',
+      fontStyle: 'bold',
+    })
+    .setOrigin(0.5);
+  container.add([sombra, fundo, borda, numero]);
+  return container;
+}
+
+function animarEntradaBadge(cena: Scene, badge: Phaser.GameObjects.Container): void {
+  badge.setScale(0);
+  cena.tweens.add({
+    targets: badge,
+    scale: 1,
+    duration: 240,
+    ease: 'Back.easeOut',
+  });
+}

--- a/src/adapters/phaser/renderers/posicoes-mao.ts
+++ b/src/adapters/phaser/renderers/posicoes-mao.ts
@@ -160,3 +160,13 @@ function calcularInicioCentralizado(cx: number, quantidadeCartas: number, espaca
   const larguraMao = Math.max(0, quantidadeCartas - 1) * espacamento;
   return Math.round(cx - larguraMao / 2);
 }
+
+/** Centro da mão na tela — mesmo ponto usado para ancorar a carta do meio. */
+export function calcularCentroMao(mao: PosicaoMao, quantidadeCartas: number): { x: number; y: number } {
+  if (quantidadeCartas <= 0) return { x: mao.x, y: mao.y };
+  const deslocamentoTotal = (quantidadeCartas - 1) * mao.espacamento;
+  if (mao.direcao === 'horizontal') {
+    return { x: Math.round(mao.x + deslocamentoTotal / 2), y: mao.y };
+  }
+  return { x: mao.x, y: Math.round(mao.y + deslocamentoTotal / 2) };
+}

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -1,10 +1,11 @@
 import { Scene } from 'phaser';
 import { VALOR_MINIMO } from '@/core/Carta';
 import { Rodada } from '@/core/Rodada';
-import { estadoEmJogo } from '@/types/estado-rodada';
+import { ehFaseDeclaracao, estadoEmJogo } from '@/types/estado-rodada';
 import { DecisorHumano } from '../DecisorHumano';
 import { calcularLayout, type LayoutPainel, type Retangulo } from '../layout';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
+import { renderizarBadgesDeclaradoTurno0 } from '../renderers/declarado-turno0-renderer';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 import { limparObjetos } from '../renderers/limpar-objetos';
 import { renderizarMesa } from '../renderers/mesa-renderer';
@@ -19,6 +20,7 @@ export class JogoScene extends Scene {
   objetos: Phaser.GameObjects.GameObject[] = [];
   mesaObjetos: Phaser.GameObjects.GameObject[] = [];
   objetosDeclaracao: Phaser.GameObjects.GameObject[] = [];
+  objetosDeclaradoTurno0: Phaser.GameObjects.GameObject[] = [];
   destaque: EstadoDestaque = {};
   painelObjetos: Phaser.GameObjects.GameObject[] = [];
   fimJogoObjetos: Phaser.GameObjects.GameObject[] = [];
@@ -27,6 +29,7 @@ export class JogoScene extends Scene {
   private decisorHumano = new DecisorHumano();
   private labels: Phaser.GameObjects.Text[] = [];
   private direcoesLabels: ('horizontal' | 'vertical')[] = [];
+  private centrosMaos: { x: number; y: number }[] = [];
   private tweenVez?: Phaser.Tweens.Tween;
   private controller?: JogoController;
 
@@ -65,6 +68,8 @@ export class JogoScene extends Scene {
       getLabels: () => this.labels,
       getDirecoesLabels: () => this.direcoesLabels,
       modoDebug: Boolean(this.game.registry.get('modoDebug')),
+      renderizarBadges: this.renderizarBadges.bind(this),
+      limparBadges: this.limparBadges.bind(this),
     };
   }
 
@@ -107,6 +112,7 @@ export class JogoScene extends Scene {
     const cartas = estado.mesa.map((m) => m.carta);
     renderizarMesa({ cena: this, mesa: cartas, objetos: this.mesaObjetos, gameArea });
     this.controller?.redesenharDeclaracaoAtual();
+    this.sincronizarBadges();
     this.atualizarIndicadorVez();
   };
 
@@ -123,9 +129,40 @@ export class JogoScene extends Scene {
     });
     this.labels = resultado.labels;
     this.direcoesLabels = resultado.direcoes;
+    this.centrosMaos = resultado.centrosMaos;
+  }
+
+  private renderizarBadges(jogadorIdAnimar?: string): void {
+    const estado = this.controller?.partida?.estado;
+    if (!estado || estado.fase === 'distribuindo') return;
+    const emJogo = estadoEmJogo(estado);
+    renderizarBadgesDeclaradoTurno0({
+      cena: this,
+      jogadores: emJogo.maos.map((m) => m.jogador),
+      declaracoes: emJogo.declaracoes,
+      centrosMaos: this.centrosMaos,
+      objetos: this.objetosDeclaradoTurno0,
+      gameArea: this.obterGameArea(),
+      jogadorIdAnimar,
+    });
+  }
+
+  private limparBadges(): void {
+    limparObjetos(this.objetosDeclaradoTurno0);
+  }
+
+  private sincronizarBadges(): void {
+    const estado = this.controller?.partida?.estado;
+    if (!estado) return;
+    if (ehFaseDeclaracao(estado.fase)) {
+      this.renderizarBadges();
+      return;
+    }
+    this.limparBadges();
   }
 
   private aoEncerrar = (): void => {
+    this.limparBadges();
     aoEncerrarCena({
       cena: this,
       redesenhar: this.redesenhar,

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -7,7 +7,7 @@ import { criarFundoInterativo } from '../input/input-humano';
 import type { Retangulo } from '../layout';
 import type { EstadoDestaque } from '../renderers/destaque-renderer';
 import { desenharMaoNaCena } from '../renderers/mao-scene-renderer';
-import { calcularPosicoes } from '../renderers/posicoes-mao';
+import { calcularCentroMao, calcularPosicoes } from '../renderers/posicoes-mao';
 
 interface ConfigMaosJogo {
   cena: Scene;
@@ -22,10 +22,12 @@ interface ConfigMaosJogo {
 export function desenharMaosJogo(config: ConfigMaosJogo): {
   labels: Phaser.GameObjects.Text[];
   direcoes: ('horizontal' | 'vertical')[];
+  centrosMaos: { x: number; y: number }[];
 } {
   const labels: Phaser.GameObjects.Text[] = [];
   const quantidadesCartas = config.maos.map((mao) => mao.cartas.length);
   const posicoes = calcularPosicoesMaos(config.cena, config.gameArea, quantidadesCartas);
+  const centrosMaos = posicoes.map((p, i) => calcularCentroMao(p.mao, quantidadesCartas[i] ?? 0));
   config.maos.forEach((mao, i) => {
     desenharMaoNaCena({
       cena: config.cena,
@@ -45,7 +47,7 @@ export function desenharMaosJogo(config: ConfigMaosJogo): {
     decisorHumano: config.decisorHumano,
     destaque: config.destaque,
   });
-  return { labels, direcoes: posicoes.map((p) => p.mao.direcao) };
+  return { labels, direcoes: posicoes.map((p) => p.mao.direcao), centrosMaos };
 }
 
 function calcularPosicoesMaos(

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -1,7 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Partida } from '@/core/Partida';
 import type { Jogador } from '@/types/entidades';
-import { estadoEmJogo } from '@/types/estado-rodada';
+import { ehFaseDeclaracao, estadoEmJogo } from '@/types/estado-rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import type { DecisorHumano } from '../DecisorHumano';
 import { fabricarPartida } from '../factories/rodada-factory';
@@ -25,6 +25,8 @@ export interface DependenciasCena {
   getLabels: () => Phaser.GameObjects.Text[];
   getDirecoesLabels: () => ('horizontal' | 'vertical')[];
   modoDebug: boolean;
+  renderizarBadges: (jogadorIdAnimar?: string) => void;
+  limparBadges: () => void;
 }
 
 export class JogoController {
@@ -86,7 +88,7 @@ export class JogoController {
     const rodada = this.partida?.rodadaAtual;
     if (!rodada) return;
     const estado = rodada.estado;
-    if (estado.fase !== 'aguardandoDeclaracao' && estado.fase !== 'processandoDeclaracao') return;
+    if (!ehFaseDeclaracao(estado.fase)) return;
     const emJogo = estadoEmJogo(estado);
     const maoAtual = emJogo.maos[emJogo.jogadorAtual];
     if (maoAtual.jogador.id !== 'humano') return;
@@ -121,6 +123,8 @@ export class JogoController {
       onAlterarDeclaracao: this.atualizarValorDeclaracao,
       atualizarIndicadorVez: this.deps.atualizarIndicadorVez,
       atualizarPainel: this.deps.atualizarPainel,
+      renderizarBadges: this.deps.renderizarBadges,
+      limparBadges: this.deps.limparBadges,
       iniciarTurnos: this.iniciarFluxoTurno.bind(this),
     }).catch(() => undefined);
   }

--- a/src/adapters/phaser/scenes/jogo-scene-loop.ts
+++ b/src/adapters/phaser/scenes/jogo-scene-loop.ts
@@ -1,7 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Rodada } from '@/core/Rodada';
 import type { Jogador } from '@/types/entidades';
-import { estadoEmJogo } from '@/types/estado-rodada';
+import { ehFaseDeclaracao, estadoEmJogo } from '@/types/estado-rodada';
 import type { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
 import type { Retangulo } from '../layout';
 import { desenharBotoesDeclaracao, limparObjetosDeclaracao } from '../renderers/declaracao-renderer';
@@ -17,8 +17,14 @@ interface ConfigDeclaracoes {
   onAlterarDeclaracao: (valor: number) => void;
   atualizarIndicadorVez: () => void;
   atualizarPainel: () => void;
+  renderizarBadges: (jogadorIdAnimar?: string) => void;
+  limparBadges: () => void;
   iniciarTurnos: () => Promise<void>;
 }
+
+const ESPERA_APOS_DECLARACAO_BOT_MS = 650;
+/** Pausa com todos os badges visíveis antes do turno 1 de jogada. */
+const ESPERA_ANTES_PRIMEIRO_TURNO_MS = 1400;
 
 interface ConfigTurnos {
   cena: Scene;
@@ -35,15 +41,23 @@ interface ConfigTurnos {
 
 export async function processarDeclaracoes(config: ConfigDeclaracoes): Promise<void> {
   const { rodada } = config;
-  while (faseDeclaracao(rodada)) {
+  while (ehFaseDeclaracao(rodada.estado.fase)) {
     await prepararDeclaracaoAtual(config);
+    const declaradorId = obterJogadorAtualId(rodada);
     const declarou = await tentarDeclarar(rodada);
     if (!declarou) return;
     limparObjetosDeclaracao(config.objetos);
+    const fimDeclaracao = rodada.estado.fase === 'aguardandoJogada';
+    config.renderizarBadges(declaradorId);
     config.atualizarPainel();
     config.atualizarIndicadorVez();
+    if (declaradorId !== 'humano' || fimDeclaracao) {
+      await esperar(config.cena, ESPERA_APOS_DECLARACAO_BOT_MS);
+    }
   }
   if (rodada.estado.fase === 'aguardandoJogada') {
+    await esperar(config.cena, ESPERA_ANTES_PRIMEIRO_TURNO_MS);
+    config.limparBadges();
     void config.iniciarTurnos().catch(() => undefined);
   }
 }
@@ -105,8 +119,9 @@ async function atualizarFimDeTurno(config: ConfigTurnos): Promise<void> {
   });
 }
 
-function faseDeclaracao(rodada: Rodada): boolean {
-  return rodada.estado.fase === 'aguardandoDeclaracao' || rodada.estado.fase === 'processandoDeclaracao';
+function obterJogadorAtualId(rodada: Rodada): string {
+  const emJogo = estadoEmJogo(rodada.estado);
+  return emJogo.maos[emJogo.jogadorAtual].jogador.id;
 }
 
 async function tentarDeclarar(rodada: Rodada): Promise<boolean> {

--- a/src/types/estado-rodada.ts
+++ b/src/types/estado-rodada.ts
@@ -66,3 +66,7 @@ export function estadoEmJogo(estado: EstadoRodada): EstadoEmJogo {
   }
   return estado;
 }
+
+export function ehFaseDeclaracao(fase: FaseRodada): boolean {
+  return fase === 'aguardandoDeclaracao' || fase === 'processandoDeclaracao';
+}


### PR DESCRIPTION
## Summary

- Exibe badges circulares com o valor declarado sobre o centro da mão de cada jogador durante a fase de declaração da 1ª rodada.
- Anima a entrada do badge do jogador que acabou de declarar; mantém todos visíveis por ~1,4s antes do primeiro turno de jogada.
- Extrai `ehFaseDeclaracao` e `calcularCentroMao` para reutilizar posicionamento e sincronização no redraw.

## Test plan

- [x] Iniciar partida com bots e chegar à fase de declaração da rodada 1.
- [x] Confirmar que cada declaração de bot exibe badge animado sobre a mão correspondente.
- [x] Declarar como humano e verificar badge + ausência de espera extra desnecessária.
- [x] Após todas as declarações, aguardar pausa e confirmar que badges somem ao iniciar jogada.
- [x] Redimensionar janela durante declaração e verificar badges realinhados.
- [x] Validar visualmente no deploy preview do Vercel.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual badges that display near player hands during the declaration phase, making it easier to identify the current declarator.
  * Badges feature a smooth scale-in animation for better visual feedback.
  * Badges automatically clear when the declaration phase ends and the game transitions to turn play.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->