### PR TITLE
[codex] Documenta Ranking e protótipo validado

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,22 @@ _Avoid_: Limiar numérico de força, valor alto
 Carta da categoria estratégica **segura** que vence a carta líder atual.
 _Avoid_: Lista manual de valores, carta forte absoluta
 
+**Perfil de Bot**:
+Identidade reconhecível de um bot entre partidas, definida pelo nome e pela faixa de temperatura estratégica, independentemente do assento temporário ocupado na **Partida**.
+_Avoid_: Slot de bot, bot1, bot2, bot3
+
+**Ranking**:
+Classificação persistida de desempenho dos participantes reconhecíveis entre **Partidas**, agregando o jogador humano e cada **Perfil de Bot**.
+_Avoid_: Leaderboard, placar, ranking da partida, placar da rodada
+
+**Vitória de Partida**:
+Resultado atribuído somente ao primeiro colocado da **Partida** encerrada.
+_Avoid_: Vitória de rodada, vaza vencida, turno ganho
+
+**Classificação da Partida**:
+Ordem final dos participantes ao encerrar uma **Partida**, definida por **Pontos** finais decrescentes. Em empate de **Pontos**, o jogador humano fica acima dos **Perfis de Bot**.
+_Avoid_: Tabela final, ranking visual, placar final
+
 ## Relationships
 
 - Uma **Partida** contém uma ou mais **Rodadas**.
@@ -121,6 +137,11 @@ _Avoid_: Lista manual de valores, carta forte absoluta
 - Uma **Decisão de Jogada do Bot** parte de uma **Leitura da Mesa** única, compartilhada pela **Linha fria** e pela **Linha quente**.
 - Uma **Decisão de Jogada do Bot** considera a **Posição na Mesa** antes de avaliar a força da carta.
 - Uma **Decisão de Jogada do Bot** no meio da mesa considera se há **Jogadores por agir** que ainda precisam fazer ou já cumpriram.
+- Um **Ranking** agrega estatísticas por participante reconhecível: o jogador humano e cada **Perfil de Bot**.
+- Um **Perfil de Bot** pode ocupar assentos temporários diferentes em **Partidas** diferentes sem mudar sua identidade no **Ranking**.
+- O win rate no **Ranking** é calculado por **Vitórias de Partida** divididas pelas **Partidas** computadas em que o participante apareceu.
+- A **Classificação da Partida** define a **Vitória de Partida** e a posição registrada no **Ranking**.
+- O **Ranking** registra apenas **Partidas** concluídas e exibe **Perfis de Bot** somente depois que aparecem em pelo menos uma **Partida** computada.
 
 ## Example dialogue
 
@@ -131,3 +152,5 @@ _Avoid_: Lista manual de valores, carta forte absoluta
 
 - `turno` é usado em sentido amplo: inclui o **Turno 0** de declaração e os **Turnos 1..N** de jogada.
 - `G[N-X]` e `P[N-X]` são aliases técnicos; na linguagem de produto use **Escolha de vencedora por necessidade** e **Descarte por necessidade**.
+- `bot1`, `bot2` e `bot3` são assentos técnicos temporários; na linguagem de produto e no **Ranking**, use o **Perfil de Bot**.
+- `vitória` no contexto do **Ranking** significa **Vitória de Partida**, não turno feito nem rodada sobrevivida.

--- a/docs/adr/0002-ranking-renderizado-no-phaser.md
+++ b/docs/adr/0002-ranking-renderizado-no-phaser.md
@@ -1,0 +1,3 @@
+# Ranking renderizado no Phaser
+
+O Ranking do FDP será renderizado pelo adapter Phaser, não por um overlay DOM/HTML em produção. Embora o protótipo tenha usado HTML para validar layout rapidamente, a implementação final permanece no mesmo sistema de cena, input e coordenadas do jogo para manter consistência visual, evitar dois modelos de interface no MVP e preservar o core como TypeScript puro desacoplado da engine.

