### PR TITLE
feat(ranking): tela vazia acessível pelo troféu no painel

### DIFF
--- a/src/adapters/phaser/renderers/painel-info-renderer.ts
+++ b/src/adapters/phaser/renderers/painel-info-renderer.ts
@@ -18,6 +18,7 @@ export interface ConfigPainelInfo {
   cartaVirada: Carta | null;
   layout: LayoutPainel;
   objetos: Phaser.GameObjects.GameObject[];
+  aoAbrirRanking?: () => void;
 }
 
 interface ConfigDesenho {
@@ -42,6 +43,7 @@ export function desenharPainelInfo(config: ConfigPainelInfo): void {
 
   desenharFundo(base);
   desenharCabecalhoRodada(base, config.numeroRodada);
+  if (config.aoAbrirRanking) desenharBotaoTrofeu(base, config.aoAbrirRanking);
   const { colunas, areaManilha } = calcularLayoutTabela(cena, infoArea, ehPaisagem);
   desenharTabela(base, config, colunas);
   if (config.cartaVirada) {
@@ -83,6 +85,20 @@ function desenharCabecalhoRodada(config: ConfigDesenho, numero: number): void {
     .setOrigin(0.5, 0)
     .setDepth(81);
   objetos.push(texto);
+}
+
+function desenharBotaoTrofeu(config: ConfigDesenho, aoAbrir: () => void): void {
+  const { cena, objetos, area } = config;
+  const x = area.x + escalar(16, cena);
+  const y = area.y + escalar(22, cena);
+  const trofeu = cena.add
+    .text(x, y, '🏆', { fontSize: escalarFonte(18, cena), fontFamily: 'Arial' })
+    .setOrigin(0, 0.5)
+    .setDepth(82);
+  const alvo = escalar(36, cena);
+  const zona = cena.add.zone(x, y, alvo, alvo).setOrigin(0, 0.5).setDepth(82).setInteractive({ useHandCursor: true });
+  zona.on('pointerdown', aoAbrir);
+  objetos.push(trofeu, zona);
 }
 
 function calcularLayoutTabela(

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -128,8 +128,14 @@ export class JogoScene extends Scene {
       cartaVirada: emJogo?.cartaVirada ?? null,
       layout: this.layout,
       objetos: this.painelObjetos,
+      aoAbrirRanking: this.abrirRanking,
     });
   }
+
+  private abrirRanking = (): void => {
+    this.scene.launch('RankingScene');
+    this.scene.pause();
+  };
 
   private redesenharTela = (): void => {
     destruirDestaque(this.destaque);

--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -1,5 +1,5 @@
 import { Scene } from 'phaser';
-import { carregarRanking } from '@/store/ranking/carregar-ranking';
+import { carregarRanking, type RankingPersistido } from '@/store/ranking/carregar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 
@@ -12,8 +12,10 @@ const COR_BORDA = 0x2a3550;
 /**
  * Tela cheia do Ranking, aberta sobre a JogoScene (que fica pausada).
  *
- * Nesta fatia (#244) só lê o snapshot persistido e, por estar vazio,
- * mostra o estado vazio. Pódio e tabela entram a partir do #245.
+ * Nesta fatia (#244) só renderiza o estado vazio. O snapshot é lido pela
+ * boundary estrita `carregarRanking`, mas, enquanto o pódio/tabela não
+ * existem, qualquer ranking (inclusive populado) é exibido como vazio — sem
+ * uma tela só com título/fechar. O caso populado entra a partir do #245.
  */
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
@@ -41,11 +43,15 @@ export class RankingScene extends Scene {
     this.desenharFundo();
     this.desenharTitulo();
     this.desenharBotaoFechar();
-    if (ranking.participantes.length === 0) {
-      this.desenharVazio();
-      return;
+    this.desenharConteudo(ranking);
+  }
+
+  private desenharConteudo(ranking: RankingPersistido): void {
+    if (ranking.tipo === 'populado') {
+      // #245: renderizar pódio + tabela a partir de `ranking.participantes`.
+      // Até lá, qualquer snapshot cai no estado vazio.
     }
-    // Pódio + tabela populada entram no #245.
+    this.desenharVazio();
   }
 
   private desenharFundo(): void {

--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -1,0 +1,114 @@
+import { Scene } from 'phaser';
+import { carregarRanking } from '@/store/ranking/carregar-ranking';
+import { escalar, escalarFonte } from '../escala';
+import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
+
+const COR_FUNDO = 0x1a1a2e;
+const COR_TITULO = '#e8ecf5';
+const COR_DIM = '#8b95ad';
+const COR_BOTAO_FUNDO = 0x111827;
+const COR_BORDA = 0x2a3550;
+
+/**
+ * Tela cheia do Ranking, aberta sobre a JogoScene (que fica pausada).
+ *
+ * Nesta fatia (#244) só lê o snapshot persistido e, por estar vazio,
+ * mostra o estado vazio. Pódio e tabela entram a partir do #245.
+ */
+export class RankingScene extends Scene {
+  private objetos: Phaser.GameObjects.GameObject[] = [];
+  private redesenhar?: ResizeDebouncer;
+
+  constructor() {
+    super({ key: 'RankingScene' });
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor('#1a1a2e');
+    this.desenhar();
+    this.redesenhar = criarDebounceResize(this, () => {
+      this.desenhar();
+    });
+    this.scale.on('resize', this.redesenhar);
+    this.events.once('shutdown', () => {
+      this.aoEncerrar();
+    });
+  }
+
+  private desenhar(): void {
+    this.limpar();
+    const ranking = carregarRanking(window.localStorage);
+    this.desenharFundo();
+    this.desenharTitulo();
+    this.desenharBotaoFechar();
+    if (ranking.participantes.length === 0) {
+      this.desenharVazio();
+      return;
+    }
+    // Pódio + tabela populada entram no #245.
+  }
+
+  private desenharFundo(): void {
+    const { width, height } = this.cameras.main;
+    const fundo = this.add.rectangle(width / 2, height / 2, width, height, COR_FUNDO, 1);
+    this.objetos.push(fundo);
+  }
+
+  private desenharTitulo(): void {
+    const titulo = this.add
+      .text(this.cameras.main.centerX, escalar(28, this), 'Ranking', {
+        fontSize: escalarFonte(22, this),
+        color: COR_TITULO,
+        fontStyle: 'bold',
+        fontFamily: 'Arial',
+      })
+      .setOrigin(0.5, 0);
+    this.objetos.push(titulo);
+  }
+
+  private desenharBotaoFechar(): void {
+    const raio = escalar(20, this);
+    const x = this.cameras.main.width - escalar(16, this) - raio;
+    const y = escalar(16, this) + raio;
+    const circulo = this.add.circle(x, y, raio, COR_BOTAO_FUNDO, 1).setStrokeStyle(escalar(1, this), COR_BORDA);
+    const x_ = this.add
+      .text(x, y, '×', { fontSize: escalarFonte(22, this), color: COR_DIM, fontFamily: 'Arial' })
+      .setOrigin(0.5);
+    circulo.setInteractive({ useHandCursor: true }).on('pointerdown', () => {
+      this.fechar();
+    });
+    this.objetos.push(circulo, x_);
+  }
+
+  private desenharVazio(): void {
+    const { centerX, centerY } = this.cameras.main;
+    const mensagem = this.add
+      .text(centerX, centerY, 'Nenhuma partida concluída', {
+        fontSize: escalarFonte(15, this),
+        color: COR_DIM,
+        fontFamily: 'Arial',
+      })
+      .setOrigin(0.5);
+    this.objetos.push(mensagem);
+  }
+
+  private fechar(): void {
+    this.scene.stop();
+    this.scene.resume('JogoScene');
+  }
+
+  private limpar(): void {
+    this.objetos.forEach((obj) => {
+      obj.destroy();
+    });
+    this.objetos = [];
+  }
+
+  private aoEncerrar(): void {
+    if (this.redesenhar) {
+      this.scale.off('resize', this.redesenhar);
+      this.redesenhar.limpar();
+    }
+    this.limpar();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Game } from 'phaser';
 import { JogoScene } from './adapters/phaser/scenes/JogoScene';
 import { MenuScene } from './adapters/phaser/scenes/MenuScene';
+import { RankingScene } from './adapters/phaser/scenes/RankingScene';
 import './style.css';
 
 let jogo: Game | null = null;
@@ -23,7 +24,7 @@ function criarConfiguracaoJogo(containerId?: string): Phaser.Types.Core.GameConf
     height: window.innerHeight * dpr,
     parent: containerId,
     zoom: 1 / dpr,
-    scene: [MenuScene, JogoScene],
+    scene: [MenuScene, JogoScene, RankingScene],
     scale: {
       mode: Phaser.Scale.NONE,
     },

--- a/src/store/ranking/carregar-ranking.ts
+++ b/src/store/ranking/carregar-ranking.ts
@@ -1,9 +1,12 @@
 /**
  * Caminho de leitura do Ranking persistido.
  *
- * Esta fatia (#244) só lê o snapshot para distinguir vazio de preenchido.
- * A gravação e a agregação de métricas entram no #245, que estende
- * `ParticipanteRanking` com os campos derivados (win rate, posição média).
+ * Esta fatia (#244) só distingue ranking vazio de populado. A gravação e a
+ * renderização do ranking populado (pódio + tabela) entram no #245.
+ *
+ * A leitura é uma boundary estrita: qualquer conteúdo que não seja um snapshot
+ * `versao: 1` com uma lista de participantes íntegros é tratado como vazio, para
+ * não entregar dados corrompidos como se fossem confiáveis.
  */
 
 export const CHAVE_RANKING = 'fdp.ranking.v1';
@@ -16,34 +19,49 @@ export interface ParticipanteRanking {
   somaPosicoes: number;
 }
 
-export interface RankingPersistido {
-  versao: 1;
-  participantes: ParticipanteRanking[];
-}
+export type RankingPersistido = { tipo: 'vazio' } | { tipo: 'populado'; participantes: ParticipanteRanking[] };
 
-const RANKING_VAZIO: RankingPersistido = { versao: 1, participantes: [] };
+const VAZIO: RankingPersistido = { tipo: 'vazio' };
 
 export function carregarRanking(armazenamento: Pick<Storage, 'getItem'>): RankingPersistido {
   const bruto = armazenamento.getItem(CHAVE_RANKING);
-  if (bruto === null) return RANKING_VAZIO;
+  if (bruto === null) return VAZIO;
   return interpretar(bruto);
 }
 
 function interpretar(bruto: string): RankingPersistido {
   try {
-    const conteudo: unknown = JSON.parse(bruto);
-    if (!ehSnapshotValido(conteudo)) return RANKING_VAZIO;
-    return { versao: 1, participantes: conteudo.participantes };
+    return classificar(JSON.parse(bruto));
   } catch {
-    return RANKING_VAZIO;
+    return VAZIO;
   }
 }
 
-function ehSnapshotValido(conteudo: unknown): conteudo is { participantes: ParticipanteRanking[] } {
+function classificar(conteudo: unknown): RankingPersistido {
+  if (!ehSnapshotV1(conteudo)) return VAZIO;
+  const participantes = conteudo.participantes.filter(ehParticipante);
+  if (participantes.length === 0 || participantes.length !== conteudo.participantes.length) return VAZIO;
+  return { tipo: 'populado', participantes };
+}
+
+function ehSnapshotV1(conteudo: unknown): conteudo is { versao: 1; participantes: unknown[] } {
+  if (typeof conteudo !== 'object' || conteudo === null) return false;
+  const registro = conteudo as Record<string, unknown>;
+  return registro.versao === 1 && Array.isArray(registro.participantes);
+}
+
+function ehParticipante(valor: unknown): valor is ParticipanteRanking {
+  if (typeof valor !== 'object' || valor === null) return false;
+  const p = valor as Record<string, unknown>;
   return (
-    typeof conteudo === 'object' &&
-    conteudo !== null &&
-    'participantes' in conteudo &&
-    Array.isArray(conteudo.participantes)
+    typeof p.nome === 'string' &&
+    typeof p.humano === 'boolean' &&
+    ehNumeroFinito(p.vitorias) &&
+    ehNumeroFinito(p.partidas) &&
+    ehNumeroFinito(p.somaPosicoes)
   );
+}
+
+function ehNumeroFinito(valor: unknown): valor is number {
+  return typeof valor === 'number' && Number.isFinite(valor);
 }

--- a/src/store/ranking/carregar-ranking.ts
+++ b/src/store/ranking/carregar-ranking.ts
@@ -1,0 +1,49 @@
+/**
+ * Caminho de leitura do Ranking persistido.
+ *
+ * Esta fatia (#244) só lê o snapshot para distinguir vazio de preenchido.
+ * A gravação e a agregação de métricas entram no #245, que estende
+ * `ParticipanteRanking` com os campos derivados (win rate, posição média).
+ */
+
+export const CHAVE_RANKING = 'fdp.ranking.v1';
+
+export interface ParticipanteRanking {
+  nome: string;
+  humano: boolean;
+  vitorias: number;
+  partidas: number;
+  somaPosicoes: number;
+}
+
+export interface RankingPersistido {
+  versao: 1;
+  participantes: ParticipanteRanking[];
+}
+
+const RANKING_VAZIO: RankingPersistido = { versao: 1, participantes: [] };
+
+export function carregarRanking(armazenamento: Pick<Storage, 'getItem'>): RankingPersistido {
+  const bruto = armazenamento.getItem(CHAVE_RANKING);
+  if (bruto === null) return RANKING_VAZIO;
+  return interpretar(bruto);
+}
+
+function interpretar(bruto: string): RankingPersistido {
+  try {
+    const conteudo: unknown = JSON.parse(bruto);
+    if (!ehSnapshotValido(conteudo)) return RANKING_VAZIO;
+    return { versao: 1, participantes: conteudo.participantes };
+  } catch {
+    return RANKING_VAZIO;
+  }
+}
+
+function ehSnapshotValido(conteudo: unknown): conteudo is { participantes: ParticipanteRanking[] } {
+  return (
+    typeof conteudo === 'object' &&
+    conteudo !== null &&
+    'participantes' in conteudo &&
+    Array.isArray(conteudo.participantes)
+  );
+}

--- a/tests/store/carregar-ranking.test.ts
+++ b/tests/store/carregar-ranking.test.ts
@@ -5,40 +5,60 @@ function armazenamentoCom(valor: string | null): Pick<Storage, 'getItem'> {
   return { getItem: (chave) => (chave === CHAVE_RANKING ? valor : null) };
 }
 
+function snapshot(participantes: unknown[], versao: unknown = 1): string {
+  return JSON.stringify({ versao, participantes });
+}
+
+const participanteValido = { nome: 'Você', humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 };
+
+describe('carregarRanking trata como vazio', () => {
+  it('quando a chave está ausente', () => {
+    expect(carregarRanking(armazenamentoCom(null))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando o conteúdo é um JSON inválido', () => {
+    expect(carregarRanking(armazenamentoCom('{ não é json'))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando o conteúdo não é um objeto', () => {
+    expect(carregarRanking(armazenamentoCom(JSON.stringify(42)))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando a versão não é 1', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot([participanteValido], 2)))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando os participantes não são uma lista', () => {
+    const conteudo = JSON.stringify({ versao: 1, participantes: 'x' });
+    expect(carregarRanking(armazenamentoCom(conteudo))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando a lista de participantes está vazia', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot([])))).toEqual({ tipo: 'vazio' });
+  });
+});
+
+describe('carregarRanking rejeita participante inválido', () => {
+  it('quando um item da lista é nulo', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot([participanteValido, null])))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando uma métrica não é numérica', () => {
+    const corrompido = { ...participanteValido, vitorias: '2' };
+    expect(carregarRanking(armazenamentoCom(snapshot([corrompido])))).toEqual({ tipo: 'vazio' });
+  });
+
+  it('quando falta o nome', () => {
+    const semNome = { humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 };
+    expect(carregarRanking(armazenamentoCom(snapshot([semNome])))).toEqual({ tipo: 'vazio' });
+  });
+});
+
 describe('carregarRanking', () => {
-  it('deve retornar ranking vazio quando a chave está ausente', () => {
-    const ranking = carregarRanking(armazenamentoCom(null));
+  it('deve retornar populado com os participantes de um snapshot válido', () => {
+    const ranking = carregarRanking(armazenamentoCom(snapshot([participanteValido])));
 
-    expect(ranking.participantes).toEqual([]);
-  });
-
-  it('deve retornar ranking vazio quando o conteúdo é um JSON inválido', () => {
-    const ranking = carregarRanking(armazenamentoCom('{ não é json'));
-
-    expect(ranking.participantes).toEqual([]);
-  });
-
-  it('deve retornar ranking vazio quando os participantes não são uma lista', () => {
-    const ranking = carregarRanking(armazenamentoCom(JSON.stringify({ versao: 1, participantes: 'x' })));
-
-    expect(ranking.participantes).toEqual([]);
-  });
-
-  it('deve retornar ranking vazio quando o conteúdo não é um objeto', () => {
-    const ranking = carregarRanking(armazenamentoCom(JSON.stringify(42)));
-
-    expect(ranking.participantes).toEqual([]);
-  });
-
-  it('deve preservar os participantes de um snapshot válido', () => {
-    const conteudo = JSON.stringify({
-      versao: 1,
-      participantes: [{ nome: 'Você', humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 }],
-    });
-
-    const ranking = carregarRanking(armazenamentoCom(conteudo));
-
-    expect(ranking.participantes).toHaveLength(1);
-    expect(ranking.participantes[0].nome).toBe('Você');
+    expect(ranking.tipo).toBe('populado');
+    expect(ranking).toMatchObject({ tipo: 'populado', participantes: [{ nome: 'Você' }] });
   });
 });

--- a/tests/store/carregar-ranking.test.ts
+++ b/tests/store/carregar-ranking.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { CHAVE_RANKING, carregarRanking } from '@/store/ranking/carregar-ranking';
+
+function armazenamentoCom(valor: string | null): Pick<Storage, 'getItem'> {
+  return { getItem: (chave) => (chave === CHAVE_RANKING ? valor : null) };
+}
+
+describe('carregarRanking', () => {
+  it('deve retornar ranking vazio quando a chave está ausente', () => {
+    const ranking = carregarRanking(armazenamentoCom(null));
+
+    expect(ranking.participantes).toEqual([]);
+  });
+
+  it('deve retornar ranking vazio quando o conteúdo é um JSON inválido', () => {
+    const ranking = carregarRanking(armazenamentoCom('{ não é json'));
+
+    expect(ranking.participantes).toEqual([]);
+  });
+
+  it('deve retornar ranking vazio quando os participantes não são uma lista', () => {
+    const ranking = carregarRanking(armazenamentoCom(JSON.stringify({ versao: 1, participantes: 'x' })));
+
+    expect(ranking.participantes).toEqual([]);
+  });
+
+  it('deve retornar ranking vazio quando o conteúdo não é um objeto', () => {
+    const ranking = carregarRanking(armazenamentoCom(JSON.stringify(42)));
+
+    expect(ranking.participantes).toEqual([]);
+  });
+
+  it('deve preservar os participantes de um snapshot válido', () => {
+    const conteudo = JSON.stringify({
+      versao: 1,
+      participantes: [{ nome: 'Você', humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 }],
+    });
+
+    const ranking = carregarRanking(armazenamentoCom(conteudo));
+
+    expect(ranking.participantes).toHaveLength(1);
+    expect(ranking.participantes[0].nome).toBe('Você');
+  });
+});


### PR DESCRIPTION
Closes #244

Primeira fatia vertical do Ranking (PRD #242), já visível no jogo.

## O que entrega

- Botão de troféu 🏆 no painel da partida que abre a `RankingScene` em tela cheia sobre a `JogoScene`.
- Abrir o Ranking **pausa de verdade** a `JogoScene` (`scene.pause()`); fechar retoma do mesmo ponto (`scene.resume('JogoScene')`). O loop dos bots avança via `time.delayedCall`, cujo clock congela ao pausar a cena — então bots e animações não avançam por baixo.
- Estado vazio: título `Ranking`, botão circular de fechar no canto superior direito e a mensagem `Nenhuma partida concluída`, sem pódio nem tabela.
- Caminho de **leitura** da persistência no módulo puro `src/store/ranking/carregar-ranking.ts`, lendo a chave versionada `fdp.ranking.v1`. Chave ausente ou conteúdo inválido vira estado vazio.

Fora de escopo (entra nas próximas fatias): gravação de partida, agregação de métricas, tabela populada, pódio e controle de ordenação.

## Critérios de aceite

- [x] Botão de troféu no painel; tocar abre o Ranking.
- [x] Ranking em tela cheia com botão circular de fechar no canto superior direito.
- [x] Abrir pausa a `JogoScene`; fechar retoma do mesmo ponto.
- [x] Sem dados persistidos, mostra `Nenhuma partida concluída`, sem pódio nem tabela.
- [x] Leitura usa a chave versionada `fdp.ranking.v1`; ausente ou inválida vira estado vazio.
- [x] Acesso só pelo troféu no painel — nada novo no menu nem na tela de fim de jogo.

## Testes e verificação

- Parte pura via TDD (Vitest): 5 testes em `tests/store/carregar-ranking.test.ts` cobrindo chave ausente, JSON inválido, formato inválido, não-objeto e snapshot válido.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (746 testes) e `pnpm build` passando.
- Validação visual no browser (Chrome DevTools MCP): troféu abre a cena, `JogoScene` fica pausada (`time.now` congelado durante a pausa) e retoma no mesmo ponto ao fechar; estado vazio renderizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trophy/ranking button now available in the info panel for accessing rankings
  * New ranking overlay displays game statistics and player leaderboard information
  * Rankings automatically persist across sessions using local storage

* **Tests**
  * Added test suite for ranking data loading, validation, and edge case handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->