### PR TITLE
feat(ui): painel da manilha sem overflow em viewports estreitos

### DIFF
--- a/src/adapters/phaser/layout-manilha.ts
+++ b/src/adapters/phaser/layout-manilha.ts
@@ -1,0 +1,55 @@
+import type { Retangulo } from './layout';
+
+export interface ConfigLayoutManilha {
+  area: Retangulo;
+  cartaLargura: number;
+  cartaAltura: number;
+  margem: number;
+  gapCartaLabel: number;
+  alturaLabel: number;
+  ehPaisagem: boolean;
+}
+
+export interface LayoutManilha {
+  cartaX: number;
+  cartaY: number;
+  escala: number;
+  labelX: number;
+  labelY: number;
+}
+
+/** `area` e dimensões da carta devem estar no mesmo espaço de pixels (device px). */
+export function calcularLayoutManilha(config: ConfigLayoutManilha): LayoutManilha {
+  const { area, cartaAltura, margem, gapCartaLabel, alturaLabel, ehPaisagem } = config;
+  const escala = calcularEscalaMaxima(config);
+  const alturaEfetiva = cartaAltura * escala;
+  const blocoAltura = alturaEfetiva + gapCartaLabel + alturaLabel;
+  const cartaX = area.x + area.largura / 2;
+
+  const topoBloco = ehPaisagem ? area.y + area.altura - margem - blocoAltura : area.y + (area.altura - blocoAltura) / 2;
+
+  const cartaY = topoBloco + alturaEfetiva / 2;
+  const labelY = topoBloco + alturaEfetiva + gapCartaLabel + alturaLabel / 2;
+
+  return { cartaX, cartaY, escala, labelX: cartaX, labelY };
+}
+
+function calcularEscalaMaxima(config: ConfigLayoutManilha): number {
+  const { area, cartaLargura, cartaAltura, margem, gapCartaLabel, alturaLabel } = config;
+  const larguraDisponivel = area.largura - margem * 2;
+  const alturaDisponivel = area.altura - margem * 2 - gapCartaLabel - alturaLabel;
+  const escalaLargura = larguraDisponivel / cartaLargura;
+  const escalaAltura = alturaDisponivel / cartaAltura;
+
+  return Math.min(1, escalaLargura, escalaAltura);
+}
+
+export function calcularAreaManilha(area: Retangulo, ehPaisagem: boolean): Retangulo {
+  if (ehPaisagem) return area;
+  return {
+    x: area.x + Math.round(area.largura * 0.65),
+    y: area.y,
+    largura: Math.round(area.largura * 0.35),
+    altura: area.altura,
+  };
+}

--- a/src/adapters/phaser/renderers/painel-info-renderer.ts
+++ b/src/adapters/phaser/renderers/painel-info-renderer.ts
@@ -5,6 +5,7 @@ import type { EstadoRodada, EstadoEmJogo } from '@/types/estado-rodada';
 import { estadoEmJogo } from '@/types/estado-rodada';
 import { escalar, escalarFonte } from '../escala';
 import type { LayoutPainel, Retangulo } from '../layout';
+import { calcularAreaManilha } from '../layout-manilha';
 import { limparObjetos } from './limpar-objetos';
 import { desenharManilhaNoPainel } from './painel-manilha-renderer';
 
@@ -97,14 +98,7 @@ function calcularLayoutTabela(
     feito: tabelaX + Math.round(larguraTabela * 0.58),
     pontos: tabelaX + Math.round(larguraTabela * 0.74),
   };
-  const areaManilha = ehPaisagem
-    ? area
-    : {
-        x: area.x + Math.round(area.largura * 0.65),
-        y: area.y,
-        largura: Math.round(area.largura * 0.35),
-        altura: area.altura,
-      };
+  const areaManilha = calcularAreaManilha(area, ehPaisagem);
   return { colunas, areaManilha };
 }
 

--- a/src/adapters/phaser/renderers/painel-manilha-renderer.ts
+++ b/src/adapters/phaser/renderers/painel-manilha-renderer.ts
@@ -2,7 +2,12 @@ import type { Scene } from 'phaser';
 import type { Carta, Valor } from '@/core/Carta';
 import { escalar, escalarFonte } from '../escala';
 import type { Retangulo } from '../layout';
