### PR TITLE
feat(ranking): pódio acompanha métrica ativa

### DIFF
--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -3,7 +3,10 @@ import { carregarRanking, type RankingPersistido } from '@/store/ranking/carrega
 import type { MetricaRanking } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
-import { desenharTabelaRanking, OPCOES_METRICA_RANKING } from './desenhar-tabela-ranking';
+import { desenharPodioRanking } from './desenhar-podio-ranking';
+import { desenharTabelaRanking } from './desenhar-tabela-ranking';
+import { calcularLayoutRanking, type LayoutRanking } from './layout-ranking';
+import { OPCOES_METRICA_RANKING, prepararRankingRenderModel } from './ranking-view';
 
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
@@ -25,8 +28,8 @@ interface SegmentoCtx {
  * Tela cheia do Ranking, aberta sobre a JogoScene (que fica pausada).
  *
  * Lê o snapshot pela boundary estrita `carregarRanking`: ranking vazio mostra a
- * mensagem de tela vazia; ranking populado renderiza a tabela de participantes
- * ordenada pela métrica ativa. O pódio (#247) entra numa fatia posterior.
+ * mensagem de tela vazia; ranking populado renderiza pódio e tabela com a
+ * mesma ordenação da métrica ativa.
  */
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
@@ -61,8 +64,11 @@ export class RankingScene extends Scene {
 
   private desenharConteudo(ranking: RankingPersistido): void {
     if (ranking.tipo === 'populado') {
-      this.desenharControleOrdenacao();
-      this.objetos.push(...desenharTabelaRanking(this, ranking.participantes, this.metricaAtiva));
+      const layout = calcularLayoutRanking(this);
+      const model = prepararRankingRenderModel(ranking.participantes, this.metricaAtiva);
+      this.objetos.push(...desenharPodioRanking(this, model, layout));
+      this.desenharControleOrdenacao(layout);
+      this.objetos.push(...desenharTabelaRanking(this, model, layout));
       return;
     }
     this.desenharVazio();
@@ -100,20 +106,19 @@ export class RankingScene extends Scene {
     this.objetos.push(circulo, x_);
   }
 
-  private desenharControleOrdenacao(): void {
-    const largura = Math.min(this.cameras.main.width - escalar(32, this), escalar(600, this));
-    const esquerda = (this.cameras.main.width - largura) / 2;
-    const y = escalar(76, this);
+  private desenharControleOrdenacao(layout: LayoutRanking): void {
+    const { esquerda, largura } = layout.faixa;
+    const y = layout.controle.yRotulo;
     const rotulo = this.add.text(esquerda, y, 'Ordenar por', {
       fontSize: escalarFonte(12, this),
       color: COR_DIM,
       fontFamily: 'Arial',
     });
     const fundo = this.add
-      .rectangle(esquerda, y + escalar(34, this), largura, escalar(40, this), COR_SEGMENTO, 1)
+      .rectangle(esquerda, layout.controle.ySegmentos, largura, layout.controle.altura, COR_SEGMENTO, 1)
       .setOrigin(0, 0.5)
       .setStrokeStyle(escalar(1, this), COR_BORDA);
-    this.objetos.push(rotulo, fundo, ...this.desenharSegmentos(esquerda, y + escalar(34, this), largura));
+    this.objetos.push(rotulo, fundo, ...this.desenharSegmentos(esquerda, layout.controle.ySegmentos, largura));
   }
 
   private desenharSegmentos(x: number, y: number, largura: number): Phaser.GameObjects.GameObject[] {

--- a/src/adapters/phaser/scenes/desenhar-podio-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-podio-ranking.ts
@@ -1,0 +1,140 @@
+import type { Scene } from 'phaser';
+import type { MetricaRanking, ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
+import { escalar, escalarFonte } from '../escala';
+import type { LayoutRanking } from './layout-ranking';
+import { formatarMetricaRanking, rotuloCurtoMetricaRanking, type RankingRenderModel } from './ranking-view';
+
+const COR_TEXTO = '#e8ecf5';
+const COR_DIM = '#8b95ad';
+const COR_ACENTO = '#facc15';
+const COR_ACENTO_NUMERICA = 0xfacc15;
+const COR_SUPERFICIE = 0x111827;
+const COR_FITA = 0x2f80ed;
+const COR_PRATA = 0xc0c6d4;
+const COR_BRONZE = 0xc98a4b;
+
+interface SlotPodio {
+  item: ParticipanteRankeado;
+  posicao: number;
+  x: number;
+}
+
+interface EstatisticaCtx {
+  slot: SlotPodio;
+  metrica: MetricaRanking;
+  y: number;
+}
+
+interface DesenhoSlotCtx {
+  slot: SlotPodio;
+  metrica: MetricaRanking;
+  layout: LayoutRanking;
+}
+
+export function desenharPodioRanking(
+  cena: Scene,
+  model: RankingRenderModel,
+  layout: LayoutRanking,
+): Phaser.GameObjects.GameObject[] {
+  return calcularSlots(cena, model.participantes, layout).flatMap((slot) =>
+    desenharSlot(cena, { slot, metrica: model.metrica, layout }),
+  );
+}
+
+function calcularSlots(cena: Scene, participantes: ParticipanteRankeado[], layout: LayoutRanking): SlotPodio[] {
+  const top3 = participantes.slice(0, 3);
+  const centro = cena.cameras.main.centerX;
+  const intervalo = layout.podio.intervalo;
+  if (top3.length === 1) return [{ item: top3[0], posicao: 1, x: centro }];
+  if (top3.length === 2) {
+    return top3.map((item, indice) => ({ item, posicao: indice + 1, x: centro + (indice - 0.5) * intervalo }));
+  }
+  return [
+    { item: top3[1], posicao: 2, x: centro - intervalo },
+    { item: top3[0], posicao: 1, x: centro },
+    { item: top3[2], posicao: 3, x: centro + intervalo },
+  ];
+}
+
+function desenharSlot(cena: Scene, ctx: DesenhoSlotCtx): Phaser.GameObjects.GameObject[] {
+  const { slot, metrica, layout } = ctx;
+  const yBase = layout.podio.topo + (slot.posicao === 1 ? 0 : escalar(14, cena));
+  return [
+    medalha(cena, slot, yBase),
+    avatar(cena, slot, yBase + escalar(32, cena)),
+    nome(cena, slot, yBase + escalar(78, cena)),
+    estatistica(cena, { slot, metrica, y: yBase + escalar(98, cena) }),
+  ];
+}
+
+function medalha(cena: Scene, slot: SlotPodio, y: number): Phaser.GameObjects.GameObject {
+  const fita = cena.add.triangle(
+    slot.x,
+    y - escalar(5, cena),
+    0,
+    0,
+    escalar(12, cena),
+    0,
+    escalar(6, cena),
+    escalar(12, cena),
+    COR_FITA,
+  );
+  const moeda = cena.add.circle(slot.x, y + escalar(5, cena), escalar(7, cena), corDaPosicao(slot.posicao), 1);
+  const numero = cena.add
+    .text(slot.x, y + escalar(5, cena), String(slot.posicao), {
+      fontSize: escalarFonte(8, cena),
+      color: '#1a1a2e',
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+  return cena.add.container(0, 0, [fita, moeda, numero]);
+}
+
+function avatar(cena: Scene, slot: SlotPodio, y: number): Phaser.GameObjects.GameObject {
+  const principal = slot.posicao === 1;
+  const raio = escalar(principal ? 36 : 28, cena);
+  const circulo = cena.add
+    .circle(slot.x, y, raio, COR_SUPERFICIE, 1)
+    .setStrokeStyle(escalar(2, cena), corDaPosicao(slot.posicao));
+  const inicial = cena.add
+    .text(slot.x, y, slot.item.nomeExibicao.charAt(0).toUpperCase(), {
+      fontSize: escalarFonte(principal ? 26 : 20, cena),
+      color: principal ? COR_ACENTO : COR_TEXTO,
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+  return cena.add.container(0, 0, [circulo, inicial]);
+}
+
+function nome(cena: Scene, slot: SlotPodio, y: number): Phaser.GameObjects.Text {
+  return cena.add
+    .text(slot.x, y, slot.item.humano ? 'Você' : slot.item.nomeExibicao, {
+      fontSize: escalarFonte(13, cena),
+      color: slot.item.humano ? COR_ACENTO : COR_TEXTO,
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+}
+
+function estatistica(cena: Scene, ctx: EstatisticaCtx): Phaser.GameObjects.Text {
+  return cena.add
+    .text(ctx.slot.x, ctx.y, `${formatarMetricaRanking(ctx.slot.item, ctx.metrica)} ${rotuloMetrica(ctx.metrica)}`, {
+      fontSize: escalarFonte(11, cena),
+      color: COR_DIM,
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+}
+
+function corDaPosicao(posicao: number): number {
+  if (posicao === 1) return COR_ACENTO_NUMERICA;
+  if (posicao === 2) return COR_PRATA;
+  return COR_BRONZE;
+}
+
+function rotuloMetrica(metrica: MetricaRanking): string {
+  return rotuloCurtoMetricaRanking(metrica);
+}

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -1,7 +1,8 @@
 import type { Scene } from 'phaser';
-import { ordenarRanking, type MetricaRanking, type ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
-import type { ParticipanteRanking } from '@/store/ranking/tipos';
+import type { MetricaRanking, ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
+import type { LayoutRanking } from './layout-ranking';
+import { formatarMetricaRanking, OPCOES_METRICA_RANKING, type RankingRenderModel } from './ranking-view';
 
 /**
  * Tabela de participantes do Ranking, posicionada por coordenada (sem layout
@@ -16,16 +17,6 @@ const COR_ACENTO = '#facc15';
 const COR_VERDE = '#4ecca3';
 const COR_LINHA_FUNDO = 0x111827;
 const COR_LIDER = 0x4ecca3;
-
-const MAX_FAIXA = 600;
-const COL_METRICA = 84;
-const GAP = 6;
-
-export const OPCOES_METRICA_RANKING: { chave: MetricaRanking; rotulo: string }[] = [
-  { chave: 'vitorias', rotulo: 'Vitórias' },
-  { chave: 'winRate', rotulo: 'Win rate' },
-  { chave: 'posMedia', rotulo: 'Pos. média' },
-];
 
 interface LayoutTabela {
   esquerda: number;
@@ -44,31 +35,34 @@ interface Pincel {
 
 export function desenharTabelaRanking(
   cena: Scene,
-  participantes: ParticipanteRanking[],
+  model: RankingRenderModel,
+  layoutRanking: LayoutRanking,
+): Phaser.GameObjects.GameObject[] {
+  const pincel: Pincel = { cena, layout: layoutTabela(layoutRanking) };
+  return desenharTabelaOrdenada(pincel, model.participantes, model.metrica);
+}
+
+function desenharTabelaOrdenada(
+  pincel: Pincel,
+  ordenados: ParticipanteRankeado[],
   metrica: MetricaRanking,
 ): Phaser.GameObjects.GameObject[] {
-  const pincel: Pincel = { cena, layout: calcularLayout(cena) };
-  const ordenados = ordenarRanking(participantes, metrica);
   const objetos = desenharCabecalho(pincel);
   ordenados.forEach((item, indice) => {
-    const y = pincel.layout.topo + escalar(34, cena) + indice * pincel.layout.alturaLinha;
+    const y = pincel.layout.topo + escalar(34, pincel.cena) + indice * pincel.layout.alturaLinha;
     objetos.push(...desenharLinha(pincel, { item, indice, y, metrica }));
   });
   return objetos;
 }
 
-function calcularLayout(cena: Scene): LayoutTabela {
-  const { width } = cena.cameras.main;
-  const margem = escalar(16, cena);
-  const larguraFaixa = Math.min(width - margem * 2, escalar(MAX_FAIXA, cena));
-  const esquerda = (width - larguraFaixa) / 2;
+function layoutTabela(layout: LayoutRanking): LayoutTabela {
   return {
-    esquerda,
-    direita: esquerda + larguraFaixa - escalar(12, cena),
-    larguraColuna: escalar(COL_METRICA, cena),
-    gap: escalar(GAP, cena),
-    alturaLinha: escalar(64, cena),
-    topo: escalar(144, cena),
+    esquerda: layout.faixa.esquerda,
+    direita: layout.tabela.direita,
+    larguraColuna: layout.tabela.larguraColuna,
+    gap: layout.tabela.gap,
+    alturaLinha: layout.tabela.alturaLinha,
+    topo: layout.tabela.topo,
   };
 }
 
@@ -147,7 +141,7 @@ function identidade({ cena, layout }: Pincel, y: number, item: ParticipanteRanke
 }
 
 function metricas({ cena, layout }: Pincel, ctx: LinhaCtx): Phaser.GameObjects.GameObject[] {
-  const valores = [String(ctx.item.vitorias), `${String(ctx.item.winRate)}%`, ctx.item.posMedia.toFixed(1)];
+  const valores = OPCOES_METRICA_RANKING.map((opcao) => formatarMetricaRanking(ctx.item, opcao.chave));
   return valores.map((valor, coluna) =>
     cena.add
       .text(colunaX(layout, 2 - coluna), ctx.y, valor, {

--- a/src/adapters/phaser/scenes/layout-ranking.ts
+++ b/src/adapters/phaser/scenes/layout-ranking.ts
@@ -1,0 +1,46 @@
+import type { Scene } from 'phaser';
+import { escalar } from '../escala';
+
+const MAX_FAIXA = 600;
+const COL_METRICA = 84;
+const GAP = 6;
+const PARTICIPANTES_VISIVEIS_SEM_SCROLL = 7;
+
+export interface LayoutRanking {
+  faixa: { esquerda: number; largura: number; direita: number };
+  podio: { topo: number; intervalo: number };
+  controle: { yRotulo: number; ySegmentos: number; altura: number };
+  tabela: { topo: number; direita: number; larguraColuna: number; gap: number; alturaLinha: number };
+}
+
+export function calcularLayoutRanking(cena: Scene): LayoutRanking {
+  const faixa = calcularFaixa(cena);
+  const controle = { yRotulo: escalar(190, cena), ySegmentos: escalar(224, cena), altura: escalar(40, cena) };
+  const topoTabela = escalar(258, cena);
+  return {
+    faixa,
+    podio: { topo: escalar(66, cena), intervalo: escalar(124, cena) },
+    controle,
+    tabela: {
+      topo: topoTabela,
+      direita: faixa.direita - escalar(12, cena),
+      larguraColuna: escalar(COL_METRICA, cena),
+      gap: escalar(GAP, cena),
+      alturaLinha: calcularAlturaLinha(cena, topoTabela),
+    },
+  };
+}
+
+function calcularFaixa(cena: Scene): LayoutRanking['faixa'] {
+  const margem = escalar(16, cena);
+  const largura = Math.min(cena.cameras.main.width - margem * 2, escalar(MAX_FAIXA, cena));
+  const esquerda = (cena.cameras.main.width - largura) / 2;
+  return { esquerda, largura, direita: esquerda + largura };
+}
+
+function calcularAlturaLinha(cena: Scene, topoTabela: number): number {
+  const fimTabela = cena.cameras.main.height - escalar(18, cena);
+  const alturaDisponivel = fimTabela - topoTabela - escalar(34, cena);
+  const alturaCompacta = Math.floor(alturaDisponivel / PARTICIPANTES_VISIVEIS_SEM_SCROLL);
+  return Math.max(escalar(48, cena), Math.min(escalar(64, cena), alturaCompacta));
+}

--- a/src/adapters/phaser/scenes/ranking-view.ts
+++ b/src/adapters/phaser/scenes/ranking-view.ts
@@ -1,0 +1,30 @@
+import { ordenarRanking, type MetricaRanking, type ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
+import type { ParticipanteRanking } from '@/store/ranking/tipos';
+
+export const OPCOES_METRICA_RANKING: { chave: MetricaRanking; rotulo: string; rotuloCurto: string }[] = [
+  { chave: 'vitorias', rotulo: 'Vitórias', rotuloCurto: 'vitórias' },
+  { chave: 'winRate', rotulo: 'Win rate', rotuloCurto: 'win rate' },
+  { chave: 'posMedia', rotulo: 'Pos. média', rotuloCurto: 'pos. média' },
+];
+
+export interface RankingRenderModel {
+  metrica: MetricaRanking;
+  participantes: ParticipanteRankeado[];
+}
+
+export function prepararRankingRenderModel(
+  participantes: ParticipanteRanking[],
+  metrica: MetricaRanking,
+): RankingRenderModel {
+  return { metrica, participantes: ordenarRanking(participantes, metrica) };
+}
+
+export function formatarMetricaRanking(item: ParticipanteRankeado, metrica: MetricaRanking): string {
+  if (metrica === 'winRate') return `${String(item.winRate)}%`;
+  if (metrica === 'posMedia') return item.posMedia.toFixed(1);
+  return String(item.vitorias);
+}
+
+export function rotuloCurtoMetricaRanking(metrica: MetricaRanking): string {
+  return OPCOES_METRICA_RANKING.find((opcao) => opcao.chave === metrica)?.rotuloCurto ?? '';
+}


### PR DESCRIPTION
## Resumo

- adiciona pódio dos 3 melhores ao topo da tela de Ranking
- usa a mesma lista ordenada pela métrica ativa para pódio e tabela
- desloca controle segmentado e tabela para manter a composição compacta do protótipo

Closes #247

## Validação

- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- validação visual local com Playwright comparando `prototype-ranking.html` e `RankingScene` com snapshot mockado
