### PR TITLE
[codex] feat(ranking): controle segmentado de ordenação

### DIFF
--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { carregarRanking, type RankingPersistido } from '@/store/ranking/carregar-ranking';
+import type { MetricaRanking } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { desenharTabelaRanking } from './desenhar-tabela-ranking';
@@ -7,20 +8,36 @@ import { desenharTabelaRanking } from './desenhar-tabela-ranking';
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
 const COR_DIM = '#8b95ad';
+const COR_ACENTO_TEXTO = '#1a1a2e';
 const COR_BOTAO_FUNDO = 0x111827;
 const COR_BORDA = 0x2a3550;
+const COR_SEGMENTO = 0x111827;
+const COR_SEGMENTO_ATIVO = 0xfacc15;
+
+const OPCOES_METRICA: { chave: MetricaRanking; rotulo: string }[] = [
+  { chave: 'vitorias', rotulo: 'Vitórias' },
+  { chave: 'winRate', rotulo: 'Win rate' },
+  { chave: 'posMedia', rotulo: 'Pos. média' },
+];
+
+interface SegmentoCtx {
+  opcao: { chave: MetricaRanking; rotulo: string };
+  x: number;
+  y: number;
+  largura: number;
+}
 
 /**
  * Tela cheia do Ranking, aberta sobre a JogoScene (que fica pausada).
  *
  * Lê o snapshot pela boundary estrita `carregarRanking`: ranking vazio mostra a
  * mensagem de tela vazia; ranking populado renderiza a tabela de participantes
- * ordenada por Vitórias (#245). O pódio (#247) e os controles de ordenação
- * (#246) entram nas próximas fatias.
+ * ordenada pela métrica ativa. O pódio (#247) entra numa fatia posterior.
  */
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
   private redesenhar?: ResizeDebouncer;