--- a/prototype-ranking.html
+++ b/prototype-ranking.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<!--
+  PROTÓTIPO DESCARTÁVEL — Tela de Ranking do FDP  (variante D, consolidada)
+  =========================================================================
+  Pergunta que este protótipo responde: "Como deve ser a tela cheia de Ranking?"
+
+  IMPORTANTE — este protótipo é desenhável no Phaser:
+  o jogo roda em Phaser.Scale.NONE e a cena recebe a largura/altura reais.
+  Logo NÃO usamos CSS grid / display:table / media query / flex-grow.
+  Tudo é posicionado por COORDENADA, como um Phaser.Container faria:
+    - faixa central de largura = min(larguraJanela - margem, MAX_FAIXA)
+    - colunas de métrica em x fixo (right-aligned)
+    - linhas empilhadas em y = topo + i * ALTURA_LINHA
+  A única "responsividade" é recalcular essas coordenadas no resize — exatamente
+  o que a cena Phaser faria ao ler this.scale.width / this.scale.height.
+
+  Dados mockados em memória (sem localStorage). NÃO é código de produção.
+  Rodar:  pnpm dev  →  http://localhost:5173/prototype-ranking.html
+  Linguagem canônica: ver CONTEXT.md (Ranking, Perfil de Bot, Vitória de Partida).
+-->
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FDP — Ranking (protótipo)</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --surface: #111827;
+      --surface-2: #1b2436;
+      --line: #2a3550;
+      --text: #e8ecf5;
+      --text-dim: #8b95ad;
+      --accent: #facc15;
+      --winner: #4ecca3;
+
+      /* "constantes de layout" — equivalem a números que a cena Phaser usaria */
+      --max-faixa: 600px;   /* largura máxima da faixa de conteúdo */
+      --col-metr: 78px;     /* largura de cada coluna de métrica */
+      --gap-metr: 8px;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      background: var(--bg); color: var(--text);
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+    .mono { font-variant-numeric: tabular-nums; }
+    .voce { color: var(--accent); }
+
+    /* tela cheia bloqueante */
+    .tela { position: fixed; inset: 0; background: var(--bg); display: flex; flex-direction: column; }
+    .fechar {
+      position: absolute; top: 14px; right: 16px; z-index: 5;
+      width: 40px; height: 40px; border-radius: 999px;
+      border: 1px solid var(--line); background: var(--surface);
+      color: var(--text-dim); font-size: 20px; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .fechar:hover { color: var(--text); border-color: var(--text-dim); }
+
+    /* faixa central de largura fixa (coordenada), centralizada — não estica em telas largas */
+    .faixa { width: 100%; max-width: var(--max-faixa); margin: 0 auto; }
+
+    h1 { font-size: 22px; font-weight: 800; text-align: center; padding: 18px 16px 14px; }
+
+    /* ---- pódio: três colunas de largura fixa, centralizadas (sem flex-grow) ---- */
+    .podio { text-align: center; white-space: nowrap; margin-bottom: 18px; }
+    .col {
+      display: inline-block; vertical-align: bottom; width: 120px; white-space: normal;
+      text-align: center; margin: 0 4px;
+    }
+    .av {
+      width: 56px; height: 56px; margin: 0 auto; border-radius: 999px; background: var(--surface-2);
+      display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 20px;
+      border: 2px solid var(--line);
+    }
+    .col.p1 .av { width: 72px; height: 72px; border-color: var(--accent); color: var(--accent); font-size: 26px; }
+    .col.p2 .av { border-color: #c0c6d4; }
+    .col.p3 .av { border-color: #c98a4b; }
+    .col .medalha { font-size: 18px; margin-bottom: 4px; }
+    .col .nome { font-weight: 700; font-size: 13px; margin-top: 6px; }
+    .col .stat { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+    .col.p1 .stat strong { color: var(--accent); }
+
+    /* ---- controles de ordenação ---- */
+    .rotulo { color: var(--text-dim); font-size: 12px; padding: 0 16px 6px; }
+    .seg {
+      margin: 0 16px 6px; background: var(--surface); border: 1px solid var(--line);
+      border-radius: 10px; padding: 4px; white-space: nowrap;
+    }
+    .seg button {
+      display: inline-block; width: calc((100% - 0px) / 3); padding: 9px 4px; border: none;
+      background: transparent; color: var(--text-dim); font-size: 12px; font-weight: 600;
+      border-radius: 7px; cursor: pointer; vertical-align: middle;
+    }
+    .seg button.ativo { background: var(--accent); color: var(--bg); }
+
+    /* ---- lista (rola) ---- */
+    .lista { flex: 1; overflow-y: auto; padding-bottom: 24px; }
+
+    /* cabeçalho de colunas — alinhado às mesmas colunas de métrica */
+    .cab { padding: 0 16px 6px; color: var(--text-dim); font-size: 10px;
+           text-transform: uppercase; letter-spacing: .05em; white-space: nowrap; }
+    .cab .nome-h { display: inline-block; }
+    .cab .metr-h { float: right; }
+    .cab .ch { display: inline-block; width: var(--col-metr); margin-left: var(--gap-metr);
+               text-align: right; vertical-align: middle; }
+
+    /* uma LINHA = altura fixa, colunas em x fixo (right-aligned). Mapeia 1:1 pro Phaser. */
+    .linha {
+      position: relative; margin: 0 16px 8px; height: 60px; background: var(--surface);
+      border-radius: 12px; border: 1px solid transparent;
+    }
+    .linha.lider { border-color: var(--winner); }
+    .linha .rk {
+      position: absolute; left: 0; top: 0; width: 40px; height: 100%;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 800; color: var(--text-dim);
+    }
+    .linha.lider .rk { color: var(--winner); }
+    .linha .ident { position: absolute; left: 44px; top: 0; height: 100%;
+                    display: flex; flex-direction: column; justify-content: center; }
+    .linha .ident .n { font-weight: 700; font-size: 15px; }
+    .linha .ident .part { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+    /* bloco de métricas ancorado à direita; cada coluna largura fixa */
+    .linha .metr { position: absolute; right: 12px; top: 0; height: 100%; white-space: nowrap;
+                   display: flex; align-items: center; }
+    .linha .metr .m { width: var(--col-metr); margin-left: var(--gap-metr); text-align: right; }
+    .linha .metr .m .v { font-weight: 700; font-size: 15px; }
+    .linha .metr .m .v.on { color: var(--accent); }
+
+    /* faixa switcher removida — protótipo focado só na variante D */
+  </style>
+</head>
+<body>
+  <div class="tela" id="tela"></div>
+
+  <script>
+    // ---- Dados mockados (Perfis de Bot reais + jogador humano). V = Vitórias de Partida ----
+    const PARTICIPANTES = [
+      { nome: 'Você',     humano: true,  vitorias: 5, partidas: 14, posMedia: 1.9 },
+      { nome: 'Severino', humano: false, vitorias: 4, partidas: 12, posMedia: 2.1 },
+      { nome: 'Iara',     humano: false, vitorias: 4, partidas: 16, posMedia: 2.4 },
+      { nome: 'Brás',     humano: false, vitorias: 3, partidas: 9,  posMedia: 2.0 },
+      { nome: 'Vitória',  humano: false, vitorias: 2, partidas: 11, posMedia: 2.8 },
+      { nome: 'Augusto',  humano: false, vitorias: 1, partidas: 7,  posMedia: 3.1 },
+      { nome: 'Fabiano',  humano: false, vitorias: 0, partidas: 5,  posMedia: 3.4 },
+    ];
+
+    const winRate = (p) => p.partidas === 0 ? 0 : Math.round((p.vitorias / p.partidas) * 100);
+    const fmtWr = (p) => winRate(p) + '%';
+    const fmtPos = (p) => p.posMedia.toFixed(1);
+    const inicial = (p) => p.nome[0].toUpperCase();
+
+    const estado = { chave: 'vitorias' };
+    // sentido fixo por métrica: +1 = menor é melhor, -1 = maior é melhor
+    const sentido = { vitorias: -1, winRate: -1, posMedia: 1 };
+    const valor = (p, c) => c === 'vitorias' ? p.vitorias : c === 'winRate' ? winRate(p) : p.posMedia;
+
+    function ordenar() {
+      const sign = sentido[estado.chave];
+      return [...PARTICIPANTES].sort((a, b) => {
+        const d = (valor(a, estado.chave) - valor(b, estado.chave)) * sign;
+        if (d !== 0) return d;
+        if (a.vitorias !== b.vitorias) return b.vitorias - a.vitorias;
+        if (winRate(a) !== winRate(b)) return winRate(b) - winRate(a);
+        if (a.posMedia !== b.posMedia) return a.posMedia - b.posMedia;
+        return (b.humano ? 1 : 0) - (a.humano ? 1 : 0);
+      });
+    }
+    function setOrdem(chave) { estado.chave = chave; render(); }
+
+    // rótulo da métrica ativa, usado no destaque do pódio
+    const rotuloMetrica = { vitorias: 'vitórias', winRate: 'win rate', posMedia: 'pos. média' };
+    const valorFmt = { vitorias: (p) => p.vitorias, winRate: fmtWr, posMedia: fmtPos };
+
+    function render() {
+      const ranqueados = ordenar();              // pódio E lista seguem a métrica ativa
+      const [p1, p2, p3] = ranqueados;
+      const medalhas = ['🥇', '🥈', '🥉'];
+      const nomeClass = (p) => p.humano ? 'voce' : '';
+      const podioCol = (p, cls, m) => p ? `
+        <div class="col ${cls}">
+          <div class="medalha">${m}</div>
+          <div class="av">${inicial(p)}</div>
+          <div class="nome ${nomeClass(p)}">${p.nome}</div>
+          <div class="stat"><strong>${valorFmt[estado.chave](p)}</strong> ${rotuloMetrica[estado.chave]}</div>
+        </div>` : '';
+
+      const segBtn = (c, t) => `<button class="${estado.chave === c ? 'ativo' : ''}" data-ord="${c}">${t}</button>`;
+      const on = (c) => estado.chave === c ? 'on' : '';
+
+      const linhas = ranqueados.map((p, i) => `
+        <div class="linha ${i === 0 ? 'lider' : ''}">
+          <div class="rk">${i + 1}</div>
+          <div class="ident">
+            <div class="n ${nomeClass(p)}">${p.nome}</div>
+            <div class="part">partidas: ${p.partidas}</div>
+          </div>
+          <div class="metr">
+            <div class="m"><div class="v mono ${on('vitorias')}">${p.vitorias}</div></div>
+            <div class="m"><div class="v mono ${on('winRate')}">${fmtWr(p)}</div></div>
+            <div class="m"><div class="v mono ${on('posMedia')}">${fmtPos(p)}</div></div>
+          </div>
+        </div>`).join('');
+
+      document.getElementById('tela').innerHTML = `
+        <button class="fechar" title="Fechar">×</button>
+        <div class="faixa">
+          <h1>Ranking</h1>
+          <div class="podio">
+            ${podioCol(p2, 'p2', medalhas[1])}
+            ${podioCol(p1, 'p1', medalhas[0])}
+            ${podioCol(p3, 'p3', medalhas[2])}
+          </div>
+          <div class="rotulo">Ordenar por</div>
+          <div class="seg">${segBtn('vitorias', 'Vitórias')}${segBtn('winRate', 'Win rate')}${segBtn('posMedia', 'Pos. média')}</div>
+        </div>
+        <div class="lista">
+          <div class="faixa">
+            <div class="cab">
+              <span class="nome-h">Participante</span>
+              <span class="metr-h"><span class="ch">Vitórias</span><span class="ch">Win rate</span><span class="ch">Pos. média</span></span>
+            </div>
+            ${linhas}
+          </div>
+        </div>`;
+
+      const tela = document.getElementById('tela');
+      tela.querySelectorAll('[data-ord]').forEach((el) =>
+        el.addEventListener('click', () => setOrdem(el.getAttribute('data-ord'))));
+    }
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## O que mudou

- Documenta no `CONTEXT.md` a linguagem canônica de Ranking, Perfil de Bot, Vitória de Partida e Classificação da Partida.
- Registra um ADR para manter a implementação final do Ranking no Phaser, apesar do protótipo ter sido feito em HTML.
- Adiciona `prototype-ranking.html` como protótipo descartável validado para guiar a implementação até a feature ficar pronta.

## Por quê

O Ranking já foi refinado e validado visualmente. Este PR preserva as decisões de domínio, arquitetura e layout para que os próximos agentes implementem a feature sem reabrir escolhas já fechadas.

## Validação

- `pnpm lint`
- Hook de push: `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`
- Hook de push: `vitest run` — 51 arquivos, 741 testes passando


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified domain definitions for bot profiles, match rankings, and victory tracking across matches.
  * Documented the architectural approach for rendering the ranking interface.

* **Prototype**
  * Added a visual prototype demonstrating the upcoming ranking UI with participant standings, performance metrics, and sorting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->