### PR TITLE
feat(ui): cartas com tamanho mínimo maior em telas grandes

### DIFF
--- a/src/adapters/phaser/escala.ts
+++ b/src/adapters/phaser/escala.ts
@@ -1,11 +1,40 @@
 import type { Scene } from 'phaser';
 
+/**
+ * Abaixo desta menor dimensão (px CSS) a UI mantém o tamanho atual (fator 1).
+ * Telas com menor dimensão maior que isso ampliam a UI proporcionalmente.
+ */
+const REFERENCIA_TELA = 480;
+/** Teto da ampliação para não exagerar em monitores muito grandes. */
+const FATOR_MAXIMO = 2;
+
 export function obterDpr(cena: Scene): number {
   return 1 / cena.game.scale.zoom;
 }
 
+/**
+ * Fator de ampliação da UI conforme o tamanho da tela.
+ * Usa a menor dimensão (px CSS) para garantir que o layout continue cabendo:
+ * vale 1 em telas pequenas (celulares) e cresce até {@link FATOR_MAXIMO}.
+ */
+export function fatorTela(cena: Scene): number {
+  const zoom = cena.game.scale.zoom;
+  const larguraCss = cena.scale.width * zoom;
+  const alturaCss = cena.scale.height * zoom;
+  const menorDimensao = Math.min(larguraCss, alturaCss);
+  if (!Number.isFinite(menorDimensao) || menorDimensao <= 0) {
+    return 1;
+  }
+  return Math.min(FATOR_MAXIMO, Math.max(1, menorDimensao / REFERENCIA_TELA));
+}
+
+/** Fator total que converte unidades lógicas em pixels físicos do canvas. */
+export function fatorEscala(cena: Scene): number {
+  return obterDpr(cena) * fatorTela(cena);
+}
+
 export function escalar(valor: number, cena: Scene): number {
-  return Math.round(valor * obterDpr(cena));
+  return Math.round(valor * fatorEscala(cena));
 }
 
 export function escalarFonte(tamanhoPx: number, cena: Scene): string {

--- a/src/adapters/phaser/renderers/posicoes-mao.ts
+++ b/src/adapters/phaser/renderers/posicoes-mao.ts
@@ -15,7 +15,8 @@ export interface ConfigPosicoes {
   espacamentoVertical: number;
   alturaCarta: number;
   quantidadesCartas: number[];
-  dpr: number;
+  /** Fator que converte unidades lógicas em pixels (DPR × ampliação por tela). */
+  fatorEscala: number;
 }
 
 interface MedidasTela {
@@ -29,8 +30,8 @@ export function calcularPosicoes(config: ConfigPosicoes): PosicaoTela[] {
   const { x: ox, y: oy, largura, altura } = config.gameArea;
   const cx = ox + Math.round(largura / 2);
   const cy = oy + Math.round(altura / 2);
-  const offsetBase = Math.round(10 * config.dpr);
-  const offsetLateral = Math.round(60 * config.dpr);
+  const offsetBase = Math.round(10 * config.fatorEscala);
+  const offsetLateral = Math.round(60 * config.fatorEscala);
   const dl = config.alturaCarta / 2 + offsetBase;
   const vertical = config.espacamentoVertical;
   return [

--- a/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
+++ b/src/adapters/phaser/scenes/desenhar-maos-jogo.ts
@@ -2,7 +2,7 @@ import type { Scene } from 'phaser';
 import type { Rodada } from '@/core/Rodada';
 import type { MaoJogador } from '@/types/estado-rodada';
 import type { DecisorHumano } from '../DecisorHumano';
-import { obterDpr, escalar } from '../escala';
+import { fatorEscala, escalar } from '../escala';
 import { criarFundoInterativo } from '../input/input-humano';
 import type { Retangulo } from '../layout';
 import type { EstadoDestaque } from '../renderers/destaque-renderer';
@@ -63,6 +63,6 @@ function calcularPosicoesMaos(
     espacamentoVertical: escalar(6, cena),
     alturaCarta: escalar(75, cena),
     quantidadesCartas,
-    dpr: obterDpr(cena),
+    fatorEscala: fatorEscala(cena),
   });
 }


### PR DESCRIPTION
## Problema

Em telas grandes (monitores/TVs) as cartas apareciam pequenas demais. Todo o render passa por `escalar()`, que antes só multiplicava pelo DPR — uma carta tinha sempre ~50px CSS independentemente do tamanho da tela.

## Solução

Introduz um **fator de ampliação por tela** em `src/adapters/phaser/escala.ts`:

- `fatorTela(cena)` usa a **menor dimensão da viewport (px CSS)**: vale **1** abaixo de `REFERENCIA_TELA` (480px → celulares, comportamento idêntico ao atual) e cresce proporcionalmente até `FATOR_MAXIMO` (**2.0**).
- `escalar()` passa a multiplicar por `DPR × fatorTela`, então **toda a UI** (cartas, fontes, espaçamentos, painéis) amplia junta mantendo as proporções do celular.
- Usar a menor dimensão garante que o layout continue cabendo: como já cabe na referência, ampliar pela menor dimensão nunca estoura a tela.

Os offsets das mãos (`posicoes-mao.ts` / `desenhar-maos-jogo.ts`) passam a usar o fator completo (campo renomeado `dpr` → `fatorEscala`).

## Validação (Chrome DevTools MCP)

| Tela (CSS) | Menor dim. | Fator | Resultado |
|---|---|---|---|
| 333×562 (celular) | 333 | **1.0** | idêntico ao atual |
| 1280×719 | 719 | **1.5** | cartas ~1.5× maiores |
| 1733×1333 | 1333 | **2.0** (teto) | cartas 2×, sem overflow |

Suíte de testes 100% verde (812 testes), typecheck e lint limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the UI scaling system to combine device specifications with screen size factors, improving visual consistency and adaptive sizing across different screen sizes and device types
  * Updated hand position layout calculations to leverage the improved scaling mechanism for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->