-import { criarMiniCarta } from './mini-carta-renderer';
+import { calcularLayoutManilha, type LayoutManilha } from '../layout-manilha';
+import { ALTURA, criarCartaFrente, LARGURA } from './carta-renderer';
+
+export const MARGEM_BASE = 8;
+export const GAP_CARTA_LABEL_BASE = 4;
+export const ALTURA_LABEL_BASE = 14;
 
 interface ConfigManilha {
   cena: Scene;
@@ -15,31 +20,32 @@ interface ConfigManilha {
 
 export function desenharManilhaNoPainel(config: ConfigManilha): void {
   const { cena, objetos, cartaVirada, manilha, areaManilha, ehPaisagem } = config;
-  const posicao = calcularPosicaoManilha(cena, areaManilha, ehPaisagem);
-  const miniCarta = criarMiniCarta({ cena, x: posicao.x, y: posicao.y, carta: cartaVirada });
-  miniCarta.setDepth(81);
-  objetos.push(miniCarta);
-  const label = criarLabelManilha({ cena, manilha, posicao });
+  const layout = calcularLayoutManilha({
+    area: areaManilha,
+    cartaLargura: escalar(LARGURA, cena),
+    cartaAltura: escalar(ALTURA, cena),
+    margem: escalar(MARGEM_BASE, cena),
+    gapCartaLabel: escalar(GAP_CARTA_LABEL_BASE, cena),
+    alturaLabel: escalar(ALTURA_LABEL_BASE, cena),
+    ehPaisagem,
+  });
+  const carta = criarCartaFrente({ cena, x: layout.cartaX, y: layout.cartaY, carta: cartaVirada });
+  carta.setScale(layout.escala).setDepth(81);
+  objetos.push(carta);
+  const label = criarLabelManilha({ cena, manilha, layout });
   objetos.push(label);
-}
-
-function calcularPosicaoManilha(cena: Scene, area: Retangulo, ehPaisagem: boolean): { x: number; y: number } {
-  if (ehPaisagem) {
-    return { x: area.x + area.largura / 2, y: area.y + area.altura - escalar(70, cena) };
-  }
-  return { x: area.x + area.largura / 2, y: area.y + area.altura / 2 };
 }
 
 interface ConfigLabel {
   cena: Scene;
   manilha: Valor;
-  posicao: { x: number; y: number };
+  layout: LayoutManilha;
 }
 
 function criarLabelManilha(config: ConfigLabel): Phaser.GameObjects.Text {
-  const { cena, manilha, posicao } = config;
+  const { cena, manilha, layout } = config;
   return cena.add
-    .text(posicao.x, posicao.y + escalar(32, cena), `Manilha: ${manilha}`, {
+    .text(layout.labelX, layout.labelY, `Manilha: ${manilha}`, {
       fontSize: escalarFonte(9, cena),
       color: '#facc15',
       fontFamily: 'Arial',

--- a/tests/adapters/layout-manilha.test.ts
+++ b/tests/adapters/layout-manilha.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { calcularLayout } from '@/adapters/phaser/layout';
+import { calcularAreaManilha, calcularLayoutManilha } from '@/adapters/phaser/layout-manilha';
+import { ALTURA, LARGURA } from '@/adapters/phaser/renderers/carta-renderer';
+import {
+  ALTURA_LABEL_BASE,
+  GAP_CARTA_LABEL_BASE,
+  MARGEM_BASE,
+} from '@/adapters/phaser/renderers/painel-manilha-renderer';
+
+function criarConfig(area: { x: number; y: number; largura: number; altura: number }, ehPaisagem: boolean) {
+  return {
+    area,
+    cartaLargura: LARGURA,
+    cartaAltura: ALTURA,
+    margem: MARGEM_BASE,
+    gapCartaLabel: GAP_CARTA_LABEL_BASE,
+    alturaLabel: ALTURA_LABEL_BASE,
+    ehPaisagem,
+  };
+}
+
+function limitesCarta(layout: ReturnType<typeof calcularLayoutManilha>) {
+  const metadeLargura = (LARGURA * layout.escala) / 2;
+  const metadeAltura = (ALTURA * layout.escala) / 2;
+  return {
+    esquerda: layout.cartaX - metadeLargura,
+    direita: layout.cartaX + metadeLargura,
+    topo: layout.cartaY - metadeAltura,
+    base: layout.cartaY + metadeAltura,
+  };
+}
+
+describe('calcularLayoutManilha — escala', () => {
+  it('deve usar escala 1 em desktop paisagem com área ampla', () => {
+    const { infoArea } = calcularLayout(1280, 720);
+    const layout = calcularLayoutManilha(criarConfig(infoArea, true));
+
+    expect(layout.escala).toBe(1);
+  });
+
+  it('deve reduzir escala em viewport retrato estreito', () => {
+    const { infoArea } = calcularLayout(320, 568);
+    const area = calcularAreaManilha(infoArea, false);
+    const layout = calcularLayoutManilha(criarConfig(area, false));
+
+    expect(layout.escala).toBeLessThan(1);
+  });
+
+  it('nunca deve ultrapassar escala 1', () => {
+    const { infoArea } = calcularLayout(1920, 1080);
+    const area = calcularAreaManilha(infoArea, true);
+    const layout = calcularLayoutManilha(criarConfig(area, true));
+
+    expect(layout.escala).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('calcularLayoutManilha — contenção', () => {
+  it('deve manter carta e label dentro da área em mobile retrato', () => {
+    const { infoArea } = calcularLayout(390, 844);
+    const area = calcularAreaManilha(infoArea, false);
+    const layout = calcularLayoutManilha(criarConfig(area, false));
+    const carta = limitesCarta(layout);
+
+    expect(carta.esquerda).toBeGreaterThanOrEqual(area.x + MARGEM_BASE);
+    expect(carta.direita).toBeLessThanOrEqual(area.x + area.largura - MARGEM_BASE);
+    expect(carta.topo).toBeGreaterThanOrEqual(area.y + MARGEM_BASE);
+    expect(layout.labelY + ALTURA_LABEL_BASE / 2).toBeLessThanOrEqual(area.y + area.altura - MARGEM_BASE);
+  });
+
+  it('deve manter carta e label dentro da área em viewport estreito', () => {
+    const { infoArea } = calcularLayout(320, 568);
+    const area = calcularAreaManilha(infoArea, false);
+    const layout = calcularLayoutManilha(criarConfig(area, false));
+    const carta = limitesCarta(layout);
+
+    expect(carta.esquerda).toBeGreaterThanOrEqual(area.x + MARGEM_BASE);
+    expect(carta.direita).toBeLessThanOrEqual(area.x + area.largura - MARGEM_BASE);
+    expect(carta.topo).toBeGreaterThanOrEqual(area.y + MARGEM_BASE);
+    expect(layout.labelY + ALTURA_LABEL_BASE / 2).toBeLessThanOrEqual(area.y + area.altura - MARGEM_BASE);
+  });
+});
+
+describe('calcularLayoutManilha — posicionamento', () => {
+  it('deve alinhar manilha na parte inferior em paisagem', () => {
+    const { infoArea } = calcularLayout(1280, 720);
+    const layout = calcularLayoutManilha(criarConfig(infoArea, true));
+    const carta = limitesCarta(layout);
+
+    expect(layout.cartaX).toBe(infoArea.x + infoArea.largura / 2);
+    expect(carta.base).toBeLessThanOrEqual(infoArea.y + infoArea.altura - MARGEM_BASE + 0.5);
+    expect(carta.base).toBeGreaterThan(infoArea.y + infoArea.altura * 0.7);
+  });
+
+  it('deve centralizar manilha na coluna direita em retrato', () => {
+    const { infoArea } = calcularLayout(390, 844);
+    const area = calcularAreaManilha(infoArea, false);
+    const layout = calcularLayoutManilha(criarConfig(area, false));
+    const carta = limitesCarta(layout);
+    const blocoAltura = ALTURA * layout.escala + GAP_CARTA_LABEL_BASE + ALTURA_LABEL_BASE;
+    const centroBloco = (carta.topo + layout.labelY + ALTURA_LABEL_BASE / 2) / 2;
+    const centroEsperado = area.y + area.altura / 2;
+
+    expect(layout.cartaX).toBe(area.x + area.largura / 2);
+    expect(centroBloco).toBeCloseTo(centroEsperado, 0);
+    expect(blocoAltura).toBeLessThanOrEqual(area.altura - MARGEM_BASE * 2);
+  });
+});


### PR DESCRIPTION
## Summary

- Extrai `calcularLayoutManilha` e `calcularAreaManilha` para `layout-manilha.ts`, com escala automática para caber carta + label na área disponível.
- Atualiza o renderer da manilha para usar carta de frente (em vez de mini-carta) com posicionamento derivado do layout calculado.
- Adiciona testes unitários de escala, contenção e posicionamento em retrato/paisagem (viewports 320–1920px).

## Test plan

- [x] `pnpm test tests/adapters/layout-manilha.test.ts` — 7 testes passando
- [x] `pnpm typecheck`
- [x] Abrir painel de info em **retrato** (ex.: 390×844) e confirmar que carta virada + label "Manilha: X" não ultrapassam a coluna direita
- [x] Verificar em **paisagem** (1280×720) que a manilha permanece alinhada na parte inferior do painel
- [x] Conferir visualmente em viewport muito estreito (320×568) que a escala reduz sem cortar conteúdo


Made with [Cursor](https://cursor.com)