+  private metricaAtiva: MetricaRanking = 'vitorias';
 
   constructor() {
     super({ key: 'RankingScene' });
@@ -49,7 +66,8 @@ export class RankingScene extends Scene {
 
   private desenharConteudo(ranking: RankingPersistido): void {
     if (ranking.tipo === 'populado') {
-      this.objetos.push(...desenharTabelaRanking(this, ranking.participantes));
+      this.desenharControleOrdenacao();
+      this.objetos.push(...desenharTabelaRanking(this, ranking.participantes, this.metricaAtiva));
       return;
     }
     this.desenharVazio();
@@ -87,6 +105,57 @@ export class RankingScene extends Scene {
     this.objetos.push(circulo, x_);
   }
 
+  private desenharControleOrdenacao(): void {
+    const largura = Math.min(this.cameras.main.width - escalar(32, this), escalar(600, this));
+    const esquerda = (this.cameras.main.width - largura) / 2;
+    const y = escalar(76, this);
+    const rotulo = this.add.text(esquerda, y, 'Ordenar por', {
+      fontSize: escalarFonte(12, this),
+      color: COR_DIM,
+      fontFamily: 'Arial',
+    });
+    const fundo = this.add
+      .rectangle(esquerda, y + escalar(34, this), largura, escalar(40, this), COR_SEGMENTO, 1)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(escalar(1, this), COR_BORDA);
+    this.objetos.push(rotulo, fundo, ...this.desenharSegmentos(esquerda, y + escalar(34, this), largura));
+  }
+
+  private desenharSegmentos(x: number, y: number, largura: number): Phaser.GameObjects.GameObject[] {
+    const larguraSegmento = largura / OPCOES_METRICA.length;
+    return OPCOES_METRICA.flatMap((opcao, indice) => {
+      const centroX = x + larguraSegmento * indice + larguraSegmento / 2;
+      return this.desenharSegmento({ opcao, x: centroX, y, largura: larguraSegmento });
+    });
+  }
+
+  private desenharSegmento({ opcao, x, y, largura }: SegmentoCtx): Phaser.GameObjects.GameObject[] {
+    const ativo = opcao.chave === this.metricaAtiva;
+    const fundo = this.add.rectangle(
+      x,
+      y,
+      largura - escalar(8, this),
+      escalar(30, this),
+      ativo ? COR_SEGMENTO_ATIVO : 0,
+      ativo ? 1 : 0,
+    );
+    const texto = this.add
+      .text(x, y, opcao.rotulo, {
+        fontSize: escalarFonte(12, this),
+        color: ativo ? COR_ACENTO_TEXTO : COR_DIM,
+        fontStyle: 'bold',
+        fontFamily: 'Arial',
+      })
+      .setOrigin(0.5);
+    fundo.setInteractive({ useHandCursor: true }).on('pointerdown', () => {
+      this.alterarMetrica(opcao.chave);
+    });
+    texto.setInteractive({ useHandCursor: true }).on('pointerdown', () => {
+      this.alterarMetrica(opcao.chave);
+    });
+    return [fundo, texto];
+  }
+
   private desenharVazio(): void {
     const { centerX, centerY } = this.cameras.main;
     const mensagem = this.add
@@ -102,6 +171,12 @@ export class RankingScene extends Scene {
   private fechar(): void {
     this.scene.stop();
     this.scene.resume('JogoScene');
+  }
+
+  private alterarMetrica(metrica: MetricaRanking): void {
+    if (this.metricaAtiva === metrica) return;
+    this.metricaAtiva = metrica;
+    this.desenhar();
   }
 
   private limpar(): void {

--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -3,7 +3,7 @@ import { carregarRanking, type RankingPersistido } from '@/store/ranking/carrega
 import type { MetricaRanking } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
-import { desenharTabelaRanking } from './desenhar-tabela-ranking';
+import { desenharTabelaRanking, OPCOES_METRICA_RANKING } from './desenhar-tabela-ranking';
 
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
@@ -14,14 +14,8 @@ const COR_BORDA = 0x2a3550;
 const COR_SEGMENTO = 0x111827;
 const COR_SEGMENTO_ATIVO = 0xfacc15;
 
-const OPCOES_METRICA: { chave: MetricaRanking; rotulo: string }[] = [
-  { chave: 'vitorias', rotulo: 'Vitórias' },
-  { chave: 'winRate', rotulo: 'Win rate' },
-  { chave: 'posMedia', rotulo: 'Pos. média' },
-];
-
 interface SegmentoCtx {
-  opcao: { chave: MetricaRanking; rotulo: string };
+  opcao: (typeof OPCOES_METRICA_RANKING)[number];
   x: number;
   y: number;
   largura: number;
@@ -44,6 +38,7 @@ export class RankingScene extends Scene {
   }
 
   create(): void {
+    this.metricaAtiva = 'vitorias';
     this.cameras.main.setBackgroundColor('#1a1a2e');
     this.desenhar();
     this.redesenhar = criarDebounceResize(this, () => {
@@ -122,8 +117,8 @@ export class RankingScene extends Scene {
   }
 
   private desenharSegmentos(x: number, y: number, largura: number): Phaser.GameObjects.GameObject[] {
-    const larguraSegmento = largura / OPCOES_METRICA.length;
-    return OPCOES_METRICA.flatMap((opcao, indice) => {
+    const larguraSegmento = largura / OPCOES_METRICA_RANKING.length;
+    return OPCOES_METRICA_RANKING.flatMap((opcao, indice) => {
       const centroX = x + larguraSegmento * indice + larguraSegmento / 2;
       return this.desenharSegmento({ opcao, x: centroX, y, largura: larguraSegmento });
     });

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -21,6 +21,12 @@ const MAX_FAIXA = 600;
 const COL_METRICA = 84;
 const GAP = 6;
 
+export const OPCOES_METRICA_RANKING: { chave: MetricaRanking; rotulo: string }[] = [
+  { chave: 'vitorias', rotulo: 'Vitórias' },
+  { chave: 'winRate', rotulo: 'Win rate' },
+  { chave: 'posMedia', rotulo: 'Pos. média' },
+];
+
 interface LayoutTabela {
   esquerda: number;
   direita: number;
@@ -62,7 +68,7 @@ function calcularLayout(cena: Scene): LayoutTabela {
     larguraColuna: escalar(COL_METRICA, cena),
     gap: escalar(GAP, cena),
     alturaLinha: escalar(64, cena),
-    topo: escalar(122, cena),
+    topo: escalar(144, cena),
   };
 }
 
@@ -74,8 +80,8 @@ function desenharCabecalho({ cena, layout }: Pincel): Phaser.GameObjects.GameObj
   const y = layout.topo;
   const estilo = { fontSize: escalarFonte(10, cena), color: COR_DIM, fontFamily: 'Arial' };
   const titulo = cena.add.text(layout.esquerda, y, 'Participante', estilo).setOrigin(0, 0.5);
-  const cabecalhos = ['Vitórias', 'Win rate', 'Pos. média'].map((rotulo, coluna) =>
-    cena.add.text(colunaX(layout, 2 - coluna), y, rotulo, estilo).setOrigin(1, 0.5),
+  const cabecalhos = OPCOES_METRICA_RANKING.map((opcao, coluna) =>
+    cena.add.text(colunaX(layout, 2 - coluna), y, opcao.rotulo, estilo).setOrigin(1, 0.5),
   );
   return [titulo, ...cabecalhos];
 }
@@ -142,12 +148,11 @@ function identidade({ cena, layout }: Pincel, y: number, item: ParticipanteRanke
 
 function metricas({ cena, layout }: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameObject[] {
   const valores = [String(ctx.item.vitorias), `${String(ctx.item.winRate)}%`, ctx.item.posMedia.toFixed(1)];
-  const metricasRanking: MetricaRanking[] = ['vitorias', 'winRate', 'posMedia'];
   return valores.map((valor, coluna) =>
     cena.add
       .text(colunaX(layout, 2 - coluna), ctx.y, valor, {
         fontSize: escalarFonte(15, cena),
-        color: metricasRanking[coluna] === ctx.metrica ? COR_ACENTO : COR_TEXTO,
+        color: OPCOES_METRICA_RANKING[coluna]?.chave === ctx.metrica ? COR_ACENTO : COR_TEXTO,
         fontStyle: 'bold',
         fontFamily: 'Arial',
       })

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -1,14 +1,13 @@
 import type { Scene } from 'phaser';
-import { ordenarRanking, type ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
+import { ordenarRanking, type MetricaRanking, type ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
 import type { ParticipanteRanking } from '@/store/ranking/tipos';
 import { escalar, escalarFonte } from '../escala';
 
 /**
  * Tabela de participantes do Ranking, posicionada por coordenada (sem layout
  * CSS), espelhando o protótipo validado: faixa central de largura máxima fixa,
- * colunas de métrica à direita, `partidas: N` sob o nome e `Você` em dourado.
- * Esta fatia (#245) renderiza a ordenação fixa por Vitórias; os controles de
- * ordenação (#246) e o pódio (#247) entram depois.
+ * colunas de métrica à direita, `partidas: N` sob o nome, `Você` em dourado e
+ * destaque visual na métrica ativa.
  */
 
 const COR_TEXTO = '#e8ecf5';
@@ -40,13 +39,14 @@ interface Pincel {
 export function desenharTabelaRanking(
   cena: Scene,
   participantes: ParticipanteRanking[],
+  metrica: MetricaRanking,
 ): Phaser.GameObjects.GameObject[] {
   const pincel: Pincel = { cena, layout: calcularLayout(cena) };
-  const ordenados = ordenarRanking(participantes, 'vitorias');
+  const ordenados = ordenarRanking(participantes, metrica);
   const objetos = desenharCabecalho(pincel);
   ordenados.forEach((item, indice) => {
     const y = pincel.layout.topo + escalar(34, cena) + indice * pincel.layout.alturaLinha;
-    objetos.push(...desenharLinha(pincel, { item, indice, y }));
+    objetos.push(...desenharLinha(pincel, { item, indice, y, metrica }));
   });
   return objetos;
 }
@@ -62,7 +62,7 @@ function calcularLayout(cena: Scene): LayoutTabela {
     larguraColuna: escalar(COL_METRICA, cena),
     gap: escalar(GAP, cena),
     alturaLinha: escalar(64, cena),
-    topo: escalar(70, cena),
+    topo: escalar(122, cena),
   };
 }
 
@@ -84,6 +84,7 @@ interface LinhaCtx {
   item: ParticipanteRankeado;
   indice: number;
   y: number;
+  metrica: MetricaRanking;
 }
 
 function desenharLinha(pincel: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameObject[] {
@@ -92,7 +93,7 @@ function desenharLinha(pincel: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameOb
     fundoLinha(pincel, ctx.y, lider),
     posicao(pincel, { y: ctx.y, numero: ctx.indice + 1, lider }),
     ...identidade(pincel, ctx.y, ctx.item),
-    ...metricas(pincel, ctx.y, ctx.item),
+    ...metricas(pincel, ctx),
   ];
 }
 
@@ -139,13 +140,14 @@ function identidade({ cena, layout }: Pincel, y: number, item: ParticipanteRanke
   return [nome, partidas];
 }
 
-function metricas({ cena, layout }: Pincel, y: number, item: ParticipanteRankeado): Phaser.GameObjects.GameObject[] {
-  const valores = [String(item.vitorias), `${String(item.winRate)}%`, item.posMedia.toFixed(1)];
+function metricas({ cena, layout }: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameObject[] {
+  const valores = [String(ctx.item.vitorias), `${String(ctx.item.winRate)}%`, ctx.item.posMedia.toFixed(1)];
+  const metricasRanking: MetricaRanking[] = ['vitorias', 'winRate', 'posMedia'];
   return valores.map((valor, coluna) =>
     cena.add
-      .text(colunaX(layout, 2 - coluna), y, valor, {
+      .text(colunaX(layout, 2 - coluna), ctx.y, valor, {
         fontSize: escalarFonte(15, cena),
-        color: COR_TEXTO,
+        color: metricasRanking[coluna] === ctx.metrica ? COR_ACENTO : COR_TEXTO,
         fontStyle: 'bold',
         fontFamily: 'Arial',
       })


### PR DESCRIPTION
## O que mudou

- Adiciona o controle segmentado `Vitórias`, `Win rate` e `Pos. média` na tela de Ranking.
- Mantém `Vitórias` como ordenação inicial ao abrir a cena.
- Reordena a tabela imediatamente ao tocar em outra métrica, usando `ordenarRanking` e o desempate canônico já existente.
- Destaca em dourado a coluna da métrica ativa, seguindo o protótipo validado.

## Validação

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (57 arquivos, 784 testes)
- Hook de push: typecheck + testes

Closes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive metric selection control to the ranking view, allowing users to choose which metric to sort rankings by (e.g., victories).
  * The active sorting metric is visually highlighted.
  * Rankings automatically update when changing the sort metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->