### PR TITLE
feat(ranking): grava partida concluída e exibe tabela de dados reais

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,7 +117,7 @@ Resultado atribuído somente ao primeiro colocado da **Partida** encerrada.
 _Avoid_: Vitória de rodada, vaza vencida, turno ganho
 
 **Classificação da Partida**:
-Ordem final dos participantes ao encerrar uma **Partida**, definida por **Pontos** finais decrescentes. Em empate de **Pontos**, o jogador humano fica acima dos **Perfis de Bot**.
+Ordem final dos participantes ao encerrar uma **Partida**, definida por sobrevivência: vencedor primeiro, depois **Jogadores eliminados** do mais recente para o mais antigo. Entre jogadores eliminados no mesmo fechamento de **Rodada**, vence quem ficou com mais **Pontos**; em empate de **Pontos**, o jogador humano fica acima dos **Perfis de Bot**.
 _Avoid_: Tabela final, ranking visual, placar final
 
 ## Relationships

--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -2,6 +2,7 @@ import { Scene } from 'phaser';
 import { carregarRanking, type RankingPersistido } from '@/store/ranking/carregar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
+import { desenharTabelaRanking } from './desenhar-tabela-ranking';
 
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
@@ -12,10 +13,10 @@ const COR_BORDA = 0x2a3550;
 /**
  * Tela cheia do Ranking, aberta sobre a JogoScene (que fica pausada).
  *
- * Nesta fatia (#244) só renderiza o estado vazio. O snapshot é lido pela
- * boundary estrita `carregarRanking`, mas, enquanto o pódio/tabela não
- * existem, qualquer ranking (inclusive populado) é exibido como vazio — sem
- * uma tela só com título/fechar. O caso populado entra a partir do #245.
+ * Lê o snapshot pela boundary estrita `carregarRanking`: ranking vazio mostra a
+ * mensagem de tela vazia; ranking populado renderiza a tabela de participantes
+ * ordenada por Vitórias (#245). O pódio (#247) e os controles de ordenação
+ * (#246) entram nas próximas fatias.
  */
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
@@ -48,8 +49,8 @@ export class RankingScene extends Scene {
 
   private desenharConteudo(ranking: RankingPersistido): void {
     if (ranking.tipo === 'populado') {
-      // #245: renderizar pódio + tabela a partir de `ranking.participantes`.
-      // Até lá, qualquer snapshot cai no estado vazio.
+      this.objetos.push(...desenharTabelaRanking(this, ranking.participantes));
+      return;
     }
     this.desenharVazio();
   }

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -1,0 +1,153 @@
+import type { Scene } from 'phaser';
+import { ordenarRanking, type ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
+import type { ParticipanteRanking } from '@/store/ranking/tipos';
+import { escalar, escalarFonte } from '../escala';
+
+/**
+ * Tabela de participantes do Ranking, posicionada por coordenada (sem layout
+ * CSS), espelhando o protótipo validado: faixa central de largura máxima fixa,
+ * colunas de métrica à direita, `partidas: N` sob o nome e `Você` em dourado.
+ * Esta fatia (#245) renderiza a ordenação fixa por Vitórias; os controles de
+ * ordenação (#246) e o pódio (#247) entram depois.
+ */
+
+const COR_TEXTO = '#e8ecf5';
+const COR_DIM = '#8b95ad';
+const COR_ACENTO = '#facc15';
+const COR_VERDE = '#4ecca3';
+const COR_LINHA_FUNDO = 0x111827;
+const COR_LIDER = 0x4ecca3;
+
+const MAX_FAIXA = 600;
+const COL_METRICA = 84;
+const GAP = 6;
+
+interface LayoutTabela {
+  esquerda: number;
+  direita: number;
+  larguraColuna: number;
+  gap: number;
+  alturaLinha: number;
+  topo: number;
+}
+
+/** Pincel = cena + geometria já calculada, para manter as funções com ≤3 params. */
+interface Pincel {
+  cena: Scene;
+  layout: LayoutTabela;
+}
+
+export function desenharTabelaRanking(
+  cena: Scene,
+  participantes: ParticipanteRanking[],
+): Phaser.GameObjects.GameObject[] {
+  const pincel: Pincel = { cena, layout: calcularLayout(cena) };
+  const ordenados = ordenarRanking(participantes, 'vitorias');
+  const objetos = desenharCabecalho(pincel);
+  ordenados.forEach((item, indice) => {
+    const y = pincel.layout.topo + escalar(34, cena) + indice * pincel.layout.alturaLinha;
+    objetos.push(...desenharLinha(pincel, { item, indice, y }));
+  });
+  return objetos;
+}
+
+function calcularLayout(cena: Scene): LayoutTabela {
+  const { width } = cena.cameras.main;
+  const margem = escalar(16, cena);
+  const larguraFaixa = Math.min(width - margem * 2, escalar(MAX_FAIXA, cena));
+  const esquerda = (width - larguraFaixa) / 2;
+  return {
+    esquerda,
+    direita: esquerda + larguraFaixa - escalar(12, cena),
+    larguraColuna: escalar(COL_METRICA, cena),
+    gap: escalar(GAP, cena),
+    alturaLinha: escalar(64, cena),
+    topo: escalar(70, cena),
+  };
+}
+
+function colunaX(layout: LayoutTabela, ordemDireita: number): number {
+  return layout.direita - ordemDireita * (layout.larguraColuna + layout.gap);
+}
+
+function desenharCabecalho({ cena, layout }: Pincel): Phaser.GameObjects.GameObject[] {
+  const y = layout.topo;
+  const estilo = { fontSize: escalarFonte(10, cena), color: COR_DIM, fontFamily: 'Arial' };
+  const titulo = cena.add.text(layout.esquerda, y, 'Participante', estilo).setOrigin(0, 0.5);
+  const cabecalhos = ['Vitórias', 'Win rate', 'Pos. média'].map((rotulo, coluna) =>
+    cena.add.text(colunaX(layout, 2 - coluna), y, rotulo, estilo).setOrigin(1, 0.5),
+  );
+  return [titulo, ...cabecalhos];
+}
+
+interface LinhaCtx {
+  item: ParticipanteRankeado;
+  indice: number;
+  y: number;
+}
+
+function desenharLinha(pincel: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameObject[] {
+  const lider = ctx.indice === 0;
+  return [
+    fundoLinha(pincel, ctx.y, lider),
+    posicao(pincel, { y: ctx.y, numero: ctx.indice + 1, lider }),
+    ...identidade(pincel, ctx.y, ctx.item),
+    ...metricas(pincel, ctx.y, ctx.item),
+  ];
+}
+
+function fundoLinha({ cena, layout }: Pincel, y: number, lider: boolean): Phaser.GameObjects.GameObject {
+  const largura = layout.direita - layout.esquerda + escalar(12, cena);
+  const altura = layout.alturaLinha - escalar(8, cena);
+  const fundo = cena.add.rectangle(layout.esquerda, y, largura, altura, COR_LINHA_FUNDO, 1).setOrigin(0, 0.5);
+  if (lider) fundo.setStrokeStyle(escalar(1, cena), COR_LIDER);
+  return fundo;
+}
+
+function posicao(
+  { cena, layout }: Pincel,
+  ctx: { y: number; numero: number; lider: boolean },
+): Phaser.GameObjects.GameObject {
+  return cena.add
+    .text(layout.esquerda + escalar(16, cena), ctx.y, String(ctx.numero), {
+      fontSize: escalarFonte(15, cena),
+      color: ctx.lider ? COR_VERDE : COR_DIM,
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+}
+
+function identidade({ cena, layout }: Pincel, y: number, item: ParticipanteRankeado): Phaser.GameObjects.GameObject[] {
+  const x = layout.esquerda + escalar(40, cena);
+  const nome = cena.add
+    .text(x, y - escalar(8, cena), item.nomeExibicao, {
+      fontSize: escalarFonte(15, cena),
+      color: item.humano ? COR_ACENTO : COR_TEXTO,
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0, 0.5);
+  const partidas = cena.add
+    .text(x, y + escalar(10, cena), `partidas: ${String(item.partidas)}`, {
+      fontSize: escalarFonte(10, cena),
+      color: COR_DIM,
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0, 0.5);
+  return [nome, partidas];
+}
+
+function metricas({ cena, layout }: Pincel, y: number, item: ParticipanteRankeado): Phaser.GameObjects.GameObject[] {
+  const valores = [String(item.vitorias), `${String(item.winRate)}%`, item.posMedia.toFixed(1)];
+  return valores.map((valor, coluna) =>
+    cena.add
+      .text(colunaX(layout, 2 - coluna), y, valor, {
+        fontSize: escalarFonte(15, cena),
+        color: COR_TEXTO,
+        fontStyle: 'bold',
+        fontFamily: 'Arial',
+      })
+      .setOrigin(1, 0.5),
+  );
+}

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -120,8 +120,9 @@ function posicao(
 
 function identidade({ cena, layout }: Pincel, y: number, item: ParticipanteRankeado): Phaser.GameObjects.GameObject[] {
   const x = layout.esquerda + escalar(40, cena);
+  const rotulo = item.humano ? 'Você' : item.nomeExibicao;
   const nome = cena.add
-    .text(x, y - escalar(8, cena), item.nomeExibicao, {
+    .text(x, y - escalar(8, cena), rotulo, {
       fontSize: escalarFonte(15, cena),
       color: item.humano ? COR_ACENTO : COR_TEXTO,
       fontStyle: 'bold',

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -87,7 +87,7 @@ export class JogoController {
         this.deps.atualizarPainel();
       },
       onJogoEncerrado: (classificacao: Jogador[]) => {
-        registrarPartidaNoArmazenamento(window.localStorage, classificacao);
+        registrarPartidaNoArmazenamento(() => window.localStorage, classificacao);
         this.deps.desativarResize();
         this.deps.mostrarFimJogo(classificacao);
       },

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -1,5 +1,6 @@
 import type { Scene } from 'phaser';
 import type { Partida } from '@/core/Partida';
+import { registrarPartidaNoArmazenamento } from '@/store/ranking/gravar-ranking';
 import type { Jogador } from '@/types/entidades';
 import { ehFaseDeclaracao, estadoEmJogo } from '@/types/estado-rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
@@ -86,6 +87,7 @@ export class JogoController {
         this.deps.atualizarPainel();
       },
       onJogoEncerrado: (classificacao: Jogador[]) => {
+        registrarPartidaNoArmazenamento(window.localStorage, classificacao);
         this.deps.desativarResize();
         this.deps.mostrarFimJogo(classificacao);
       },

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -18,6 +18,11 @@ interface DecisoresPartida {
   rng?: GeradorAleatorio;
 }
 
+interface Eliminacao {
+  jogador: Jogador;
+  ordem: number;
+}
+
 export class Partida {
   private jogadores: Jogador[];
   private decisores: DecisoresPartida;
@@ -27,7 +32,8 @@ export class Partida {
   private embaralhadorIndice: number;
   private rng: GeradorAleatorio;
   private jogoEncerrado = false;
-  private eliminados: Jogador[] = [];
+  private eliminados: Eliminacao[] = [];
+  private ordemEliminacao = 0;
 
   constructor(jogadores: Jogador[], emissor: EmissorPartida, decisores: DecisoresPartida) {
     this.jogadores = jogadores;
@@ -110,7 +116,9 @@ export class Partida {
 
     const eliminados = this.jogadores.filter(deveEliminar);
     if (eliminados.length === 0) return false;
-    this.eliminados = [...this.eliminados, ...eliminados];
+    const ordem = this.ordemEliminacao;
+    this.ordemEliminacao += 1;
+    this.eliminados = [...this.eliminados, ...eliminados.map((jogador) => ({ jogador, ordem }))];
     this.jogadores = this.jogadores.filter((jogador) => !deveEliminar(jogador));
     this.ajustarEmbaralhadorAposEliminacao();
     eliminados.forEach((jogador) => {
@@ -174,9 +182,20 @@ export class Partida {
     this.emissor.emit({
       ...criarEventoBase(),
       tipo: 'JOGO_ENCERRADO',
-      classificacao: [...this.jogadores, ...this.eliminados].sort(compararClassificacao),
+      classificacao: this.montarClassificacao(),
     });
   }
+
+  private montarClassificacao(): Jogador[] {
+    const vencedores = [...this.jogadores].sort(compararClassificacao);
+    const eliminados = [...this.eliminados].sort(compararEliminacao).map(({ jogador }) => jogador);
+    return [...vencedores, ...eliminados];
+  }
+}
+
+function compararEliminacao(a: Eliminacao, b: Eliminacao): number {
+  if (a.ordem !== b.ordem) return b.ordem - a.ordem;
+  return compararClassificacao(a.jogador, b.jogador);
 }
 
 function compararClassificacao(a: Jogador, b: Jogador): number {

--- a/src/core/Partida.ts
+++ b/src/core/Partida.ts
@@ -174,7 +174,16 @@ export class Partida {
     this.emissor.emit({
       ...criarEventoBase(),
       tipo: 'JOGO_ENCERRADO',
-      classificacao: [...this.jogadores, ...this.eliminados].sort((a, b) => b.pontos - a.pontos),
+      classificacao: [...this.jogadores, ...this.eliminados].sort(compararClassificacao),
     });
   }
+}
+
+function compararClassificacao(a: Jogador, b: Jogador): number {
+  if (a.pontos !== b.pontos) return b.pontos - a.pontos;
+  return ehHumano(b) - ehHumano(a);
+}
+
+function ehHumano(jogador: Jogador): number {
+  return jogador.id === 'humano' ? 1 : 0;
 }

--- a/src/store/ranking/carregar-ranking.ts
+++ b/src/store/ranking/carregar-ranking.ts
@@ -1,61 +1,73 @@
 /**
- * Caminho de leitura do Ranking persistido.
+ * Boundary de leitura do Ranking persistido (`fdp.ranking.v1`).
  *
- * Esta fatia (#244) só distingue ranking vazio de populado. A gravação e a
- * renderização do ranking populado (pódio + tabela) entram no #245.
- *
- * A leitura é uma boundary estrita: qualquer conteúdo que não seja um snapshot
- * `versao: 1` com uma lista de participantes íntegros é tratado como vazio, para
- * não entregar dados corrompidos como se fossem confiáveis.
+ * O snapshot guarda somatórios brutos por participante num `Record` chaveado
+ * pela identidade de Ranking (`humano`, `bot:bras`). A leitura é estrita:
+ * qualquer conteúdo que não seja um snapshot `versao: 1` com participantes
+ * íntegros é tratado como vazio, para nunca entregar dado corrompido como
+ * confiável. Para a tela, o `Record` é materializado numa lista com a chave e o
+ * flag humano; as métricas e a ordem são calculadas em `ordenarRanking`.
  */
 
-export const CHAVE_RANKING = 'fdp.ranking.v1';
+import { CHAVE_RANKING, SNAPSHOT_VAZIO } from './tipos';
+import type { ParticipanteRanking, ParticipantePersistido, SnapshotRanking } from './tipos';
 
-export interface ParticipanteRanking {
-  nome: string;
-  humano: boolean;
-  vitorias: number;
-  partidas: number;
-  somaPosicoes: number;
-}
+export { CHAVE_RANKING } from './tipos';
+export type { ParticipanteRanking } from './tipos';
 
 export type RankingPersistido = { tipo: 'vazio' } | { tipo: 'populado'; participantes: ParticipanteRanking[] };
 
 const VAZIO: RankingPersistido = { tipo: 'vazio' };
 
 export function carregarRanking(armazenamento: Pick<Storage, 'getItem'>): RankingPersistido {
-  const bruto = armazenamento.getItem(CHAVE_RANKING);
-  if (bruto === null) return VAZIO;
-  return interpretar(bruto);
-}
-
-function interpretar(bruto: string): RankingPersistido {
-  try {
-    return classificar(JSON.parse(bruto));
-  } catch {
-    return VAZIO;
-  }
-}
-
-function classificar(conteudo: unknown): RankingPersistido {
-  if (!ehSnapshotV1(conteudo)) return VAZIO;
-  const participantes = conteudo.participantes.filter(ehParticipante);
-  if (participantes.length === 0 || participantes.length !== conteudo.participantes.length) return VAZIO;
+  const participantes = materializar(lerSnapshot(armazenamento));
+  if (participantes.length === 0) return VAZIO;
   return { tipo: 'populado', participantes };
 }
 
-function ehSnapshotV1(conteudo: unknown): conteudo is { versao: 1; participantes: unknown[] } {
-  if (typeof conteudo !== 'object' || conteudo === null) return false;
-  const registro = conteudo as Record<string, unknown>;
-  return registro.versao === 1 && Array.isArray(registro.participantes);
+/** Lê o snapshot bruto; qualquer conteúdo inválido vira o snapshot vazio. */
+export function lerSnapshot(armazenamento: Pick<Storage, 'getItem'>): SnapshotRanking {
+  const bruto = armazenamento.getItem(CHAVE_RANKING);
+  if (bruto === null) return SNAPSHOT_VAZIO;
+  try {
+    return validar(JSON.parse(bruto));
+  } catch {
+    return SNAPSHOT_VAZIO;
+  }
 }
 
-function ehParticipante(valor: unknown): valor is ParticipanteRanking {
+function materializar(snapshot: SnapshotRanking): ParticipanteRanking[] {
+  return Object.entries(snapshot.participantes).map(([chave, p]) => ({
+    ...p,
+    chave,
+    humano: chave === 'humano',
+  }));
+}
+
+function validar(conteudo: unknown): SnapshotRanking {
+  if (!ehSnapshotV1(conteudo)) return SNAPSHOT_VAZIO;
+  const entradas = Object.entries(conteudo.participantes);
+  if (!entradas.every(([chave, valor]) => chave !== '' && ehParticipante(valor))) return SNAPSHOT_VAZIO;
+  return conteudo as SnapshotRanking;
+}
+
+function ehSnapshotV1(conteudo: unknown): conteudo is { versao: 1; participantes: Record<string, unknown> } {
+  if (typeof conteudo !== 'object' || conteudo === null) return false;
+  const registro = conteudo as Record<string, unknown>;
+  const participantes = registro.participantes;
+  return (
+    registro.versao === 1 &&
+    typeof participantes === 'object' &&
+    participantes !== null &&
+    !Array.isArray(participantes)
+  );
+}
+
+function ehParticipante(valor: unknown): valor is ParticipantePersistido {
   if (typeof valor !== 'object' || valor === null) return false;
   const p = valor as Record<string, unknown>;
   return (
-    typeof p.nome === 'string' &&
-    typeof p.humano === 'boolean' &&
+    typeof p.nomeExibicao === 'string' &&
     ehNumeroFinito(p.vitorias) &&
     ehNumeroFinito(p.partidas) &&
     ehNumeroFinito(p.somaPosicoes)

--- a/src/store/ranking/carregar-ranking.ts
+++ b/src/store/ranking/carregar-ranking.ts
@@ -65,15 +65,22 @@ function ehSnapshotV1(conteudo: unknown): conteudo is { versao: 1; participantes
 
 function ehParticipante(valor: unknown): valor is ParticipantePersistido {
   if (typeof valor !== 'object' || valor === null) return false;
-  const p = valor as Record<string, unknown>;
-  return (
-    typeof p.nomeExibicao === 'string' &&
-    ehNumeroFinito(p.vitorias) &&
-    ehNumeroFinito(p.partidas) &&
-    ehNumeroFinito(p.somaPosicoes)
-  );
+  const { nomeExibicao, partidas, vitorias, somaPosicoes } = valor as Record<string, unknown>;
+  if (typeof nomeExibicao !== 'string' || nomeExibicao === '') return false;
+  if (!ehContagem(partidas) || !ehContagem(vitorias) || !ehContagem(somaPosicoes)) return false;
+  return ehSomatorioCoerente(partidas, vitorias, somaPosicoes);
 }
 
-function ehNumeroFinito(valor: unknown): valor is number {
-  return typeof valor === 'number' && Number.isFinite(valor);
+/**
+ * Invariantes do somatório: cada participante persistido apareceu em ao menos
+ * uma Partida; não vence mais Partidas do que disputou; e, como cada aparição
+ * contribui com posição ≥ 1, a soma das posições nunca fica abaixo do total de
+ * Partidas (o que mantém a Pos. média ≥ 1).
+ */
+function ehSomatorioCoerente(partidas: number, vitorias: number, somaPosicoes: number): boolean {
+  return partidas >= 1 && vitorias <= partidas && somaPosicoes >= partidas;
+}
+
+function ehContagem(valor: unknown): valor is number {
+  return typeof valor === 'number' && Number.isInteger(valor) && valor >= 0;
 }

--- a/src/store/ranking/gravar-ranking.ts
+++ b/src/store/ranking/gravar-ranking.ts
@@ -2,11 +2,15 @@
  * Boundary de escrita do Ranking. Lê o snapshot atual (corrompido → começa do
  * zero), registra a Partida concluída acumulando somatórios brutos e persiste
  * de volta na chave `fdp.ranking.v1`. Disparada quando `JOGO_ENCERRADO` é
- * processado — fora do Phaser, com `Storage` injetado para ser testável.
+ * processado — fora do Phaser, com o `Storage` fornecido por um provedor lazy
+ * para ser testável.
  *
- * O Ranking é um side effect secundário: qualquer falha de `Storage` (quota,
- * modo privado, `SecurityError`) é absorvida aqui para nunca interromper o
- * encerramento da Partida nem a tela de fim de jogo.
+ * O Ranking é um side effect secundário: qualquer falha de `Storage` é absorvida
+ * aqui para nunca interromper o encerramento da Partida nem a tela de fim de
+ * jogo. O acesso ao `Storage` passa pelo provedor _dentro_ do `try`, porque o
+ * próprio getter `window.localStorage` pode lançar `SecurityError` (storage
+ * bloqueado, contexto sandbox) — não só `getItem`/`setItem` (quota, modo
+ * privado).
  */
 
 import type { Jogador } from '@/types/entidades';
@@ -14,11 +18,14 @@ import { lerSnapshot } from './carregar-ranking';
 import { registrarPartida } from './registrar-partida';
 import { CHAVE_RANKING } from './tipos';
 
+type ProvedorArmazenamento = () => Pick<Storage, 'getItem' | 'setItem'>;
+
 export function registrarPartidaNoArmazenamento(
-  armazenamento: Pick<Storage, 'getItem' | 'setItem'>,
+  obterArmazenamento: ProvedorArmazenamento,
   classificacao: Jogador[],
 ): void {
   try {
+    const armazenamento = obterArmazenamento();
     const atualizado = registrarPartida(lerSnapshot(armazenamento), classificacao);
     armazenamento.setItem(CHAVE_RANKING, JSON.stringify(atualizado));
   } catch (erro) {

--- a/src/store/ranking/gravar-ranking.ts
+++ b/src/store/ranking/gravar-ranking.ts
@@ -1,0 +1,19 @@
+/**
+ * Boundary de escrita do Ranking. Lê o snapshot atual (corrompido → começa do
+ * zero), registra a Partida concluída acumulando somatórios brutos e persiste
+ * de volta na chave `fdp.ranking.v1`. Disparada quando `JOGO_ENCERRADO` é
+ * processado — fora do Phaser, com `Storage` injetado para ser testável.
+ */
+
+import type { Jogador } from '@/types/entidades';
+import { lerSnapshot } from './carregar-ranking';
+import { registrarPartida } from './registrar-partida';
+import { CHAVE_RANKING } from './tipos';
+
+export function registrarPartidaNoArmazenamento(
+  armazenamento: Pick<Storage, 'getItem' | 'setItem'>,
+  classificacao: Jogador[],
+): void {
+  const atualizado = registrarPartida(lerSnapshot(armazenamento), classificacao);
+  armazenamento.setItem(CHAVE_RANKING, JSON.stringify(atualizado));
+}

--- a/src/store/ranking/gravar-ranking.ts
+++ b/src/store/ranking/gravar-ranking.ts
@@ -3,6 +3,10 @@
  * zero), registra a Partida concluída acumulando somatórios brutos e persiste
  * de volta na chave `fdp.ranking.v1`. Disparada quando `JOGO_ENCERRADO` é
  * processado — fora do Phaser, com `Storage` injetado para ser testável.
+ *
+ * O Ranking é um side effect secundário: qualquer falha de `Storage` (quota,
+ * modo privado, `SecurityError`) é absorvida aqui para nunca interromper o
+ * encerramento da Partida nem a tela de fim de jogo.
  */
 
 import type { Jogador } from '@/types/entidades';
@@ -14,6 +18,11 @@ export function registrarPartidaNoArmazenamento(
   armazenamento: Pick<Storage, 'getItem' | 'setItem'>,
   classificacao: Jogador[],
 ): void {
-  const atualizado = registrarPartida(lerSnapshot(armazenamento), classificacao);
-  armazenamento.setItem(CHAVE_RANKING, JSON.stringify(atualizado));
+  try {
+    const atualizado = registrarPartida(lerSnapshot(armazenamento), classificacao);
+    armazenamento.setItem(CHAVE_RANKING, JSON.stringify(atualizado));
+  } catch (erro) {
+    // eslint-disable-next-line no-console -- sinaliza a falha sem interromper o encerramento da Partida
+    console.warn('Não foi possível persistir o Ranking; encerramento da Partida segue normalmente.', erro);
+  }
 }

--- a/src/store/ranking/identidade.ts
+++ b/src/store/ranking/identidade.ts
@@ -1,0 +1,26 @@
+/**
+ * Identidade de Ranking de um participante a partir de um jogador da
+ * Classificação da Partida. O jogador humano colapsa na chave `humano`; cada
+ * Perfil de Bot vira um slug ASCII estável derivado do nome reconhecível
+ * (`Brás` → `bot:bras`), independente do assento técnico (`bot1/bot2/bot3`).
+ */
+
+import type { Jogador } from '@/types/entidades';
+
+export interface IdentidadeRanking {
+  chave: string;
+  nomeExibicao: string;
+}
+
+export function identidadeDe(jogador: Jogador): IdentidadeRanking {
+  if (jogador.id === 'humano') return { chave: 'humano', nomeExibicao: jogador.nome };
+  return { chave: `bot:${slug(jogador.nome)}`, nomeExibicao: jogador.nome };
+}
+
+function slug(nome: string): string {
+  return nome
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}

--- a/src/store/ranking/ordenar-ranking.ts
+++ b/src/store/ranking/ordenar-ranking.ts
@@ -1,0 +1,46 @@
+/**
+ * Cálculo de métricas derivadas e ordenação do Ranking.
+ *
+ * Win rate = Vitórias / Partidas em que o participante apareceu (percentual
+ * inteiro). Pos. média = somaPosicoes / Partidas (mantida bruta; a casa decimal
+ * é formatada na renderização). A ordenação já nasce com o desempate canônico
+ * completo — métrica ativa → Vitórias desc → win rate desc → pos. média asc →
+ * humano acima dos Perfis de Bot — embora esta fatia só renderize por Vitórias.
+ */
+
+import type { ParticipanteRanking } from './tipos';
+
+export type MetricaRanking = 'vitorias' | 'winRate' | 'posMedia';
+
+export interface ParticipanteRankeado extends ParticipanteRanking {
+  winRate: number;
+  posMedia: number;
+}
+
+export function ordenarRanking(participantes: ParticipanteRanking[], metrica: MetricaRanking): ParticipanteRankeado[] {
+  return participantes.map(comMetricas).sort((a, b) => comparar(a, b, metrica));
+}
+
+function comMetricas(p: ParticipanteRanking): ParticipanteRankeado {
+  if (p.partidas === 0) return { ...p, winRate: 0, posMedia: 0 };
+  return { ...p, winRate: Math.round((p.vitorias / p.partidas) * 100), posMedia: p.somaPosicoes / p.partidas };
+}
+
+function comparar(a: ParticipanteRankeado, b: ParticipanteRankeado, metrica: MetricaRanking): number {
+  return porMetrica(a, b, metrica) || desempateCanonico(a, b);
+}
+
+function porMetrica(a: ParticipanteRankeado, b: ParticipanteRankeado, metrica: MetricaRanking): number {
+  if (metrica === 'posMedia') return a.posMedia - b.posMedia;
+  if (metrica === 'winRate') return b.winRate - a.winRate;
+  return b.vitorias - a.vitorias;
+}
+
+function desempateCanonico(a: ParticipanteRankeado, b: ParticipanteRankeado): number {
+  return (
+    b.vitorias - a.vitorias ||
+    b.winRate - a.winRate ||
+    a.posMedia - b.posMedia ||
+    (b.humano ? 1 : 0) - (a.humano ? 1 : 0)
+  );
+}

--- a/src/store/ranking/ordenar-ranking.ts
+++ b/src/store/ranking/ordenar-ranking.ts
@@ -5,7 +5,8 @@
  * inteiro). Pos. média = somaPosicoes / Partidas (mantida bruta; a casa decimal
  * é formatada na renderização). A ordenação já nasce com o desempate canônico
  * completo — métrica ativa → Vitórias desc → win rate desc → pos. média asc →
- * humano acima dos Perfis de Bot — embora esta fatia só renderize por Vitórias.
+ * humano acima dos Perfis de Bot → chave (lexical, para ordem determinística
+ * entre reloads) — embora esta fatia só renderize por Vitórias.
  */
 
 import type { ParticipanteRanking } from './tipos';
@@ -41,6 +42,7 @@ function desempateCanonico(a: ParticipanteRankeado, b: ParticipanteRankeado): nu
     b.vitorias - a.vitorias ||
     b.winRate - a.winRate ||
     a.posMedia - b.posMedia ||
-    (b.humano ? 1 : 0) - (a.humano ? 1 : 0)
+    (b.humano ? 1 : 0) - (a.humano ? 1 : 0) ||
+    a.chave.localeCompare(b.chave)
   );
 }

--- a/src/store/ranking/registrar-partida.ts
+++ b/src/store/ranking/registrar-partida.ts
@@ -1,0 +1,35 @@
+/**
+ * Registro puro de uma Partida concluída no snapshot do Ranking.
+ *
+ * A Classificação da Partida chega ordenada (posição = índice + 1, já com o
+ * desempate do core). Para cada participante acumulamos somatórios brutos:
+ * uma partida a mais, a Vitória de Partida só do primeiro colocado, e a soma
+ * das posições ordinais (eliminados inclusos). Nunca muta a entrada.
+ */
+
+import type { Jogador } from '@/types/entidades';
+import { identidadeDe } from './identidade';
+import type { ParticipantePersistido, SnapshotRanking } from './tipos';
+
+export function registrarPartida(snapshot: SnapshotRanking, classificacao: Jogador[]): SnapshotRanking {
+  const participantes = { ...snapshot.participantes };
+  classificacao.forEach((jogador, indice) => {
+    const { chave, nomeExibicao } = identidadeDe(jogador);
+    participantes[chave] = acumular(participantes[chave], nomeExibicao, indice + 1);
+  });
+  return { versao: 1, participantes };
+}
+
+function acumular(
+  anterior: ParticipantePersistido | undefined,
+  nomeExibicao: string,
+  posicao: number,
+): ParticipantePersistido {
+  const base = anterior ?? { nomeExibicao, partidas: 0, vitorias: 0, somaPosicoes: 0 };
+  return {
+    nomeExibicao,
+    partidas: base.partidas + 1,
+    vitorias: base.vitorias + (posicao === 1 ? 1 : 0),
+    somaPosicoes: base.somaPosicoes + posicao,
+  };
+}

--- a/src/store/ranking/tipos.ts
+++ b/src/store/ranking/tipos.ts
@@ -1,0 +1,27 @@
+/**
+ * Contrato persistido do Ranking (chave `fdp.ranking.v1`) e os tipos derivados
+ * usados na leitura/escrita. Guardamos somatórios brutos por participante
+ * (não histórico de partidas); as métricas são recalculadas na leitura.
+ */
+
+export const CHAVE_RANKING = 'fdp.ranking.v1';
+
+export interface ParticipantePersistido {
+  nomeExibicao: string;
+  partidas: number;
+  vitorias: number;
+  somaPosicoes: number;
+}
+
+export interface SnapshotRanking {
+  versao: 1;
+  participantes: Record<string, ParticipantePersistido>;
+}
+
+export const SNAPSHOT_VAZIO: SnapshotRanking = { versao: 1, participantes: {} };
+
+/** Participante já materializado com sua chave de identidade e o flag humano. */
+export interface ParticipanteRanking extends ParticipantePersistido {
+  chave: string;
+  humano: boolean;
+}

--- a/tests/core/Partida.classificacao-desempate.test.ts
+++ b/tests/core/Partida.classificacao-desempate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Partida } from '@/core/Partida';
+import type { Rodada } from '@/core/Rodada';
+import { createEmissorEventos } from '@/store/emissor-eventos';
+import type { Jogador } from '@/types/entidades';
+import type { EstadoMutavel } from '@/types/estado-rodada';
+import type { EventoDominio } from '@/types/eventos-dominio';
+import { criarDecisorPrimeiraCarta } from './rodada-fixtures';
+
+function jogadores(ids: string[]): Jogador[] {
+  return ids.map((id) => ({ id, nome: id, pontos: 5 }));
+}
+
+function criarPartidaComEmissor(ids: string[]): { emissor: ReturnType<typeof createEmissorEventos>; partida: Partida } {
+  const lista = jogadores(ids);
+  const emissor = createEmissorEventos();
+  const decisoresJogada = new Map(lista.map((jogador) => [jogador.id, criarDecisorPrimeiraCarta()]));
+  const partida = new Partida(lista, emissor, { jogada: decisoresJogada, declaracao: new Map() });
+  return { emissor, partida };
+}
+
+function concluirRodadaComPontos(partida: Partida, pontos: Record<string, number>): void {
+  const rodada = partida.iniciarProximaRodada() as Rodada;
+  rodada.restaurarEstado({ ...rodada.estado, fase: 'rodadaConcluida', pontos } as EstadoMutavel);
+}
+
+function classificacaoAoEncerrar(ids: string[], pontos: Record<string, number>): Jogador[] {
+  const { emissor, partida } = criarPartidaComEmissor(ids);
+  const handler = vi.fn<(ev: EventoDominio) => void>();
+  emissor.on('JOGO_ENCERRADO', handler);
+  concluirRodadaComPontos(partida, pontos);
+  partida.iniciarProximaRodada();
+  const evento = handler.mock.calls[0][0];
+  if (evento.tipo !== 'JOGO_ENCERRADO') throw new Error('Evento JOGO_ENCERRADO não emitido');
+  return evento.classificacao;
+}
+
+describe('Partida — desempate da Classificação por pontos iguais', () => {
+  it('deve colocar o jogador humano acima dos Perfis de Bot em empate de pontos', () => {
+    const classificacao = classificacaoAoEncerrar(['bot1', 'humano', 'bot2'], { bot1: 0, humano: 0, bot2: 2 });
+
+    expect(classificacao.map((j) => j.id)).toEqual(['bot2', 'humano', 'bot1']);
+  });
+
+  it('deve manter a ordem por pontos quando não há empate envolvendo o humano', () => {
+    const classificacao = classificacaoAoEncerrar(['humano', 'bot1', 'bot2'], { humano: -1, bot1: 0, bot2: 3 });
+
+    expect(classificacao.map((j) => j.id)).toEqual(['bot2', 'bot1', 'humano']);
+  });
+});

--- a/tests/core/Partida.classificacao-desempate.test.ts
+++ b/tests/core/Partida.classificacao-desempate.test.ts
@@ -36,6 +36,23 @@ function classificacaoAoEncerrar(ids: string[], pontos: Record<string, number>):
 }
 
 describe('Partida — desempate da Classificação por pontos iguais', () => {
+  it('deve ordenar a Classificação pela ordem de eliminação quando jogadores caem em rodadas diferentes', () => {
+    const { emissor, partida } = criarPartidaComEmissor(['bot1', 'bot2', 'humano', 'bot3']);
+    const handler = vi.fn<(ev: EventoDominio) => void>();
+    emissor.on('JOGO_ENCERRADO', handler);
+
+    concluirRodadaComPontos(partida, { bot1: 0, bot2: 3, humano: 5, bot3: 4 });
+    partida.iniciarProximaRodada();
+    concluirRodadaComPontos(partida, { bot2: -1, humano: 2, bot3: 3 });
+    partida.iniciarProximaRodada();
+    concluirRodadaComPontos(partida, { humano: -2, bot3: 1 });
+    partida.iniciarProximaRodada();
+
+    const evento = handler.mock.calls[0][0];
+    if (evento.tipo !== 'JOGO_ENCERRADO') throw new Error('Evento JOGO_ENCERRADO não emitido');
+    expect(evento.classificacao.map((j) => j.id)).toEqual(['bot3', 'humano', 'bot2', 'bot1']);
+  });
+
   it('deve colocar o jogador humano acima dos Perfis de Bot em empate de pontos', () => {
     const classificacao = classificacaoAoEncerrar(['bot1', 'humano', 'bot2'], { bot1: 0, humano: 0, bot2: 2 });
 

--- a/tests/store/carregar-ranking.test.ts
+++ b/tests/store/carregar-ranking.test.ts
@@ -5,11 +5,11 @@ function armazenamentoCom(valor: string | null): Pick<Storage, 'getItem'> {
   return { getItem: (chave) => (chave === CHAVE_RANKING ? valor : null) };
 }
 
-function snapshot(participantes: unknown[], versao: unknown = 1): string {
+function snapshot(participantes: unknown, versao: unknown = 1): string {
   return JSON.stringify({ versao, participantes });
 }
 
-const participanteValido = { nome: 'Você', humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 };
+const participanteValido = { nomeExibicao: 'Você', partidas: 5, vitorias: 2, somaPosicoes: 9 };
 
 describe('carregarRanking trata como vazio', () => {
   it('quando a chave está ausente', () => {
@@ -25,40 +25,56 @@ describe('carregarRanking trata como vazio', () => {
   });
 
   it('quando a versão não é 1', () => {
-    expect(carregarRanking(armazenamentoCom(snapshot([participanteValido], 2)))).toEqual({ tipo: 'vazio' });
+    expect(carregarRanking(armazenamentoCom(snapshot({ humano: participanteValido }, 2)))).toEqual({ tipo: 'vazio' });
   });
 
-  it('quando os participantes não são uma lista', () => {
-    const conteudo = JSON.stringify({ versao: 1, participantes: 'x' });
-    expect(carregarRanking(armazenamentoCom(conteudo))).toEqual({ tipo: 'vazio' });
+  it('quando os participantes são uma lista em vez de um Record', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot([participanteValido])))).toEqual({ tipo: 'vazio' });
   });
 
-  it('quando a lista de participantes está vazia', () => {
-    expect(carregarRanking(armazenamentoCom(snapshot([])))).toEqual({ tipo: 'vazio' });
+  it('quando o Record de participantes está vazio', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot({})))).toEqual({ tipo: 'vazio' });
   });
 });
 
 describe('carregarRanking rejeita participante inválido', () => {
-  it('quando um item da lista é nulo', () => {
-    expect(carregarRanking(armazenamentoCom(snapshot([participanteValido, null])))).toEqual({ tipo: 'vazio' });
+  it('quando uma entrada é nula', () => {
+    expect(carregarRanking(armazenamentoCom(snapshot({ humano: participanteValido, 'bot:bras': null })))).toEqual({
+      tipo: 'vazio',
+    });
   });
 
   it('quando uma métrica não é numérica', () => {
     const corrompido = { ...participanteValido, vitorias: '2' };
-    expect(carregarRanking(armazenamentoCom(snapshot([corrompido])))).toEqual({ tipo: 'vazio' });
+    expect(carregarRanking(armazenamentoCom(snapshot({ humano: corrompido })))).toEqual({ tipo: 'vazio' });
   });
 
-  it('quando falta o nome', () => {
-    const semNome = { humano: true, vitorias: 2, partidas: 5, somaPosicoes: 9 };
-    expect(carregarRanking(armazenamentoCom(snapshot([semNome])))).toEqual({ tipo: 'vazio' });
+  it('quando falta o nome de exibição', () => {
+    const semNome = { partidas: 5, vitorias: 2, somaPosicoes: 9 };
+    expect(carregarRanking(armazenamentoCom(snapshot({ humano: semNome })))).toEqual({ tipo: 'vazio' });
   });
 });
 
 describe('carregarRanking', () => {
-  it('deve retornar populado com os participantes de um snapshot válido', () => {
-    const ranking = carregarRanking(armazenamentoCom(snapshot([participanteValido])));
+  it('materializa o Record num participante com chave e flag humano', () => {
+    const ranking = carregarRanking(
+      armazenamentoCom(
+        snapshot({ humano: participanteValido, 'bot:bras': { ...participanteValido, nomeExibicao: 'Brás' } }),
+      ),
+    );
 
     expect(ranking.tipo).toBe('populado');
-    expect(ranking).toMatchObject({ tipo: 'populado', participantes: [{ nome: 'Você' }] });
+    if (ranking.tipo !== 'populado') throw new Error('esperava populado');
+    expect(ranking.participantes).toContainEqual({
+      chave: 'humano',
+      humano: true,
+      nomeExibicao: 'Você',
+      partidas: 5,
+      vitorias: 2,
+      somaPosicoes: 9,
+    });
+    expect(ranking.participantes).toContainEqual(
+      expect.objectContaining({ chave: 'bot:bras', humano: false, nomeExibicao: 'Brás' }),
+    );
   });
 });

--- a/tests/store/carregar-ranking.test.ts
+++ b/tests/store/carregar-ranking.test.ts
@@ -53,6 +53,29 @@ describe('carregarRanking rejeita participante inválido', () => {
     const semNome = { partidas: 5, vitorias: 2, somaPosicoes: 9 };
     expect(carregarRanking(armazenamentoCom(snapshot({ humano: semNome })))).toEqual({ tipo: 'vazio' });
   });
+
+  it('quando o nome de exibição é vazio', () => {
+    const semNome = { ...participanteValido, nomeExibicao: '' };
+    expect(carregarRanking(armazenamentoCom(snapshot({ humano: semNome })))).toEqual({ tipo: 'vazio' });
+  });
+});
+
+describe('carregarRanking rejeita somatórios incoerentes', () => {
+  const casos: Record<string, Partial<typeof participanteValido>> = {
+    'partidas negativas': { partidas: -1 },
+    'partidas fracionárias': { partidas: 2.5 },
+    'sem nenhuma partida': { partidas: 0, vitorias: 0, somaPosicoes: 0 },
+    'mais vitórias do que partidas': { partidas: 2, vitorias: 3, somaPosicoes: 4 },
+    'soma de posições abaixo do total de partidas': { partidas: 5, vitorias: 1, somaPosicoes: 4 },
+    'soma de posições negativa': { partidas: 5, vitorias: 1, somaPosicoes: -3 },
+  };
+
+  for (const [descricao, override] of Object.entries(casos)) {
+    it(`quando há ${descricao}`, () => {
+      const corrompido = { ...participanteValido, ...override };
+      expect(carregarRanking(armazenamentoCom(snapshot({ humano: corrompido })))).toEqual({ tipo: 'vazio' });
+    });
+  }
 });
 
 describe('carregarRanking', () => {

--- a/tests/store/ranking-gravar.test.ts
+++ b/tests/store/ranking-gravar.test.ts
@@ -36,7 +36,7 @@ describe('registrarPartidaNoArmazenamento', () => {
   it('grava o snapshot da primeira partida na chave do Ranking', () => {
     const armazenamento = armazenamentoFake();
 
-    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+    registrarPartidaNoArmazenamento(() => armazenamento, classificacao);
 
     const gravado = snapshotGravado(armazenamento);
     expect(gravado.versao).toBe(1);
@@ -51,7 +51,7 @@ describe('registrarPartidaNoArmazenamento', () => {
     });
     const armazenamento = armazenamentoFake(inicial);
 
-    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+    registrarPartidaNoArmazenamento(() => armazenamento, classificacao);
 
     expect(snapshotGravado(armazenamento).participantes['humano']).toMatchObject({
       partidas: 2,
@@ -63,7 +63,7 @@ describe('registrarPartidaNoArmazenamento', () => {
   it('parte do zero quando o snapshot existente está corrompido', () => {
     const armazenamento = armazenamentoFake('{ corrompido');
 
-    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+    registrarPartidaNoArmazenamento(() => armazenamento, classificacao);
 
     expect(snapshotGravado(armazenamento).participantes['humano']).toMatchObject({ partidas: 1 });
   });
@@ -74,7 +74,7 @@ describe('registrarPartidaNoArmazenamento — resiliência a falha de Storage', 
     const armazenamento = armazenamentoQueLanca('setItem');
 
     expect(() => {
-      registrarPartidaNoArmazenamento(armazenamento, classificacao);
+      registrarPartidaNoArmazenamento(() => armazenamento, classificacao);
     }).not.toThrow();
   });
 
@@ -82,7 +82,17 @@ describe('registrarPartidaNoArmazenamento — resiliência a falha de Storage', 
     const armazenamento = armazenamentoQueLanca('getItem');
 
     expect(() => {
-      registrarPartidaNoArmazenamento(armazenamento, classificacao);
+      registrarPartidaNoArmazenamento(() => armazenamento, classificacao);
+    }).not.toThrow();
+  });
+
+  it('absorve falha do próprio getter de Storage (window.localStorage bloqueado)', () => {
+    const obterArmazenamento = (): never => {
+      throw new DOMException('storage bloqueado', 'SecurityError');
+    };
+
+    expect(() => {
+      registrarPartidaNoArmazenamento(obterArmazenamento, classificacao);
     }).not.toThrow();
   });
 });

--- a/tests/store/ranking-gravar.test.ts
+++ b/tests/store/ranking-gravar.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { registrarPartidaNoArmazenamento } from '@/store/ranking/gravar-ranking';
+import { CHAVE_RANKING, type SnapshotRanking } from '@/store/ranking/tipos';
+import type { Jogador } from '@/types/entidades';
+
+function armazenamentoFake(inicial?: string): Pick<Storage, 'getItem' | 'setItem'> & { dados: Map<string, string> } {
+  const dados = new Map<string, string>();
+  if (inicial !== undefined) dados.set(CHAVE_RANKING, inicial);
+  return {
+    dados,
+    getItem: (chave) => dados.get(chave) ?? null,
+    setItem: (chave, valor) => {
+      dados.set(chave, valor);
+    },
+  };
+}
+
+function snapshotGravado(armazenamento: { dados: Map<string, string> }): SnapshotRanking {
+  return JSON.parse(armazenamento.dados.get(CHAVE_RANKING) ?? '') as SnapshotRanking;
+}
+
+function jogador(id: string, nome: string): Jogador {
+  return { id, nome, pontos: 0 };
+}
+
+const classificacao: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás')];
+
+describe('registrarPartidaNoArmazenamento', () => {
+  it('grava o snapshot da primeira partida na chave do Ranking', () => {
+    const armazenamento = armazenamentoFake();
+
+    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+
+    const gravado = snapshotGravado(armazenamento);
+    expect(gravado.versao).toBe(1);
+    expect(gravado.participantes['humano']).toMatchObject({ partidas: 1, vitorias: 1, somaPosicoes: 1 });
+    expect(gravado.participantes['bot:bras']).toMatchObject({ partidas: 1, vitorias: 0, somaPosicoes: 2 });
+  });
+
+  it('acumula sobre o snapshot já gravado', () => {
+    const inicial = JSON.stringify({
+      versao: 1,
+      participantes: { humano: { nomeExibicao: 'Você', partidas: 1, vitorias: 0, somaPosicoes: 2 } },
+    });
+    const armazenamento = armazenamentoFake(inicial);
+
+    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+
+    expect(snapshotGravado(armazenamento).participantes['humano']).toMatchObject({
+      partidas: 2,
+      vitorias: 1,
+      somaPosicoes: 3,
+    });
+  });
+
+  it('parte do zero quando o snapshot existente está corrompido', () => {
+    const armazenamento = armazenamentoFake('{ corrompido');
+
+    registrarPartidaNoArmazenamento(armazenamento, classificacao);
+
+    expect(snapshotGravado(armazenamento).participantes['humano']).toMatchObject({ partidas: 1 });
+  });
+});

--- a/tests/store/ranking-gravar.test.ts
+++ b/tests/store/ranking-gravar.test.ts
@@ -19,6 +19,13 @@ function snapshotGravado(armazenamento: { dados: Map<string, string> }): Snapsho
   return JSON.parse(armazenamento.dados.get(CHAVE_RANKING) ?? '') as SnapshotRanking;
 }
 
+function armazenamentoQueLanca(metodo: 'getItem' | 'setItem'): Pick<Storage, 'getItem' | 'setItem'> {
+  const falhar = (): never => {
+    throw new DOMException('storage indisponível', 'SecurityError');
+  };
+  return { getItem: () => null, setItem: () => undefined, [metodo]: falhar };
+}
+
 function jogador(id: string, nome: string): Jogador {
   return { id, nome, pontos: 0 };
 }
@@ -59,5 +66,23 @@ describe('registrarPartidaNoArmazenamento', () => {
     registrarPartidaNoArmazenamento(armazenamento, classificacao);
 
     expect(snapshotGravado(armazenamento).participantes['humano']).toMatchObject({ partidas: 1 });
+  });
+});
+
+describe('registrarPartidaNoArmazenamento — resiliência a falha de Storage', () => {
+  it('não propaga falha de escrita (quota excedida)', () => {
+    const armazenamento = armazenamentoQueLanca('setItem');
+
+    expect(() => {
+      registrarPartidaNoArmazenamento(armazenamento, classificacao);
+    }).not.toThrow();
+  });
+
+  it('absorve falha de leitura (modo privado/SecurityError)', () => {
+    const armazenamento = armazenamentoQueLanca('getItem');
+
+    expect(() => {
+      registrarPartidaNoArmazenamento(armazenamento, classificacao);
+    }).not.toThrow();
   });
 });

--- a/tests/store/ranking-identidade.test.ts
+++ b/tests/store/ranking-identidade.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { identidadeDe } from '@/store/ranking/identidade';
+import type { Jogador } from '@/types/entidades';
+
+function jogador(id: string, nome: string): Jogador {
+  return { id, nome, pontos: 0 };
+}
+
+describe('identidadeDe', () => {
+  it('mapeia o jogador humano para a chave "humano" exibindo "Você"', () => {
+    expect(identidadeDe(jogador('humano', 'Você'))).toEqual({ chave: 'humano', nomeExibicao: 'Você' });
+  });
+
+  it('deriva slug ASCII do nome do Perfil de Bot, removendo acentos', () => {
+    expect(identidadeDe(jogador('bot1', 'Brás'))).toEqual({ chave: 'bot:bras', nomeExibicao: 'Brás' });
+    expect(identidadeDe(jogador('bot2', 'Vitória'))).toEqual({ chave: 'bot:vitoria', nomeExibicao: 'Vitória' });
+    expect(identidadeDe(jogador('bot3', 'Luís'))).toEqual({ chave: 'bot:luis', nomeExibicao: 'Luís' });
+  });
+
+  it('usa o nome do Perfil de Bot, não o assento técnico bot1/bot2/bot3', () => {
+    expect(identidadeDe(jogador('bot1', 'Iara')).chave).toBe('bot:iara');
+  });
+});

--- a/tests/store/ranking-ordenar.test.ts
+++ b/tests/store/ranking-ordenar.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { ordenarRanking, type MetricaRanking } from '@/store/ranking/ordenar-ranking';
+import type { ParticipanteRanking } from '@/store/ranking/tipos';
+
+function p(over: Partial<ParticipanteRanking> & { chave: string }): ParticipanteRanking {
+  return { nomeExibicao: over.chave, humano: false, partidas: 10, vitorias: 0, somaPosicoes: 20, ...over };
+}
+
+function chaves(participantes: ParticipanteRanking[], metrica: MetricaRanking): string[] {
+  return ordenarRanking(participantes, metrica).map((x) => x.chave);
+}
+
+describe('ordenarRanking — métricas derivadas', () => {
+  it('calcula win rate como percentual inteiro e pos. média como razão', () => {
+    const [r] = ordenarRanking([p({ chave: 'a', vitorias: 3, partidas: 8, somaPosicoes: 18 })], 'vitorias');
+
+    expect(r.winRate).toBe(38); // round(3/8*100) = 37.5 → 38
+    expect(r.posMedia).toBeCloseTo(2.25);
+  });
+
+  it('trata zero partidas sem dividir por zero', () => {
+    const [r] = ordenarRanking([p({ chave: 'a', partidas: 0, vitorias: 0, somaPosicoes: 0 })], 'vitorias');
+
+    expect(r.winRate).toBe(0);
+    expect(r.posMedia).toBe(0);
+  });
+});
+
+describe('ordenarRanking — ordenação por Vitórias com desempate canônico', () => {
+  it('ordena por Vitórias decrescente', () => {
+    const lista = [p({ chave: 'a', vitorias: 1 }), p({ chave: 'b', vitorias: 5 }), p({ chave: 'c', vitorias: 3 })];
+
+    expect(chaves(lista, 'vitorias')).toEqual(['b', 'c', 'a']);
+  });
+
+  it('desempata Vitórias iguais por win rate decrescente', () => {
+    const lista = [p({ chave: 'a', vitorias: 2, partidas: 10 }), p({ chave: 'b', vitorias: 2, partidas: 4 })];
+
+    expect(chaves(lista, 'vitorias')).toEqual(['b', 'a']); // 20% vs 50%
+  });
+
+  it('desempata win rate igual por pos. média crescente', () => {
+    const lista = [
+      p({ chave: 'a', vitorias: 2, partidas: 4, somaPosicoes: 12 }), // posMedia 3.0
+      p({ chave: 'b', vitorias: 2, partidas: 4, somaPosicoes: 8 }), //  posMedia 2.0
+    ];
+
+    expect(chaves(lista, 'vitorias')).toEqual(['b', 'a']);
+  });
+
+  it('com tudo igual, coloca o humano acima dos Perfis de Bot', () => {
+    const base = { vitorias: 2, partidas: 4, somaPosicoes: 8 };
+    const lista = [p({ chave: 'bot:bras', ...base }), p({ chave: 'humano', humano: true, ...base })];
+
+    expect(chaves(lista, 'vitorias')).toEqual(['humano', 'bot:bras']);
+  });
+});
+
+describe('ordenarRanking — outras métricas ativas', () => {
+  it('ordena por pos. média crescente quando a métrica ativa é posMedia', () => {
+    const lista = [
+      p({ chave: 'a', vitorias: 0, partidas: 4, somaPosicoes: 12 }), // 3.0
+      p({ chave: 'b', vitorias: 0, partidas: 4, somaPosicoes: 4 }), //  1.0
+    ];
+
+    expect(chaves(lista, 'posMedia')).toEqual(['b', 'a']);
+  });
+
+  it('ordena por win rate decrescente quando a métrica ativa é winRate', () => {
+    const lista = [p({ chave: 'a', vitorias: 1, partidas: 10 }), p({ chave: 'b', vitorias: 3, partidas: 10 })];
+
+    expect(chaves(lista, 'winRate')).toEqual(['b', 'a']); // 10% vs 30%
+  });
+
+  it('não muta a lista de entrada', () => {
+    const entrada = [p({ chave: 'a', vitorias: 1 }), p({ chave: 'b', vitorias: 5 })];
+    ordenarRanking(entrada, 'vitorias');
+
+    expect(entrada.map((x) => x.chave)).toEqual(['a', 'b']);
+  });
+});

--- a/tests/store/ranking-ordenar.test.ts
+++ b/tests/store/ranking-ordenar.test.ts
@@ -54,6 +54,13 @@ describe('ordenarRanking — ordenação por Vitórias com desempate canônico',
 
     expect(chaves(lista, 'vitorias')).toEqual(['humano', 'bot:bras']);
   });
+
+  it('desempata dois Perfis de Bot idênticos pela chave (ordem determinística entre reloads)', () => {
+    const base = { vitorias: 2, partidas: 4, somaPosicoes: 8 };
+    const lista = [p({ chave: 'bot:vitoria', ...base }), p({ chave: 'bot:bras', ...base })];
+
+    expect(chaves(lista, 'vitorias')).toEqual(['bot:bras', 'bot:vitoria']);
+  });
 });
 
 describe('ordenarRanking — outras métricas ativas', () => {

--- a/tests/store/ranking-registrar-partida.test.ts
+++ b/tests/store/ranking-registrar-partida.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { registrarPartida } from '@/store/ranking/registrar-partida';
+import { SNAPSHOT_VAZIO, type ParticipantePersistido, type SnapshotRanking } from '@/store/ranking/tipos';
+import type { Jogador } from '@/types/entidades';
+
+function jogador(id: string, nome: string): Jogador {
+  return { id, nome, pontos: 0 };
+}
+
+function part(nomeExibicao: string, somatorios: [number, number, number]): ParticipantePersistido {
+  const [partidas, vitorias, somaPosicoes] = somatorios;
+  return { nomeExibicao, partidas, vitorias, somaPosicoes };
+}
+
+const classificacao: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás'), jogador('bot2', 'Iara')];
+
+describe('registrarPartida', () => {
+  it('registra somatórios brutos da primeira partida a partir do snapshot vazio', () => {
+    const { participantes } = registrarPartida(SNAPSHOT_VAZIO, classificacao);
+
+    expect(participantes['humano']).toEqual(part('Você', [1, 1, 1]));
+    expect(participantes['bot:bras']).toEqual(part('Brás', [1, 0, 2]));
+    expect(participantes['bot:iara']).toEqual(part('Iara', [1, 0, 3]));
+  });
+
+  it('acumula sobre um snapshot existente sem perder os outros participantes', () => {
+    const inicial: SnapshotRanking = {
+      versao: 1,
+      participantes: { humano: part('Você', [2, 1, 3]), 'bot:fabiano': part('Fabiano', [2, 0, 6]) },
+    };
+
+    const { participantes } = registrarPartida(inicial, classificacao);
+
+    expect(participantes['humano']).toEqual(part('Você', [3, 2, 4]));
+    expect(participantes['bot:bras']).toEqual(part('Brás', [1, 0, 2]));
+    expect(participantes['bot:fabiano']).toMatchObject({ partidas: 2 });
+  });
+
+  it('conta a posição ordinal dos eliminados (denominador inclui quem apareceu)', () => {
+    const { participantes } = registrarPartida(SNAPSHOT_VAZIO, classificacao);
+
+    expect(participantes['bot:iara']).toMatchObject({ somaPosicoes: 3, partidas: 1 });
+  });
+
+  it('não muta o snapshot de entrada', () => {
+    const congelado: SnapshotRanking = { versao: 1, participantes: {} };
+    registrarPartida(congelado, classificacao);
+
+    expect(congelado.participantes).toEqual({});
+  });
+});


### PR DESCRIPTION
Segunda fatia da PRD #242 (depois do #244): o Ranking passa a mostrar dados reais. Ao encerrar uma Partida (`JOGO_ENCERRADO`), o resultado é agregado em somatórios brutos por participante e persistido em `fdp.ranking.v1`; a tela renderiza a tabela ordenada por Vitórias.

## Mudanças

- **Core (TDD):** o desempate da Classificação da Partida passa a colocar o jogador humano acima dos Perfis de Bot em empate de Pontos.
- **Store puro `src/store/ranking/`** (coberto por Vitest, fora do Phaser):
  - `identidade.ts` — humano → `humano`; Perfil de Bot → slug ASCII (`Brás` → `bot:bras`), guardando `nomeExibicao`.
  - `registrar-partida.ts` — acumula somatórios brutos (partidas, vitórias só do 1º, somaPosicoes com eliminados inclusos), sem mutar a entrada.
  - `ordenar-ranking.ts` — métricas derivadas (win rate inteiro, pos. média) + desempate canônico completo (métrica → Vitórias → win rate → pos. média → humano acima dos bots), já pronto para as 3 métricas embora a fatia só renderize por Vitórias.
  - `gravar-ranking.ts` / `carregar-ranking.ts` — contrato unificado no shape `Record<slug, somatórios>`, reconciliando a tensão de shape deixada pelo #244. Leitura estrita: qualquer conteúdo inválido vira vazio.
- **Integração:** gravação disparada no `onJogoEncerrado` do controller, sem nenhum acesso ao Ranking na tela de fim de jogo.
- **RankingScene:** tabela por coordenada espelhando o protótipo validado — `Você` em dourado, líder com borda verde, `partidas: N` sob o nome, colunas à direita.

## Validação

- Verde em `typecheck`, `lint`, `test` (772 testes) e `build`.
- Verificação visual no browser (412×915): ordenação por Vitórias e desempate (Severino 33% acima de Iara 25%, ambos com 4 vitórias) conferem; `Você` em dourado; estado vazio intacto.

## Follow-up

- #249 — rolagem da tabela quando o roster ultrapassa a tela (fora do escopo desta fatia; caso comum cabe).

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a ranking table displaying all participants sorted by victories, including win rate and average position metrics.
  * Game results now persist automatically to local storage, allowing statistics to accumulate across sessions.
  * Implemented ranking system with tie-breaking logic prioritizing human player in equal situations.

* **Tests**
  * Added comprehensive test coverage for ranking functionality and calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->