### PR TITLE
refactor(ranking): ancora identidade no perfilId canônico do Perfil de Bot (#251)

### DIFF
--- a/src/adapters/bots/perfil-bot.ts
+++ b/src/adapters/bots/perfil-bot.ts
@@ -1,41 +1,54 @@
 import type { GeradorAleatorio } from '@/core/RngComSeed';
 import type { Jogador } from '@/types/entidades';
 
-export const nomesBotsPorTemperatura = [
-  'Brás', // Brás Cubas — Memórias Póstumas de Brás Cubas (Machado de Assis)
-  'Severino', // Morte e Vida Severina (João Cabral de Melo Neto)
-  'Iara', // Iara — lenda do folclore brasileiro
-  'Bento', // Bento Santiago — D. Casmurro (Machado de Assis)
-  'Ana', // Ana Terra — O Tempo e o Vento (Érico Veríssimo)
-  'Pedro', // Pedro Bala — Capitães da Areia (Jorge Amado)
-  'Vitória', // Sinhá Vitória — Vidas Secas (Graciliano Ramos)
-  'Augusto', // Augusto Matraga — Sagarana (Guimarães Rosa)
-  'Leonardo', // Leonardo — Memórias de um Sargento de Milícias (Manuel Antônio de Almeida)
-  'Fabiano', // Fabiano — Vidas Secas (Graciliano Ramos)
-  'Sofia', // Sofia — Quincas Borba (Machado de Assis)
-  'Luís', // Luís da Silva — Angústia (Graciliano Ramos)
-  'Aurélia', // Aurélia Camargo — Senhora (José de Alencar)
-  'Clara', // Clara dos Anjos — Clara dos Anjos (Lima Barreto)
-  'Rita', // Rita Baiana — O Cortiço (Aluísio Azevedo)
-  'Sérgio', // narrador de O Ateneu (Raul Pompeia)
-  'Paulo', // Paulo Honório — São Bernardo (Graciliano Ramos)
-  'Flor', // Dona Flor — Dona Flor e Seus Dois Maridos (Jorge Amado)
-  'Jerônimo', // Jerônimo — O Cortiço (Aluísio Azevedo)
-  'Iracema', // Iracema — Iracema (José de Alencar)
+/**
+ * Fonte canônica dos Perfis de Bot. Cada perfil tem um `id` estável — a
+ * identidade reconhecível usada no Ranking entre Partidas — desacoplado do
+ * `nome` exibido: renomear o texto não muda o `id`, e dois perfis nunca
+ * compartilham `id` (lista fechada e curada à mão, sem slug derivado de nome).
+ */
+export const perfisBotsPorTemperatura = [
+  { id: 'bras', nome: 'Brás' }, // Brás Cubas — Memórias Póstumas de Brás Cubas (Machado de Assis)
+  { id: 'severino', nome: 'Severino' }, // Morte e Vida Severina (João Cabral de Melo Neto)
+  { id: 'iara', nome: 'Iara' }, // Iara — lenda do folclore brasileiro
+  { id: 'bento', nome: 'Bento' }, // Bento Santiago — D. Casmurro (Machado de Assis)
+  { id: 'ana', nome: 'Ana' }, // Ana Terra — O Tempo e o Vento (Érico Veríssimo)
+  { id: 'pedro', nome: 'Pedro' }, // Pedro Bala — Capitães da Areia (Jorge Amado)
+  { id: 'vitoria', nome: 'Vitória' }, // Sinhá Vitória — Vidas Secas (Graciliano Ramos)
+  { id: 'augusto', nome: 'Augusto' }, // Augusto Matraga — Sagarana (Guimarães Rosa)
+  { id: 'leonardo', nome: 'Leonardo' }, // Leonardo — Memórias de um Sargento de Milícias (Manuel Antônio de Almeida)
+  { id: 'fabiano', nome: 'Fabiano' }, // Fabiano — Vidas Secas (Graciliano Ramos)
+  { id: 'sofia', nome: 'Sofia' }, // Sofia — Quincas Borba (Machado de Assis)
+  { id: 'luis', nome: 'Luís' }, // Luís da Silva — Angústia (Graciliano Ramos)
+  { id: 'aurelia', nome: 'Aurélia' }, // Aurélia Camargo — Senhora (José de Alencar)
+  { id: 'clara', nome: 'Clara' }, // Clara dos Anjos — Clara dos Anjos (Lima Barreto)
+  { id: 'rita', nome: 'Rita' }, // Rita Baiana — O Cortiço (Aluísio Azevedo)
+  { id: 'sergio', nome: 'Sérgio' }, // narrador de O Ateneu (Raul Pompeia)
+  { id: 'paulo', nome: 'Paulo' }, // Paulo Honório — São Bernardo (Graciliano Ramos)
+  { id: 'flor', nome: 'Flor' }, // Dona Flor — Dona Flor e Seus Dois Maridos (Jorge Amado)
+  { id: 'jeronimo', nome: 'Jerônimo' }, // Jerônimo — O Cortiço (Aluísio Azevedo)
+  { id: 'iracema', nome: 'Iracema' }, // Iracema — Iracema (José de Alencar)
 ] as const;
+
+export const nomesBotsPorTemperatura = perfisBotsPorTemperatura.map((perfil) => perfil.nome);
 
 export interface PerfilBot {
   id: string;
+  perfilId: string;
   nome: string;
   temperatura: number;
 }
 
-const totalFaixas = nomesBotsPorTemperatura.length;
+const totalFaixas = perfisBotsPorTemperatura.length;
 const larguraFaixa = 1 / totalFaixas;
 
-export function nomePorTemperatura(temperatura: number): string {
+export function perfilPorTemperatura(temperatura: number): { id: string; nome: string } {
   const faixa = Math.min(Math.floor(temperatura * totalFaixas), totalFaixas - 1);
-  return nomesBotsPorTemperatura[faixa];
+  return perfisBotsPorTemperatura[faixa];
+}
+
+export function nomePorTemperatura(temperatura: number): string {
+  return perfilPorTemperatura(temperatura).nome;
 }
 
 export function sortearPerfisBots(
@@ -47,9 +60,11 @@ export function sortearPerfisBots(
 
   return bots.map((jogador, indice) => {
     const temperatura = (faixas[indice] + rng.random()) * larguraFaixa;
+    const perfil = perfilPorTemperatura(temperatura);
     return {
       id: jogador.id,
-      nome: nomePorTemperatura(temperatura),
+      perfilId: perfil.id,
+      nome: perfil.nome,
       temperatura,
     };
   });
@@ -59,7 +74,7 @@ export function aplicarPerfisBots(jogadores: Jogador[], perfis: PerfilBot[]): Jo
   return jogadores.map((jogador) => {
     const perfil = perfis.find((item) => item.id === jogador.id);
     if (!perfil) return jogador;
-    return { ...jogador, nome: perfil.nome, temperatura: perfil.temperatura };
+    return { ...jogador, perfilId: perfil.perfilId, nome: perfil.nome, temperatura: perfil.temperatura };
   });
 }
 

--- a/src/store/ranking/identidade.ts
+++ b/src/store/ranking/identidade.ts
@@ -1,8 +1,13 @@
 /**
  * Identidade de Ranking de um participante a partir de um jogador da
  * Classificação da Partida. O jogador humano colapsa na chave `humano`; cada
- * Perfil de Bot vira um slug ASCII estável derivado do nome reconhecível
- * (`Brás` → `bot:bras`), independente do assento técnico (`bot1/bot2/bot3`).
+ * Perfil de Bot ancora na sua identidade canônica (`jogador.perfilId`,
+ * ex.: `bras` → `bot:bras`), estável entre Partidas e independente tanto do
+ * assento técnico (`bot1/bot2/bot3`) quanto do nome exibido.
+ *
+ * O contrato é explícito: ou o participante carrega `perfilId` (é um Perfil de
+ * Bot), ou é o humano. Um participante sem identidade reconhecível não é
+ * silenciosamente tratado como bot — é um erro.
  */
 
 import type { Jogador } from '@/types/entidades';
@@ -13,14 +18,11 @@ export interface IdentidadeRanking {
 }
 
 export function identidadeDe(jogador: Jogador): IdentidadeRanking {
-  if (jogador.id === 'humano') return { chave: 'humano', nomeExibicao: jogador.nome };
-  return { chave: `bot:${slug(jogador.nome)}`, nomeExibicao: jogador.nome };
-}
-
-function slug(nome: string): string {
-  return nome
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '');
+  if (jogador.perfilId !== undefined) {
+    return { chave: `bot:${jogador.perfilId}`, nomeExibicao: jogador.nome };
+  }
+  if (jogador.id === 'humano') {
+    return { chave: 'humano', nomeExibicao: jogador.nome };
+  }
+  throw new Error(`Participante sem identidade de Ranking reconhecível: ${jogador.id}`);
 }

--- a/src/store/ranking/identidade.ts
+++ b/src/store/ranking/identidade.ts
@@ -5,9 +5,10 @@
  * ex.: `bras` → `bot:bras`), estável entre Partidas e independente tanto do
  * assento técnico (`bot1/bot2/bot3`) quanto do nome exibido.
  *
- * O contrato é explícito: ou o participante carrega `perfilId` (é um Perfil de
- * Bot), ou é o humano. Um participante sem identidade reconhecível não é
- * silenciosamente tratado como bot — é um erro.
+ * O contrato é explícito e o humano tem precedência: o jogador humano colapsa
+ * em `humano` mesmo que carregue um `perfilId` espúrio. Caso contrário, um
+ * Perfil de Bot precisa de um `perfilId` não-vazio. Um participante sem
+ * identidade reconhecível não é silenciosamente tratado como bot — é um erro.
  */
 
 import type { Jogador } from '@/types/entidades';
@@ -18,11 +19,11 @@ export interface IdentidadeRanking {
 }
 
 export function identidadeDe(jogador: Jogador): IdentidadeRanking {
-  if (jogador.perfilId !== undefined) {
-    return { chave: `bot:${jogador.perfilId}`, nomeExibicao: jogador.nome };
-  }
   if (jogador.id === 'humano') {
     return { chave: 'humano', nomeExibicao: jogador.nome };
+  }
+  if (jogador.perfilId) {
+    return { chave: `bot:${jogador.perfilId}`, nomeExibicao: jogador.nome };
   }
   throw new Error(`Participante sem identidade de Ranking reconhecível: ${jogador.id}`);
 }

--- a/src/types/entidades.ts
+++ b/src/types/entidades.ts
@@ -4,6 +4,11 @@ export interface Jogador {
   id: string;
   nome: string;
   pontos: number;
+  /**
+   * Identidade canônica do Perfil de Bot (estável entre Partidas, independente
+   * do assento técnico e do nome exibido). Ausente para o jogador humano.
+   */
+  perfilId?: string;
   temperatura?: number;
   avatar?: string;
 }

--- a/tests/adapters/perfil-bot.test.ts
+++ b/tests/adapters/perfil-bot.test.ts
@@ -3,6 +3,7 @@ import {
   aplicarPerfisBots,
   nomePorTemperatura,
   nomesBotsPorTemperatura,
+  perfisBotsPorTemperatura,
   sortearPerfisBots,
 } from '@/adapters/bots/perfil-bot';
 import { RngComSeed } from '@/core/RngComSeed';
@@ -28,6 +29,12 @@ describe('Nomes dos bots', () => {
   it('deve ter exatamente 20 nomes sem duplicatas', () => {
     expect(nomesBotsPorTemperatura).toHaveLength(20);
     expect(new Set(nomesBotsPorTemperatura).size).toBe(20);
+  });
+
+  it('deve ter perfilId canônico único por perfil (sem colisão de identidade)', () => {
+    const ids = perfisBotsPorTemperatura.map((perfil) => perfil.id);
+    expect(ids).toHaveLength(20);
+    expect(new Set(ids).size).toBe(20);
   });
 
   it('deve manter o nome estavel por faixa de temperatura', () => {
@@ -72,6 +79,17 @@ describe('Perfil dos bots', () => {
   });
 });
 
+describe('Perfil dos bots — identidade canônica', () => {
+  it('deve atribuir o perfilId canônico da faixa, desacoplado do nome exibido', () => {
+    for (const seed of SEEDS) {
+      const perfis = sortearPerfisBots(jogadores(), new RngComSeed(seed));
+      for (const perfil of perfis) {
+        expect(perfil.perfilId).toBe(perfisBotsPorTemperatura[faixaDe(perfil.temperatura)].id);
+      }
+    }
+  });
+});
+
 describe('Perfil dos bots — determinismo e distribuicao', () => {
   it('deve ser deterministico: mesma seed produz o mesmo resultado', () => {
     for (const seed of [0, 7, 158, 999]) {
@@ -89,18 +107,18 @@ describe('Perfil dos bots — determinismo e distribuicao', () => {
     expect(todasAltas).toBe(true);
   });
 
-  it('deve aplicar nome e temperatura apenas nos bots', () => {
+  it('deve aplicar perfilId, nome e temperatura apenas nos bots', () => {
     const perfis = [
-      { id: 'bot1', nome: 'Severino', temperatura: 0.05 },
-      { id: 'bot2', nome: 'Iara', temperatura: 0.1 },
-      { id: 'bot3', nome: 'Bento', temperatura: 0.15 },
+      { id: 'bot1', perfilId: 'severino', nome: 'Severino', temperatura: 0.05 },
+      { id: 'bot2', perfilId: 'iara', nome: 'Iara', temperatura: 0.1 },
+      { id: 'bot3', perfilId: 'bento', nome: 'Bento', temperatura: 0.15 },
     ];
 
     expect(aplicarPerfisBots(jogadores(), perfis)).toEqual([
       { id: 'humano', nome: 'Humano', pontos: 5 },
-      { id: 'bot1', nome: 'Severino', pontos: 5, temperatura: 0.05 },
-      { id: 'bot2', nome: 'Iara', pontos: 5, temperatura: 0.1 },
-      { id: 'bot3', nome: 'Bento', pontos: 5, temperatura: 0.15 },
+      { id: 'bot1', perfilId: 'severino', nome: 'Severino', pontos: 5, temperatura: 0.05 },
+      { id: 'bot2', perfilId: 'iara', nome: 'Iara', pontos: 5, temperatura: 0.1 },
+      { id: 'bot3', perfilId: 'bento', nome: 'Bento', pontos: 5, temperatura: 0.15 },
     ]);
   });
 });

--- a/tests/store/ranking-gravar.test.ts
+++ b/tests/store/ranking-gravar.test.ts
@@ -26,11 +26,11 @@ function armazenamentoQueLanca(metodo: 'getItem' | 'setItem'): Pick<Storage, 'ge
   return { getItem: () => null, setItem: () => undefined, [metodo]: falhar };
 }
 
-function jogador(id: string, nome: string): Jogador {
-  return { id, nome, pontos: 0 };
+function jogador(id: string, nome: string, perfilId?: string): Jogador {
+  return { id, nome, pontos: 0, perfilId };
 }
 
-const classificacao: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás')];
+const classificacao: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás', 'bras')];
 
 describe('registrarPartidaNoArmazenamento', () => {
   it('grava o snapshot da primeira partida na chave do Ranking', () => {

--- a/tests/store/ranking-identidade.test.ts
+++ b/tests/store/ranking-identidade.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { identidadeDe } from '@/store/ranking/identidade';
 import type { Jogador } from '@/types/entidades';
 
-function jogador(id: string, nome: string): Jogador {
-  return { id, nome, pontos: 0 };
+function jogador(id: string, nome: string, perfilId?: string): Jogador {
+  return { id, nome, pontos: 0, perfilId };
 }
 
 describe('identidadeDe', () => {
@@ -11,13 +11,25 @@ describe('identidadeDe', () => {
     expect(identidadeDe(jogador('humano', 'Você'))).toEqual({ chave: 'humano', nomeExibicao: 'Você' });
   });
 
-  it('deriva slug ASCII do nome do Perfil de Bot, removendo acentos', () => {
-    expect(identidadeDe(jogador('bot1', 'Brás'))).toEqual({ chave: 'bot:bras', nomeExibicao: 'Brás' });
-    expect(identidadeDe(jogador('bot2', 'Vitória'))).toEqual({ chave: 'bot:vitoria', nomeExibicao: 'Vitória' });
-    expect(identidadeDe(jogador('bot3', 'Luís'))).toEqual({ chave: 'bot:luis', nomeExibicao: 'Luís' });
+  it('ancora a chave do Perfil de Bot no perfilId canônico, não no nome exibido', () => {
+    expect(identidadeDe(jogador('bot1', 'Brás', 'bras'))).toEqual({ chave: 'bot:bras', nomeExibicao: 'Brás' });
+    expect(identidadeDe(jogador('bot2', 'Vitória', 'vitoria'))).toEqual({
+      chave: 'bot:vitoria',
+      nomeExibicao: 'Vitória',
+    });
   });
 
-  it('usa o nome do Perfil de Bot, não o assento técnico bot1/bot2/bot3', () => {
-    expect(identidadeDe(jogador('bot1', 'Iara')).chave).toBe('bot:iara');
+  it('mantém a chave estável quando o nome exibido muda (mesmo perfilId)', () => {
+    expect(identidadeDe(jogador('bot1', 'Brás', 'bras')).chave).toBe('bot:bras');
+    expect(identidadeDe(jogador('bot3', 'Brás Cubas', 'bras')).chave).toBe('bot:bras');
+  });
+
+  it('usa o perfilId, não o assento técnico bot1/bot2/bot3', () => {
+    expect(identidadeDe(jogador('bot1', 'Iara', 'iara')).chave).toBe('bot:iara');
+    expect(identidadeDe(jogador('bot3', 'Iara', 'iara')).chave).toBe('bot:iara');
+  });
+
+  it('não trata um participante não-humano sem perfilId como bot — lança erro explícito', () => {
+    expect(() => identidadeDe(jogador('observador', 'Fantasma'))).toThrow(/identidade de Ranking/);
   });
 });

--- a/tests/store/ranking-identidade.test.ts
+++ b/tests/store/ranking-identidade.test.ts
@@ -29,7 +29,15 @@ describe('identidadeDe', () => {
     expect(identidadeDe(jogador('bot3', 'Iara', 'iara')).chave).toBe('bot:iara');
   });
 
+  it('dá precedência ao humano mesmo que carregue um perfilId espúrio', () => {
+    expect(identidadeDe(jogador('humano', 'Você', 'bras'))).toEqual({ chave: 'humano', nomeExibicao: 'Você' });
+  });
+
   it('não trata um participante não-humano sem perfilId como bot — lança erro explícito', () => {
     expect(() => identidadeDe(jogador('observador', 'Fantasma'))).toThrow(/identidade de Ranking/);
+  });
+
+  it('rejeita perfilId vazio em vez de gerar a chave degenerada "bot:"', () => {
+    expect(() => identidadeDe(jogador('bot1', 'Sem perfil', ''))).toThrow(/identidade de Ranking/);
   });
 });

--- a/tests/store/ranking-registrar-partida.test.ts
+++ b/tests/store/ranking-registrar-partida.test.ts
@@ -3,8 +3,8 @@ import { registrarPartida } from '@/store/ranking/registrar-partida';
 import { SNAPSHOT_VAZIO, type ParticipantePersistido, type SnapshotRanking } from '@/store/ranking/tipos';
 import type { Jogador } from '@/types/entidades';
 
-function jogador(id: string, nome: string): Jogador {
-  return { id, nome, pontos: 0 };
+function jogador(id: string, nome: string, perfilId?: string): Jogador {
+  return { id, nome, pontos: 0, perfilId };
 }
 
 function part(nomeExibicao: string, somatorios: [number, number, number]): ParticipantePersistido {
@@ -12,7 +12,11 @@ function part(nomeExibicao: string, somatorios: [number, number, number]): Parti
   return { nomeExibicao, partidas, vitorias, somaPosicoes };
 }
 
-const classificacao: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás'), jogador('bot2', 'Iara')];
+const classificacao: Jogador[] = [
+  jogador('humano', 'Você'),
+  jogador('bot1', 'Brás', 'bras'),
+  jogador('bot2', 'Iara', 'iara'),
+];
 
 describe('registrarPartida', () => {
   it('registra somatórios brutos da primeira partida a partir do snapshot vazio', () => {


### PR DESCRIPTION
## Contexto

Closes #251. Surgido na revisão do #245 (PR #250): a identidade de persistência do Ranking era inferida de `bot:${slug(jogador.nome)}` — frágil a renomeação, colisão de slug e à premissa implícita "não-humano ⇒ bot".

## O que mudou

**Fonte canônica** (`src/adapters/bots/perfil-bot.ts`)
- `nomesBotsPorTemperatura` → `perfisBotsPorTemperatura`: lista de `{ id, nome }`, com `id` estável e curado à mão (`bras`, `severino`, …), desacoplado do texto exibido. `nomesBotsPorTemperatura` passa a ser derivado dela.
- `PerfilBot` ganhou `perfilId`; `sortearPerfisBots`/`aplicarPerfisBots` propagam a identidade (novo helper `perfilPorTemperatura`).

**Propagação** (`src/types/entidades.ts`)
- `Jogador` ganhou `perfilId?`, levando a identidade canônica até a boundary de gravação **sem inverter a dependência** (store lê de `types/`, nunca importa de `adapters/`).

**Identidade do Ranking** (`src/store/ranking/identidade.ts`)
- Chave passa a ser `bot:${jogador.perfilId}`; `slug()` do nome removido.
- Contrato explícito: `perfilId` presente ⇒ Perfil de Bot; `id === 'humano'` ⇒ humano; qualquer outro participante **lança erro** em vez de virar `bot:` silenciosamente (absorvido pelo try/catch de `gravar-ranking`, sem interromper o fim de jogo).

## Acceptance criteria

- [x] A chave não depende do texto de exibição (renomear não fragmenta o histórico).
- [x] Sem risco de colisão de identidade entre perfis distintos.
- [x] A montagem da identidade não assume "não-humano ⇒ bot".
- [x] Direção da Clean Architecture respeitada (store não importa de `adapters/`).
- [x] Coberto por testes Vitest no store.

## Notas

Os `id`s canônicos foram escolhidos iguais aos slugs antigos, então **rankings já persistidos continuam compatíveis**.

Lint, typecheck e os 803 testes passam localmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bots now have stable, canonical profile identities that remain consistent across matches and are independent of display names.

* **Bug Fixes**
  * Improved bot identity tracking to eliminate inconsistencies previously caused by name-based derivations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->