### PR TITLE
feat(ranking): rolagem da tabela quando o roster ultrapassa a tela

### DIFF
--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -5,9 +5,10 @@ import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { desenharPodioRanking } from './desenhar-podio-ranking';
 import { desenharTabelaRanking, type TabelaRankingRender } from './desenhar-tabela-ranking';
+import { offsetMaximoRolagem, precisaRolar, type GeometriaListaRanking } from './geometria-rolagem-tabela-ranking';
 import { calcularLayoutRanking, type LayoutRanking } from './layout-ranking';
 import { OPCOES_METRICA_RANKING, prepararRankingRenderModel } from './ranking-view';
-import { ControladorRolagemTabela, offsetMaximoRolagem, precisaRolar } from './rolagem-tabela-ranking';
+import { ControladorRolagemTabela } from './rolagem-tabela-ranking';
 
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
@@ -78,28 +79,27 @@ export class RankingScene extends Scene {
 
   private desenharTabelaComRolagem(tabela: TabelaRankingRender): void {
     this.objetos.push(...tabela.cabecalho);
-    const fundo = this.cameras.main.height - escalar(18, this);
-    const alturaVisivel = fundo - tabela.primeiraLinhaTopo;
-    if (!precisaRolar(tabela.alturaConteudo, alturaVisivel)) {
+    const { regiao, alturaConteudo, alturaVisivel } = tabela.geometria;
+    if (!precisaRolar(alturaConteudo, alturaVisivel)) {
       this.objetos.push(...tabela.linhas);
       return;
     }
     const container = this.add.container(0, 0, tabela.linhas);
-    container.setMask(this.criarMascaraLista(tabela.primeiraLinhaTopo, alturaVisivel));
+    container.setMask(this.criarMascaraLista(tabela.geometria));
     this.objetos.push(container);
     this.rolagem = new ControladorRolagemTabela({
       cena: this,
       container,
-      regiao: { topo: tabela.primeiraLinhaTopo, fundo },
-      offsetMaximo: offsetMaximoRolagem(tabela.alturaConteudo, alturaVisivel),
+      regiao,
+      offsetMaximo: offsetMaximoRolagem(alturaConteudo, alturaVisivel),
     });
   }
 
-  private criarMascaraLista(topo: number, altura: number): Phaser.Display.Masks.GeometryMask {
+  private criarMascaraLista({ regiao, alturaVisivel }: GeometriaListaRanking): Phaser.Display.Masks.GeometryMask {
     const forma = this.add
       .graphics()
       .fillStyle(0xffffff, 1)
-      .fillRect(0, topo, this.cameras.main.width, altura)
+      .fillRect(regiao.esquerda, regiao.topo, regiao.direita - regiao.esquerda, alturaVisivel)
       .setVisible(false);
     this.objetos.push(forma);
     return forma.createGeometryMask();

--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -4,9 +4,10 @@ import type { MetricaRanking } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
 import { desenharPodioRanking } from './desenhar-podio-ranking';
-import { desenharTabelaRanking } from './desenhar-tabela-ranking';
+import { desenharTabelaRanking, type TabelaRankingRender } from './desenhar-tabela-ranking';
 import { calcularLayoutRanking, type LayoutRanking } from './layout-ranking';
 import { OPCOES_METRICA_RANKING, prepararRankingRenderModel } from './ranking-view';
+import { ControladorRolagemTabela, offsetMaximoRolagem, precisaRolar } from './rolagem-tabela-ranking';
 
 const COR_FUNDO = 0x1a1a2e;
 const COR_TITULO = '#e8ecf5';
@@ -34,6 +35,7 @@ interface SegmentoCtx {
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
   private redesenhar?: ResizeDebouncer;
+  private rolagem?: ControladorRolagemTabela;
   private metricaAtiva: MetricaRanking = 'vitorias';
 
   constructor() {
@@ -68,10 +70,39 @@ export class RankingScene extends Scene {
       const model = prepararRankingRenderModel(ranking.participantes, this.metricaAtiva);
       this.objetos.push(...desenharPodioRanking(this, model, layout));
       this.desenharControleOrdenacao(layout);
-      this.objetos.push(...desenharTabelaRanking(this, model, layout));
+      this.desenharTabelaComRolagem(desenharTabelaRanking(this, model, layout));
       return;
     }
     this.desenharVazio();
+  }
+
+  private desenharTabelaComRolagem(tabela: TabelaRankingRender): void {
+    this.objetos.push(...tabela.cabecalho);
+    const fundo = this.cameras.main.height - escalar(18, this);
+    const alturaVisivel = fundo - tabela.primeiraLinhaTopo;
+    if (!precisaRolar(tabela.alturaConteudo, alturaVisivel)) {
+      this.objetos.push(...tabela.linhas);
+      return;
+    }
+    const container = this.add.container(0, 0, tabela.linhas);
+    container.setMask(this.criarMascaraLista(tabela.primeiraLinhaTopo, alturaVisivel));
+    this.objetos.push(container);
+    this.rolagem = new ControladorRolagemTabela({
+      cena: this,
+      container,
+      regiao: { topo: tabela.primeiraLinhaTopo, fundo },
+      offsetMaximo: offsetMaximoRolagem(tabela.alturaConteudo, alturaVisivel),
+    });
+  }
+
+  private criarMascaraLista(topo: number, altura: number): Phaser.Display.Masks.GeometryMask {
+    const forma = this.add
+      .graphics()
+      .fillStyle(0xffffff, 1)
+      .fillRect(0, topo, this.cameras.main.width, altura)
+      .setVisible(false);
+    this.objetos.push(forma);
+    return forma.createGeometryMask();
   }
 
   private desenharFundo(): void {
@@ -180,6 +211,8 @@ export class RankingScene extends Scene {
   }
 
   private limpar(): void {
+    this.rolagem?.destruir();
+    this.rolagem = undefined;
     this.objetos.forEach((obj) => {
       obj.destroy();
     });

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { MetricaRanking, ParticipanteRankeado } from '@/store/ranking/ordenar-ranking';
 import { escalar, escalarFonte } from '../escala';
+import { calcularGeometriaLista, type GeometriaListaRanking } from './geometria-rolagem-tabela-ranking';
 import type { LayoutRanking } from './layout-ranking';
 import { formatarMetricaRanking, OPCOES_METRICA_RANKING, type RankingRenderModel } from './ranking-view';
 
@@ -36,15 +37,14 @@ interface Pincel {
 /**
  * Resultado da tabela já separado em duas partes: `cabecalho` fica fixo na
  * cena; `linhas` é o que a `RankingScene` põe num container mascarado para
- * rolar (#249). `alturaConteudo`, `primeiraLinhaTopo` e `alturaLinha` dão a
- * geometria que o controlador de rolagem precisa para calcular os limites.
+ * rolar (#249). `geometria` traz a região retangular do corpo da tabela e as
+ * alturas visível/total — contrato fechado da viewport, sem a cena recomputar
+ * pedaços por fora.
  */
 export interface TabelaRankingRender {
   cabecalho: Phaser.GameObjects.GameObject[];
   linhas: Phaser.GameObjects.GameObject[];
-  alturaConteudo: number;
-  primeiraLinhaTopo: number;
-  alturaLinha: number;
+  geometria: GeometriaListaRanking;
 }
 
 export function desenharTabelaRanking(
@@ -61,9 +61,14 @@ export function desenharTabelaRanking(
   return {
     cabecalho: desenharCabecalho(pincel),
     linhas,
-    alturaLinha,
-    primeiraLinhaTopo: inicio - alturaLinha / 2,
-    alturaConteudo: model.participantes.length * alturaLinha,
+    geometria: calcularGeometriaLista({
+      esquerda: pincel.layout.esquerda,
+      direita: pincel.layout.direita + escalar(12, cena),
+      primeiraLinhaTopo: inicio - alturaLinha / 2,
+      fundo: cena.cameras.main.height - escalar(18, cena),
+      alturaLinha,
+      totalLinhas: model.participantes.length,
+    }),
   };
 }
 

--- a/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-tabela-ranking.ts
@@ -33,26 +33,38 @@ interface Pincel {
   layout: LayoutTabela;
 }
 
+/**
+ * Resultado da tabela já separado em duas partes: `cabecalho` fica fixo na
+ * cena; `linhas` é o que a `RankingScene` põe num container mascarado para
+ * rolar (#249). `alturaConteudo`, `primeiraLinhaTopo` e `alturaLinha` dão a
+ * geometria que o controlador de rolagem precisa para calcular os limites.
+ */
+export interface TabelaRankingRender {
+  cabecalho: Phaser.GameObjects.GameObject[];
+  linhas: Phaser.GameObjects.GameObject[];
+  alturaConteudo: number;
+  primeiraLinhaTopo: number;
+  alturaLinha: number;
+}
+
 export function desenharTabelaRanking(
   cena: Scene,
   model: RankingRenderModel,
   layoutRanking: LayoutRanking,
-): Phaser.GameObjects.GameObject[] {
+): TabelaRankingRender {
   const pincel: Pincel = { cena, layout: layoutTabela(layoutRanking) };
-  return desenharTabelaOrdenada(pincel, model.participantes, model.metrica);
-}
-
-function desenharTabelaOrdenada(
-  pincel: Pincel,
-  ordenados: ParticipanteRankeado[],
-  metrica: MetricaRanking,
-): Phaser.GameObjects.GameObject[] {
-  const objetos = desenharCabecalho(pincel);
-  ordenados.forEach((item, indice) => {
-    const y = pincel.layout.topo + escalar(34, pincel.cena) + indice * pincel.layout.alturaLinha;
-    objetos.push(...desenharLinha(pincel, { item, indice, y, metrica }));
-  });
-  return objetos;
+  const { alturaLinha } = pincel.layout;
+  const inicio = pincel.layout.topo + escalar(34, cena);
+  const linhas = model.participantes.flatMap((item, indice) =>
+    desenharLinha(pincel, { item, indice, y: inicio + indice * alturaLinha, metrica: model.metrica }),
+  );
+  return {
+    cabecalho: desenharCabecalho(pincel),
+    linhas,
+    alturaLinha,
+    primeiraLinhaTopo: inicio - alturaLinha / 2,
+    alturaConteudo: model.participantes.length * alturaLinha,
+  };
 }
 
 function layoutTabela(layout: LayoutRanking): LayoutTabela {

--- a/src/adapters/phaser/scenes/geometria-rolagem-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/geometria-rolagem-tabela-ranking.ts
@@ -1,0 +1,71 @@
+/**
+ * Geometria pura da rolagem da lista de participantes do Ranking (issue #249).
+ *
+ * Módulo deliberadamente sem `Scene`, sem o namespace `Phaser` e sem o
+ * controlador: só números e retângulos. Assim o contrato é testável em Node
+ * (Vitest) sem esbarrar na regra do AGENTS.md de não testar adapter Phaser — o
+ * controlador, que toca `Scene`/`Container`/`input`, vive em
+ * `rolagem-tabela-ranking.ts` e é validado visualmente.
+ */
+
+export interface RegiaoLista {
+  esquerda: number;
+  direita: number;
+  topo: number;
+  fundo: number;
+}
+
+export interface Ponto {
+  x: number;
+  y: number;
+}
+
+export interface EntradaGeometriaLista {
+  esquerda: number;
+  direita: number;
+  primeiraLinhaTopo: number;
+  fundo: number;
+  alturaLinha: number;
+  totalLinhas: number;
+}
+
+export interface GeometriaListaRanking {
+  regiao: RegiaoLista;
+  alturaVisivel: number;
+  alturaConteudo: number;
+}
+
+/** Região retangular do corpo da tabela + alturas visível e total do conteúdo. */
+export function calcularGeometriaLista(entrada: EntradaGeometriaLista): GeometriaListaRanking {
+  const regiao: RegiaoLista = {
+    esquerda: entrada.esquerda,
+    direita: entrada.direita,
+    topo: entrada.primeiraLinhaTopo,
+    fundo: entrada.fundo,
+  };
+  return {
+    regiao,
+    alturaVisivel: entrada.fundo - entrada.primeiraLinhaTopo,
+    alturaConteudo: entrada.totalLinhas * entrada.alturaLinha,
+  };
+}
+
+/** Hit-test único: o ponteiro está dentro do corpo da tabela? */
+export function contemPonteiroNaRegiao(regiao: RegiaoLista, ponto: Ponto): boolean {
+  return ponto.x >= regiao.esquerda && ponto.x <= regiao.direita && ponto.y >= regiao.topo && ponto.y <= regiao.fundo;
+}
+
+/** Quanto a lista pode rolar: 0 quando o conteúdo cabe na área visível. */
+export function offsetMaximoRolagem(alturaConteudo: number, alturaVisivel: number): number {
+  return Math.max(0, alturaConteudo - alturaVisivel);
+}
+
+/** Há transbordo? Só então vale criar máscara e ligar o arrasto/roda. */
+export function precisaRolar(alturaConteudo: number, alturaVisivel: number): boolean {
+  return offsetMaximoRolagem(alturaConteudo, alturaVisivel) > 0;
+}
+
+/** Prende o deslocamento entre o topo (0) e o fim da lista (offsetMáximo). */
+export function clampOffsetRolagem(offset: number, offsetMaximo: number): number {
+  return Math.min(offsetMaximo, Math.max(0, offset));
+}

--- a/src/adapters/phaser/scenes/rolagem-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/rolagem-tabela-ranking.ts
@@ -1,44 +1,25 @@
 import type { Scene } from 'phaser';
+import { clampOffsetRolagem, contemPonteiroNaRegiao, type RegiaoLista } from './geometria-rolagem-tabela-ranking';
 
 /**
- * Rolagem vertical da lista de participantes do Ranking (issue #249).
+ * Controlador Phaser da rolagem da lista do Ranking (issue #249).
  *
- * O caso comum (lista curta) cabe na tela e não rola. Quando o roster cresce
- * (1 humano + até 20 Perfis de Bot) as linhas transbordam: elas vão para um
- * `Container` mascarado na região da lista e o controlador move o container no
- * eixo Y por arrasto e roda do mouse, com o deslocamento preso entre 0 e o
- * `offsetMáximo`. Título, fundo, botão de fechar, controles de ordenação e o
- * cabeçalho de colunas ficam fora do container e permanecem fixos.
+ * Quando o roster transborda (1 humano + até 20 Perfis de Bot), as linhas vão
+ * para um `Container` mascarado e este controlador as move no eixo Y por
+ * arrasto e roda do mouse, com o deslocamento preso entre 0 e o `offsetMáximo`.
+ * Arrasto e roda só agem quando o ponteiro está dentro do corpo da tabela — a
+ * mesma `RegiaoLista`, o mesmo hit-test — para não roubar input de título,
+ * cabeçalho, controles de ordenação e botão de fechar, que ficam fixos.
  *
- * A geometria pura (limites e clamp) fica isolada nas funções abaixo, testáveis
- * sem Phaser; o `ControladorRolagemTabela` apenas as aplica ao container.
+ * A geometria (limites, clamp, hit-test) vive em
+ * `geometria-rolagem-tabela-ranking.ts`, pura e testável; aqui só há Phaser.
  */
-
-export interface RegiaoLista {
-  topo: number;
-  fundo: number;
-}
 
 export interface ConfigRolagemTabela {
   cena: Scene;
   container: Phaser.GameObjects.Container;
   regiao: RegiaoLista;
   offsetMaximo: number;
-}
-
-/** Quanto a lista pode rolar: 0 quando o conteúdo cabe na área visível. */
-export function offsetMaximoRolagem(alturaConteudo: number, alturaVisivel: number): number {
-  return Math.max(0, alturaConteudo - alturaVisivel);
-}
-
-/** Há transbordo? Só então vale criar máscara e ligar o arrasto/roda. */
-export function precisaRolar(alturaConteudo: number, alturaVisivel: number): boolean {
-  return offsetMaximoRolagem(alturaConteudo, alturaVisivel) > 0;
-}
-
-/** Prende o deslocamento entre o topo (0) e o fim da lista (offsetMáximo). */
-export function clampOffsetRolagem(offset: number, offsetMaximo: number): number {
-  return Math.min(offsetMaximo, Math.max(0, offset));
 }
 
 export class ControladorRolagemTabela {
@@ -69,7 +50,7 @@ export class ControladorRolagemTabela {
       this.arrastando = false;
     };
     this.aoRolar = (p) => {
-      this.aplicar(this.offset + p.deltaY);
+      this.rolarComRoda(p);
     };
     this.registrar();
   }
@@ -84,7 +65,7 @@ export class ControladorRolagemTabela {
   }
 
   private iniciarArrasto(p: Phaser.Input.Pointer): void {
-    if (p.y < this.regiao.topo || p.y > this.regiao.fundo) return;
+    if (!contemPonteiroNaRegiao(this.regiao, p)) return;
     this.arrastando = true;
     this.ultimoY = p.y;
   }
@@ -93,6 +74,11 @@ export class ControladorRolagemTabela {
     if (!this.arrastando) return;
     this.aplicar(this.offset - (p.y - this.ultimoY));
     this.ultimoY = p.y;
+  }
+
+  private rolarComRoda(p: Phaser.Input.Pointer): void {
+    if (!contemPonteiroNaRegiao(this.regiao, p)) return;
+    this.aplicar(this.offset + p.deltaY);
   }
 
   private aplicar(bruto: number): void {

--- a/src/adapters/phaser/scenes/rolagem-tabela-ranking.ts
+++ b/src/adapters/phaser/scenes/rolagem-tabela-ranking.ts
@@ -1,0 +1,111 @@
+import type { Scene } from 'phaser';
+
+/**
+ * Rolagem vertical da lista de participantes do Ranking (issue #249).
+ *
+ * O caso comum (lista curta) cabe na tela e não rola. Quando o roster cresce
+ * (1 humano + até 20 Perfis de Bot) as linhas transbordam: elas vão para um
+ * `Container` mascarado na região da lista e o controlador move o container no
+ * eixo Y por arrasto e roda do mouse, com o deslocamento preso entre 0 e o
+ * `offsetMáximo`. Título, fundo, botão de fechar, controles de ordenação e o
+ * cabeçalho de colunas ficam fora do container e permanecem fixos.
+ *
+ * A geometria pura (limites e clamp) fica isolada nas funções abaixo, testáveis
+ * sem Phaser; o `ControladorRolagemTabela` apenas as aplica ao container.
+ */
+
+export interface RegiaoLista {
+  topo: number;
+  fundo: number;
+}
+
+export interface ConfigRolagemTabela {
+  cena: Scene;
+  container: Phaser.GameObjects.Container;
+  regiao: RegiaoLista;
+  offsetMaximo: number;
+}
+
+/** Quanto a lista pode rolar: 0 quando o conteúdo cabe na área visível. */
+export function offsetMaximoRolagem(alturaConteudo: number, alturaVisivel: number): number {
+  return Math.max(0, alturaConteudo - alturaVisivel);
+}
+
+/** Há transbordo? Só então vale criar máscara e ligar o arrasto/roda. */
+export function precisaRolar(alturaConteudo: number, alturaVisivel: number): boolean {
+  return offsetMaximoRolagem(alturaConteudo, alturaVisivel) > 0;
+}
+
+/** Prende o deslocamento entre o topo (0) e o fim da lista (offsetMáximo). */
+export function clampOffsetRolagem(offset: number, offsetMaximo: number): number {
+  return Math.min(offsetMaximo, Math.max(0, offset));
+}
+
+export class ControladorRolagemTabela {
+  private offset = 0;
+  private arrastando = false;
+  private ultimoY = 0;
+  private readonly cena: Scene;
+  private readonly container: Phaser.GameObjects.Container;
+  private readonly regiao: RegiaoLista;
+  private readonly offsetMaximo: number;
+  private readonly aoPressionar: (p: Phaser.Input.Pointer) => void;
+  private readonly aoMover: (p: Phaser.Input.Pointer) => void;
+  private readonly aoSoltar: () => void;
+  private readonly aoRolar: (p: Phaser.Input.Pointer) => void;
+
+  constructor(config: ConfigRolagemTabela) {
+    this.cena = config.cena;
+    this.container = config.container;
+    this.regiao = config.regiao;
+    this.offsetMaximo = config.offsetMaximo;
+    this.aoPressionar = (p) => {
+      this.iniciarArrasto(p);
+    };
+    this.aoMover = (p) => {
+      this.arrastar(p);
+    };
+    this.aoSoltar = () => {
+      this.arrastando = false;
+    };
+    this.aoRolar = (p) => {
+      this.aplicar(this.offset + p.deltaY);
+    };
+    this.registrar();
+  }
+
+  private registrar(): void {
+    const input = this.cena.input;
+    input.on('pointerdown', this.aoPressionar);
+    input.on('pointermove', this.aoMover);
+    input.on('pointerup', this.aoSoltar);
+    input.on('pointerupoutside', this.aoSoltar);
+    input.on('wheel', this.aoRolar);
+  }
+
+  private iniciarArrasto(p: Phaser.Input.Pointer): void {
+    if (p.y < this.regiao.topo || p.y > this.regiao.fundo) return;
+    this.arrastando = true;
+    this.ultimoY = p.y;
+  }
+
+  private arrastar(p: Phaser.Input.Pointer): void {
+    if (!this.arrastando) return;
+    this.aplicar(this.offset - (p.y - this.ultimoY));
+    this.ultimoY = p.y;
+  }
+
+  private aplicar(bruto: number): void {
+    this.offset = clampOffsetRolagem(bruto, this.offsetMaximo);
+    this.container.y = -this.offset;
+  }
+
+  destruir(): void {
+    const input = this.cena.input;
+    input.off('pointerdown', this.aoPressionar);
+    input.off('pointermove', this.aoMover);
+    input.off('pointerup', this.aoSoltar);
+    input.off('pointerupoutside', this.aoSoltar);
+    input.off('wheel', this.aoRolar);
+  }
+}

--- a/tests/adapters/rolagem-tabela-ranking.test.ts
+++ b/tests/adapters/rolagem-tabela-ranking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { clampOffsetRolagem, offsetMaximoRolagem, precisaRolar } from '@/adapters/phaser/scenes/rolagem-tabela-ranking';
+
+describe('offsetMaximoRolagem', () => {
+  it('deve ser zero quando o conteúdo cabe na área visível', () => {
+    expect(offsetMaximoRolagem(300, 400)).toBe(0);
+  });
+
+  it('deve ser zero quando o conteúdo é exatamente do tamanho visível', () => {
+    expect(offsetMaximoRolagem(400, 400)).toBe(0);
+  });
+
+  it('deve ser a sobra quando o conteúdo transborda', () => {
+    expect(offsetMaximoRolagem(700, 400)).toBe(300);
+  });
+});
+
+describe('precisaRolar', () => {
+  it('deve retornar false quando a lista curta cabe na tela', () => {
+    expect(precisaRolar(300, 400)).toBe(false);
+  });
+
+  it('deve retornar true quando o roster ultrapassa a área visível', () => {
+    expect(precisaRolar(700, 400)).toBe(true);
+  });
+});
+
+describe('clampOffsetRolagem', () => {
+  it('deve prender no topo quando o deslocamento é negativo', () => {
+    expect(clampOffsetRolagem(-50, 300)).toBe(0);
+  });
+
+  it('deve prender no fim quando o deslocamento passa do limite', () => {
+    expect(clampOffsetRolagem(500, 300)).toBe(300);
+  });
+
+  it('deve preservar o deslocamento dentro dos limites', () => {
+    expect(clampOffsetRolagem(120, 300)).toBe(120);
+  });
+});

--- a/tests/adapters/rolagem-tabela-ranking.test.ts
+++ b/tests/adapters/rolagem-tabela-ranking.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { clampOffsetRolagem, offsetMaximoRolagem, precisaRolar } from '@/adapters/phaser/scenes/rolagem-tabela-ranking';
+import {
+  calcularGeometriaLista,
+  clampOffsetRolagem,
+  contemPonteiroNaRegiao,
+  offsetMaximoRolagem,
+  precisaRolar,
+  type RegiaoLista,
+} from '@/adapters/phaser/scenes/geometria-rolagem-tabela-ranking';
 
 describe('offsetMaximoRolagem', () => {
   it('deve ser zero quando o conteúdo cabe na área visível', () => {
@@ -36,5 +43,54 @@ describe('clampOffsetRolagem', () => {
 
   it('deve preservar o deslocamento dentro dos limites', () => {
     expect(clampOffsetRolagem(120, 300)).toBe(120);
+  });
+});
+
+describe('calcularGeometriaLista', () => {
+  const entrada = {
+    esquerda: 16,
+    direita: 616,
+    primeiraLinhaTopo: 258,
+    fundo: 800,
+    alturaLinha: 48,
+    totalLinhas: 21,
+  };
+
+  it('deve montar a região retangular do corpo da tabela', () => {
+    expect(calcularGeometriaLista(entrada).regiao).toEqual({
+      esquerda: 16,
+      direita: 616,
+      topo: 258,
+      fundo: 800,
+    });
+  });
+
+  it('deve derivar a altura visível como fundo menos topo', () => {
+    expect(calcularGeometriaLista(entrada).alturaVisivel).toBe(542);
+  });
+
+  it('deve derivar a altura do conteúdo como total de linhas vezes a altura da linha', () => {
+    expect(calcularGeometriaLista(entrada).alturaConteudo).toBe(21 * 48);
+  });
+});
+
+describe('contemPonteiroNaRegiao', () => {
+  const regiao: RegiaoLista = { esquerda: 16, direita: 616, topo: 258, fundo: 800 };
+
+  it('deve aceitar um ponto dentro do retângulo', () => {
+    expect(contemPonteiroNaRegiao(regiao, { x: 300, y: 500 })).toBe(true);
+  });
+
+  it('deve aceitar pontos exatamente na borda', () => {
+    expect(contemPonteiroNaRegiao(regiao, { x: 16, y: 258 })).toBe(true);
+    expect(contemPonteiroNaRegiao(regiao, { x: 616, y: 800 })).toBe(true);
+  });
+
+  it('deve rejeitar um ponto acima da lista (header/controles)', () => {
+    expect(contemPonteiroNaRegiao(regiao, { x: 300, y: 100 })).toBe(false);
+  });
+
+  it('deve rejeitar um ponto à direita do corpo da tabela', () => {
+    expect(contemPonteiroNaRegiao(regiao, { x: 700, y: 500 })).toBe(false);
   });
 });


### PR DESCRIPTION
## Contexto

Fecha #249. A tabela do Ranking (#245, PRD #242) era desenhada por coordenada na `RankingScene`, sem rolagem. Com o roster crescendo (1 jogador humano + até 20 Perfis de Bot), as últimas linhas transbordavam para fora da tela sem como acessá-las.

## O que mudou

Implementação do padrão Phaser **container + máscara** sugerido na issue:

- As **linhas** da tabela vão para um `Container` com máscara retangular geométrica na área da lista.
- **Arrasto** (pointer) e **roda do mouse** movem o container no eixo Y, com o deslocamento preso entre `0` e `alturaConteudo - alturaVisivel`.
- **Título, fundo, botão de fechar, controles de ordenação e o cabeçalho de colunas** ficam fora do container e permanecem fixos.
- Os **limites são recalculados ao redimensionar** — o `redesenhar` (debounce de resize) já recria a tela inteira, então a geometria nova vale para a próxima rolagem.
- O **caso comum (lista curta)** não cria máscara nem controlador: comportamento e visual idênticos ao anterior. O gate é `precisaRolar(alturaConteudo, alturaVisivel)`.
- O arrasto só começa quando o pointer pressiona dentro da região da lista, evitando conflito com os controles de ordenação acima.
- Listeners de input são removidos em `ControladorRolagemTabela.destruir()`, chamado no `limpar()`/`shutdown` da cena (sem listeners duplicados a cada redesenho).

## Estrutura

- `rolagem-tabela-ranking.ts` — geometria pura (`offsetMaximoRolagem`, `precisaRolar`, `clampOffsetRolagem`) isolada e testável sem Phaser, mais o `ControladorRolagemTabela` (adapter Phaser) que só as aplica ao container.
- `desenhar-tabela-ranking.ts` — passa a separar `cabecalho` (fixo) das `linhas` (roláveis) e expõe a geometria do conteúdo (`alturaConteudo`, `primeiraLinhaTopo`, `alturaLinha`).
- `RankingScene.ts` — monta o container mascarado e o controlador quando há transbordo.

## Acceptance criteria

- [x] Com participantes além do que cabe, é possível rolar e ver todas as linhas (arrasto e roda do mouse).
- [x] Título, fundo e botão de fechar permanecem fixos durante a rolagem.
- [x] A rolagem respeita os limites (não rola além do topo nem do fim).
- [x] Os limites são recalculados ao redimensionar a viewport.
- [x] O caso comum (lista curta) continua sem rolagem e sem mudança visual.

## Validação

Como é adapter Phaser, a validação é **visual** (deploy preview). A lógica pura de clamp/limites tem teste unitário (Vitest).

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (792 testes, +8 novos)
- `pnpm build` ✅

https://claude.ai/code/session_01Vt9SEmXG7FwbSMVz15xM2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vt9SEmXG7FwbSMVz15xM2D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ranking tables now support vertical scrolling when content exceeds the visible display area.

* **Refactor**
  * Improved the internal rendering structure for ranking tables, separating header and content elements.

* **Tests**
  * Added test coverage for scroll offset calculations and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->