### PR TITLE
feat(trofeus): Sequência de Vitórias do humano persistente (#260)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,6 +120,18 @@ _Avoid_: Vitória de rodada, vaza vencida, turno ganho
 Ordem final dos participantes ao encerrar uma **Partida**, definida por sobrevivência: vencedor primeiro, depois **Jogadores eliminados** do mais recente para o mais antigo. Entre jogadores eliminados no mesmo fechamento de **Rodada**, vence quem ficou com mais **Pontos**; em empate de **Pontos**, o jogador humano fica acima dos **Perfis de Bot**.
 _Avoid_: Tabela final, ranking visual, placar final
 
+**Sequência de Vitórias**:
+Quantidade de **Vitórias de Partida** consecutivas do jogador humano. Incrementa a cada **Partida** concluída em que o humano termina como vencedor e zera quando ele encerra uma **Partida** em qualquer outra posição. Abandonar uma **Partida** sem concluí-la não afeta a sequência. Exclusiva do jogador humano.
+_Avoid_: Winstreak, streak, combo
+
+**Troféu**:
+Marco persistente conquistado pelo jogador humano ao atingir um comprimento de **Sequência de Vitórias**. Uma vez conquistado, nunca é perdido, mesmo quando a **Sequência de Vitórias** zera. São sete níveis ordenados — Bronze (3), Prata (5), Ouro (10), Esmeralda (15), Safira (25), Rubi (50), Diamante (100) — e cada nível é conquistado uma única vez. Exclusivo do jogador humano.
+_Avoid_: Milestone, conquista, achievement, medalha
+
+**Maior Troféu**:
+**Troféu** de nível mais alto já conquistado pelo jogador humano. Resume toda a coleção, já que os níveis são ordenados: possuir um nível implica possuir todos os anteriores.
+_Avoid_: Melhor sequência, recorde
+
 ## Relationships
 
 - Uma **Partida** contém uma ou mais **Rodadas**.
@@ -142,6 +154,10 @@ _Avoid_: Tabela final, ranking visual, placar final
 - O win rate no **Ranking** é calculado por **Vitórias de Partida** divididas pelas **Partidas** computadas em que o participante apareceu.
 - A **Classificação da Partida** define a **Vitória de Partida** e a posição registrada no **Ranking**.
 - O **Ranking** registra apenas **Partidas** concluídas e exibe **Perfis de Bot** somente depois que aparecem em pelo menos uma **Partida** computada.
+- Uma **Vitória de Partida** do jogador humano incrementa a **Sequência de Vitórias**; qualquer outra **Classificação da Partida** dele a zera.
+- Atingir um comprimento de marco na **Sequência de Vitórias** conquista o **Troféu** correspondente, atualizando o **Maior Troféu**.
+- Um **Troféu** de nível já contido no **Maior Troféu** não é reconquistado: o próximo desbloqueio só ocorre no nível acima do **Maior Troféu**.
+- A **Sequência de Vitórias** e o **Maior Troféu** são atualizados no mesmo encerramento de **Partida** que alimenta o **Ranking**, mas pertencem só ao jogador humano.
 
 ## Example dialogue
 
@@ -154,3 +170,4 @@ _Avoid_: Tabela final, ranking visual, placar final
 - `G[N-X]` e `P[N-X]` são aliases técnicos; na linguagem de produto use **Escolha de vencedora por necessidade** e **Descarte por necessidade**.
 - `bot1`, `bot2` e `bot3` são assentos técnicos temporários; na linguagem de produto e no **Ranking**, use o **Perfil de Bot**.
 - `vitória` no contexto do **Ranking** significa **Vitória de Partida**, não turno feito nem rodada sobrevivida.
+- `winstreak`/`streak` é a **Sequência de Vitórias**; `milestone`/`conquista` é um **Troféu**. Ambos são exclusivos do jogador humano, ao contrário do **Ranking**, que agrega humano e **Perfis de Bot**.

--- a/docs/adr/0003-abandono-nao-zera-sequencia-de-vitorias.md
+++ b/docs/adr/0003-abandono-nao-zera-sequencia-de-vitorias.md
@@ -1,0 +1,11 @@
+# Abandono não zera a Sequência de Vitórias
+
+A Sequência de Vitórias do jogador humano é atualizada exclusivamente no encerramento de uma Partida concluída (`JOGO_ENCERRADO`), o mesmo gatilho que alimenta o Ranking: vencer incrementa, qualquer outra Classificação da Partida zera. Abandonar uma Partida no meio — fechar a aba ou voltar ao menu sem concluí-la — não conta como derrota nem zera a sequência, espelhando a regra do Ranking de só registrar Partidas concluídas.
+
+## Considered Options
+
+Avaliamos tratar o abandono como derrota (zerar a sequência ao detectar saída no meio da Partida). Isso exigiria observar a saída do navegador/cena e introduziria um segundo ponto de escrita, além de criar a categoria ambígua de "Partida abandonada" que hoje não existe em nenhum lugar do domínio.
+
+## Consequences
+
+Permite "save-scumming": o jogador que percebe a derrota iminente pode fechar a aba para preservar a sequência. Aceitamos isso conscientemente — o FDP é um jogo casual e a Sequência de Vitórias é uma recompensa de engajamento, não um placar competitivo a ser defendido contra trapaça. Em troca, a escrita fica num único ponto, coerente com o Ranking, sem detecção de saída.

--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -1,4 +1,5 @@
 import type { Scene } from 'phaser';
+import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
 import { escalar, escalarFonte } from '../escala';
 import { limparObjetos } from './limpar-objetos';
@@ -6,6 +7,7 @@ import { limparObjetos } from './limpar-objetos';
 interface ConfigFimJogo {
   cena: Scene;
   classificacao: Jogador[];
+  resultadoTrofeus: ResultadoTrofeus | null;
   objetos: Phaser.GameObjects.GameObject[];
   onReiniciar: () => void;
 }
@@ -19,10 +21,35 @@ export function desenharFimJogo(config: ConfigFimJogo): void {
   limparObjetos(config.objetos);
   desenharFundo(config);
   desenharTitulo(config.cena, config.objetos);
+  desenharSequencia(config);
   config.classificacao.forEach((jogador, indice) => {
     desenharLinha({ cena: config.cena, objetos: config.objetos, jogador, indice });
   });
   desenharBotao(config);
+}
+
+/**
+ * Ao vencer, exibe a Sequência de Vitórias atual. Ao perder, ou quando o
+ * resultado é neutro (falha de Storage), não exibe nada sobre sequência.
+ */
+function desenharSequencia(config: ConfigFimJogo): void {
+  if (config.resultadoTrofeus === null || config.classificacao[0]?.id !== 'humano') return;
+  const { cena, objetos } = config;
+  const sequencia = cena.add
+    .text(
+      cena.cameras.main.centerX,
+      cena.cameras.main.height * 0.245,
+      `Sequência de Vitórias: ${String(config.resultadoTrofeus.sequenciaAtual)}`,
+      {
+        fontSize: escalarFonte(18, cena),
+        fontStyle: 'bold',
+        color: '#facc15',
+        fontFamily: 'Arial',
+      },
+    )
+    .setOrigin(0.5)
+    .setDepth(102);
+  objetos.push(sequencia);
 }
 
 function desenharFundo(config: ConfigFimJogo): void {

--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -29,11 +29,12 @@ export function desenharFimJogo(config: ConfigFimJogo): void {
 }
 
 /**
- * Ao vencer, exibe a Sequência de Vitórias atual. Ao perder, ou quando o
- * resultado é neutro (falha de Storage), não exibe nada sobre sequência.
+ * Exibe a Sequência de Vitórias quando há resultado a mostrar. A boundary de
+ * troféus já decide isso: o resultado só existe na vitória, e é `null` na
+ * derrota ou em falha de Storage — aqui não reinspecionamos a Classificação.
  */
 function desenharSequencia(config: ConfigFimJogo): void {
-  if (config.resultadoTrofeus === null || config.classificacao[0]?.id !== 'humano') return;
+  if (config.resultadoTrofeus === null) return;
   const { cena, objetos } = config;
   const sequencia = cena.add
     .text(

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -61,8 +61,8 @@ export class JogoScene extends Scene {
       mostrarResumoRodada: (resumoRodada, onContinuar) => {
         this.exibirResumoRodada(resumoRodada, onContinuar);
       },
-      mostrarFimJogo: (classificacao) => {
-        mostrarFimJogoDaCena(this, classificacao);
+      mostrarFimJogo: (classificacao, resultadoTrofeus) => {
+        mostrarFimJogoDaCena(this, classificacao, resultadoTrofeus);
       },
       desativarResize: () => {
         desativarResize(this, this.redesenhar);

--- a/src/adapters/phaser/scenes/fim-jogo-scene.ts
+++ b/src/adapters/phaser/scenes/fim-jogo-scene.ts
@@ -1,4 +1,5 @@
 import type { Scene } from 'phaser';
+import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
 import { destruirDestaque, type EstadoDestaque } from '../renderers/destaque-renderer';
 import { desenharFimJogo } from '../renderers/fim-jogo-renderer';
@@ -8,6 +9,7 @@ import type { JogoScene } from './JogoScene';
 interface ConfigFimJogoScene {
   cena: Scene;
   classificacao: Jogador[];
+  resultadoTrofeus: ResultadoTrofeus | null;
   fimJogoObjetos: Phaser.GameObjects.GameObject[];
   objetos: Phaser.GameObjects.GameObject[];
   mesaObjetos: Phaser.GameObjects.GameObject[];
@@ -22,15 +24,21 @@ export function mostrarFimJogo(config: ConfigFimJogoScene): void {
   desenharFimJogo({
     cena: config.cena,
     classificacao: config.classificacao,
+    resultadoTrofeus: config.resultadoTrofeus,
     objetos: config.fimJogoObjetos,
     onReiniciar: config.onReiniciar,
   });
 }
 
-export function mostrarFimJogoDaCena(cena: JogoScene, classificacao: Jogador[]): void {
+export function mostrarFimJogoDaCena(
+  cena: JogoScene,
+  classificacao: Jogador[],
+  resultadoTrofeus: ResultadoTrofeus | null,
+): void {
   mostrarFimJogo({
     cena,
     classificacao,
+    resultadoTrofeus,
     fimJogoObjetos: cena.fimJogoObjetos,
     objetos: cena.objetos,
     mesaObjetos: cena.mesaObjetos,

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -1,6 +1,8 @@
 import type { Scene } from 'phaser';
 import type { Partida } from '@/core/Partida';
 import { registrarPartidaNoArmazenamento } from '@/store/ranking/gravar-ranking';
+import { registrarTrofeusNoArmazenamento } from '@/store/trofeus/gravar-trofeus';
+import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
 import { ehFaseDeclaracao, estadoEmJogo } from '@/types/estado-rodada';
 import { DecisorDeclaracaoHumano } from '../DecisorDeclaracaoHumano';
@@ -29,7 +31,7 @@ export interface DependenciasCena {
   atualizarPainel: () => void;
   animarRecolhimentoTurno: () => void;
   mostrarResumoRodada: (resumoRodada: PontuacaoRodada, onContinuar: () => void) => void;
-  mostrarFimJogo: (classificacao: Jogador[]) => void;
+  mostrarFimJogo: (classificacao: Jogador[], resultadoTrofeus: ResultadoTrofeus | null) => void;
   desativarResize: () => void;
   getGameArea: () => Retangulo;
   objetosDeclaracao: Phaser.GameObjects.GameObject[];
@@ -88,8 +90,9 @@ export class JogoController {
       },
       onJogoEncerrado: (classificacao: Jogador[]) => {
         registrarPartidaNoArmazenamento(() => window.localStorage, classificacao);
+        const resultadoTrofeus = registrarTrofeusNoArmazenamento(() => window.localStorage, classificacao);
         this.deps.desativarResize();
-        this.deps.mostrarFimJogo(classificacao);
+        this.deps.mostrarFimJogo(classificacao, resultadoTrofeus);
       },
       modoDebug: this.deps.modoDebug,
     };

--- a/src/store/trofeus/carregar-trofeus.ts
+++ b/src/store/trofeus/carregar-trofeus.ts
@@ -1,0 +1,35 @@
+/**
+ * Boundary de leitura da Sequência de Vitórias persistida (`fdp.trofeus.v1`).
+ *
+ * Espelha `carregar-ranking.ts`: a leitura é estrita — qualquer conteúdo que
+ * não seja um snapshot `versao: 1` íntegro vira o estado zero, para nunca
+ * entregar dado corrompido como confiável. Invariante: `sequenciaAtual` é um
+ * inteiro ≥ 0 e, nesta slice, `maiorTrofeu` é sempre `null`.
+ */
+
+import { CHAVE_TROFEUS, SNAPSHOT_ZERO } from './tipos';
+import type { SnapshotTrofeus } from './tipos';
+
+export { CHAVE_TROFEUS } from './tipos';
+
+/** Lê o snapshot bruto; qualquer conteúdo inválido vira o estado zero. */
+export function lerSnapshot(armazenamento: Pick<Storage, 'getItem'>): SnapshotTrofeus {
+  const bruto = armazenamento.getItem(CHAVE_TROFEUS);
+  if (bruto === null) return SNAPSHOT_ZERO;
+  try {
+    return validar(JSON.parse(bruto));
+  } catch {
+    return SNAPSHOT_ZERO;
+  }
+}
+
+function validar(conteudo: unknown): SnapshotTrofeus {
+  if (typeof conteudo !== 'object' || conteudo === null) return SNAPSHOT_ZERO;
+  const { versao, sequenciaAtual, maiorTrofeu } = conteudo as Record<string, unknown>;
+  if (versao !== 1 || maiorTrofeu !== null || !ehContagem(sequenciaAtual)) return SNAPSHOT_ZERO;
+  return { versao: 1, sequenciaAtual, maiorTrofeu: null };
+}
+
+function ehContagem(valor: unknown): valor is number {
+  return typeof valor === 'number' && Number.isInteger(valor) && valor >= 0;
+}

--- a/src/store/trofeus/gravar-trofeus.ts
+++ b/src/store/trofeus/gravar-trofeus.ts
@@ -1,0 +1,44 @@
+/**
+ * Boundary de escrita da Sequência de Vitórias. Disparada no `onJogoEncerrado`
+ * (`jogo-controller.ts`), junto do registro do Ranking, mas como boundary
+ * independente em chave separada (`fdp.trofeus.v1`).
+ *
+ * Lê o snapshot atual (corrompido → estado zero), deriva se o humano venceu da
+ * Classificação da Partida (índice 0 = vencedor), aplica a transição, persiste
+ * e **retorna** o resultado para a tela de fim de jogo.
+ *
+ * A feature é um side effect secundário: qualquer falha de `Storage` é absorvida
+ * — incluindo o próprio getter `window.localStorage`, que pode lançar
+ * `SecurityError` — para nunca interromper o encerramento da Partida. Em falha,
+ * retorna resultado neutro (`null`): a sequência simplesmente não é exibida.
+ */
+
+import type { Jogador } from '@/types/entidades';
+import { lerSnapshot } from './carregar-trofeus';
+import { CHAVE_TROFEUS, type ResultadoTrofeus } from './tipos';
+import { aplicarTransicao } from './transicao-trofeus';
+
+type ProvedorArmazenamento = () => Pick<Storage, 'getItem' | 'setItem'>;
+
+export function registrarTrofeusNoArmazenamento(
+  obterArmazenamento: ProvedorArmazenamento,
+  classificacao: Jogador[],
+): ResultadoTrofeus | null {
+  try {
+    const armazenamento = obterArmazenamento();
+    const { snapshot, resultado } = aplicarTransicao(lerSnapshot(armazenamento), humanoVenceu(classificacao));
+    armazenamento.setItem(CHAVE_TROFEUS, JSON.stringify(snapshot));
+    return resultado;
+  } catch (erro) {
+    // eslint-disable-next-line no-console -- sinaliza a falha sem interromper o encerramento da Partida
+    console.warn(
+      'Não foi possível persistir a Sequência de Vitórias; encerramento da Partida segue normalmente.',
+      erro,
+    );
+    return null;
+  }
+}
+
+function humanoVenceu(classificacao: Jogador[]): boolean {
+  return classificacao[0]?.id === 'humano';
+}

--- a/src/store/trofeus/gravar-trofeus.ts
+++ b/src/store/trofeus/gravar-trofeus.ts
@@ -4,13 +4,16 @@
  * independente em chave separada (`fdp.trofeus.v1`).
  *
  * Lê o snapshot atual (corrompido → estado zero), deriva se o humano venceu da
- * Classificação da Partida (índice 0 = vencedor), aplica a transição, persiste
- * e **retorna** o resultado para a tela de fim de jogo.
+ * Classificação da Partida (índice 0 = vencedor) — único ponto que consulta a
+ * Classificação para decidir vitória —, aplica a transição, persiste e
+ * **retorna** o que a tela de fim de jogo deve exibir.
  *
- * A feature é um side effect secundário: qualquer falha de `Storage` é absorvida
- * — incluindo o próprio getter `window.localStorage`, que pode lançar
- * `SecurityError` — para nunca interromper o encerramento da Partida. Em falha,
- * retorna resultado neutro (`null`): a sequência simplesmente não é exibida.
+ * O resultado já encapsula "há algo a exibir": é `null` tanto na derrota quanto
+ * em falha de `Storage`, então o renderer só consome o resultado e nunca
+ * reinspeciona a Classificação. A feature é um side effect secundário: qualquer
+ * falha de `Storage` é absorvida — incluindo o próprio getter
+ * `window.localStorage`, que pode lançar `SecurityError` — para nunca
+ * interromper o encerramento da Partida.
  */
 
 import type { Jogador } from '@/types/entidades';

--- a/src/store/trofeus/tipos.ts
+++ b/src/store/trofeus/tipos.ts
@@ -17,9 +17,10 @@ export interface SnapshotTrofeus {
 export const SNAPSHOT_ZERO: SnapshotTrofeus = { versao: 1, sequenciaAtual: 0, maiorTrofeu: null };
 
 /**
- * O que a tela de fim de jogo precisa saber sobre a sequência após o
- * encerramento. `null` é o resultado neutro (falha de Storage): a sequência
- * não é exibida.
+ * O que a tela de fim de jogo exibe sobre a sequência após o encerramento. Sua
+ * presença já significa "há algo a exibir": só existe quando o humano venceu. O
+ * resultado neutro — derrota ou falha de Storage — é representado por `null`, e
+ * o renderer nunca precisa reinspecionar a Classificação da Partida.
  */
 export interface ResultadoTrofeus {
   sequenciaAtual: number;

--- a/src/store/trofeus/tipos.ts
+++ b/src/store/trofeus/tipos.ts
@@ -1,0 +1,26 @@
+/**
+ * Contrato persistido da Sequência de Vitórias e Troféus (chave
+ * `fdp.trofeus.v1`), separado do Ranking. Feature exclusiva do jogador humano.
+ *
+ * Nesta entrega guardamos só a `sequenciaAtual`; `maiorTrofeu` já existe na
+ * forma mas é sempre `null` — os níveis de Troféu entram na próxima slice.
+ */
+
+export const CHAVE_TROFEUS = 'fdp.trofeus.v1';
+
+export interface SnapshotTrofeus {
+  versao: 1;
+  sequenciaAtual: number;
+  maiorTrofeu: null;
+}
+
+export const SNAPSHOT_ZERO: SnapshotTrofeus = { versao: 1, sequenciaAtual: 0, maiorTrofeu: null };
+
+/**
+ * O que a tela de fim de jogo precisa saber sobre a sequência após o
+ * encerramento. `null` é o resultado neutro (falha de Storage): a sequência
+ * não é exibida.
+ */
+export interface ResultadoTrofeus {
+  sequenciaAtual: number;
+}

--- a/src/store/trofeus/transicao-trofeus.ts
+++ b/src/store/trofeus/transicao-trofeus.ts
@@ -1,0 +1,20 @@
+/**
+ * Transição pura da Sequência de Vitórias ao encerrar uma Partida.
+ *
+ * Recebe o snapshot atual e se o humano venceu; devolve o snapshot atualizado e
+ * o resultado para a tela de fim de jogo. Venceu → sequência + 1; não venceu →
+ * zera. Nunca muta a entrada. `maiorTrofeu` permanece nulo nesta slice.
+ */
+
+import type { ResultadoTrofeus, SnapshotTrofeus } from './tipos';
+
+export function aplicarTransicao(
+  snapshot: SnapshotTrofeus,
+  venceu: boolean,
+): { snapshot: SnapshotTrofeus; resultado: ResultadoTrofeus } {
+  const sequenciaAtual = venceu ? snapshot.sequenciaAtual + 1 : 0;
+  return {
+    snapshot: { versao: 1, sequenciaAtual, maiorTrofeu: null },
+    resultado: { sequenciaAtual },
+  };
+}

--- a/src/store/trofeus/transicao-trofeus.ts
+++ b/src/store/trofeus/transicao-trofeus.ts
@@ -2,8 +2,10 @@
  * Transição pura da Sequência de Vitórias ao encerrar uma Partida.
  *
  * Recebe o snapshot atual e se o humano venceu; devolve o snapshot atualizado e
- * o resultado para a tela de fim de jogo. Venceu → sequência + 1; não venceu →
- * zera. Nunca muta a entrada. `maiorTrofeu` permanece nulo nesta slice.
+ * o resultado para a tela de fim de jogo. Venceu → sequência + 1 e resultado a
+ * exibir; não venceu → zera a sequência persistida e resultado `null` (nada a
+ * exibir, a derrota não mostra sequência). Nunca muta a entrada. `maiorTrofeu`
+ * permanece nulo nesta slice.
  */
 
 import type { ResultadoTrofeus, SnapshotTrofeus } from './tipos';
@@ -11,10 +13,10 @@ import type { ResultadoTrofeus, SnapshotTrofeus } from './tipos';
 export function aplicarTransicao(
   snapshot: SnapshotTrofeus,
   venceu: boolean,
-): { snapshot: SnapshotTrofeus; resultado: ResultadoTrofeus } {
+): { snapshot: SnapshotTrofeus; resultado: ResultadoTrofeus | null } {
   const sequenciaAtual = venceu ? snapshot.sequenciaAtual + 1 : 0;
   return {
     snapshot: { versao: 1, sequenciaAtual, maiorTrofeu: null },
-    resultado: { sequenciaAtual },
+    resultado: venceu ? { sequenciaAtual } : null,
   };
 }

--- a/tests/store/carregar-trofeus.test.ts
+++ b/tests/store/carregar-trofeus.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { CHAVE_TROFEUS, lerSnapshot } from '@/store/trofeus/carregar-trofeus';
+import { SNAPSHOT_ZERO } from '@/store/trofeus/tipos';
+
+function armazenamentoCom(valor: string | null): Pick<Storage, 'getItem'> {
+  return { getItem: (chave) => (chave === CHAVE_TROFEUS ? valor : null) };
+}
+
+function bruto(corpo: unknown): string {
+  return JSON.stringify(corpo);
+}
+
+describe('lerSnapshot de troféus trata conteúdo ausente ou malformado como estado zero', () => {
+  it('quando a chave está ausente', () => {
+    expect(lerSnapshot(armazenamentoCom(null))).toEqual(SNAPSHOT_ZERO);
+  });
+
+  it('quando o conteúdo é um JSON inválido', () => {
+    expect(lerSnapshot(armazenamentoCom('{ não é json'))).toEqual(SNAPSHOT_ZERO);
+  });
+
+  it('quando o conteúdo não é um objeto', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto(42)))).toEqual(SNAPSHOT_ZERO);
+  });
+
+  it('quando a versão não é 1', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 2, sequenciaAtual: 3, maiorTrofeu: null })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+});
+
+describe('lerSnapshot de troféus trata invariantes violadas como estado zero', () => {
+  it('quando a sequência não é numérica', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: '3', maiorTrofeu: null })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+
+  it('quando a sequência é negativa (invariante violada)', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: -1, maiorTrofeu: null })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+
+  it('quando a sequência é fracionária', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 2.5, maiorTrofeu: null })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+
+  it('quando maiorTrofeu não é nulo (fora da forma desta slice)', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 3, maiorTrofeu: 'ouro' })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+});
+
+describe('lerSnapshot de troféus', () => {
+  it('lê um snapshot válido tal como persistido', () => {
+    const valido = { versao: 1, sequenciaAtual: 4, maiorTrofeu: null };
+
+    expect(lerSnapshot(armazenamentoCom(bruto(valido)))).toEqual(valido);
+  });
+
+  it('aceita a sequência zerada como válida', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 0, maiorTrofeu: null })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+});

--- a/tests/store/transicao-trofeus.test.ts
+++ b/tests/store/transicao-trofeus.test.ts
@@ -11,23 +11,23 @@ describe('aplicarTransicao quando o humano venceu', () => {
     const { snapshot, resultado } = aplicarTransicao(SNAPSHOT_ZERO, true);
 
     expect(snapshot.sequenciaAtual).toBe(1);
-    expect(resultado.sequenciaAtual).toBe(1);
+    expect(resultado).toEqual({ sequenciaAtual: 1 });
   });
 
   it('incrementa a sequência já existente', () => {
     const { snapshot, resultado } = aplicarTransicao(comSequencia(4), true);
 
     expect(snapshot.sequenciaAtual).toBe(5);
-    expect(resultado.sequenciaAtual).toBe(5);
+    expect(resultado).toEqual({ sequenciaAtual: 5 });
   });
 });
 
 describe('aplicarTransicao quando o humano não venceu', () => {
-  it('zera a sequência', () => {
+  it('zera a sequência persistida mas não devolve nada a exibir', () => {
     const { snapshot, resultado } = aplicarTransicao(comSequencia(7), false);
 
     expect(snapshot.sequenciaAtual).toBe(0);
-    expect(resultado.sequenciaAtual).toBe(0);
+    expect(resultado).toBeNull();
   });
 
   it('mantém a sequência zerada ao perder partindo do zero', () => {

--- a/tests/store/transicao-trofeus.test.ts
+++ b/tests/store/transicao-trofeus.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { SNAPSHOT_ZERO, type SnapshotTrofeus } from '@/store/trofeus/tipos';
+import { aplicarTransicao } from '@/store/trofeus/transicao-trofeus';
+
+function comSequencia(sequenciaAtual: number): SnapshotTrofeus {
+  return { versao: 1, sequenciaAtual, maiorTrofeu: null };
+}
+
+describe('aplicarTransicao quando o humano venceu', () => {
+  it('incrementa a sequência em 1 a partir do zero', () => {
+    const { snapshot, resultado } = aplicarTransicao(SNAPSHOT_ZERO, true);
+
+    expect(snapshot.sequenciaAtual).toBe(1);
+    expect(resultado.sequenciaAtual).toBe(1);
+  });
+
+  it('incrementa a sequência já existente', () => {
+    const { snapshot, resultado } = aplicarTransicao(comSequencia(4), true);
+
+    expect(snapshot.sequenciaAtual).toBe(5);
+    expect(resultado.sequenciaAtual).toBe(5);
+  });
+});
+
+describe('aplicarTransicao quando o humano não venceu', () => {
+  it('zera a sequência', () => {
+    const { snapshot, resultado } = aplicarTransicao(comSequencia(7), false);
+
+    expect(snapshot.sequenciaAtual).toBe(0);
+    expect(resultado.sequenciaAtual).toBe(0);
+  });
+
+  it('mantém a sequência zerada ao perder partindo do zero', () => {
+    const { snapshot } = aplicarTransicao(SNAPSHOT_ZERO, false);
+
+    expect(snapshot.sequenciaAtual).toBe(0);
+  });
+});
+
+describe('aplicarTransicao preserva o contrato persistido', () => {
+  it('mantém versão 1 e maiorTrofeu nulo (slice atual)', () => {
+    const { snapshot } = aplicarTransicao(comSequencia(2), true);
+
+    expect(snapshot.versao).toBe(1);
+    expect(snapshot.maiorTrofeu).toBeNull();
+  });
+
+  it('não muta o snapshot recebido', () => {
+    const original = comSequencia(3);
+
+    aplicarTransicao(original, true);
+
+    expect(original.sequenciaAtual).toBe(3);
+  });
+});

--- a/tests/store/trofeus-gravar.test.ts
+++ b/tests/store/trofeus-gravar.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { registrarTrofeusNoArmazenamento } from '@/store/trofeus/gravar-trofeus';
+import { CHAVE_TROFEUS, type SnapshotTrofeus } from '@/store/trofeus/tipos';
+import type { Jogador } from '@/types/entidades';
+
+function armazenamentoFake(inicial?: string): Pick<Storage, 'getItem' | 'setItem'> & { dados: Map<string, string> } {
+  const dados = new Map<string, string>();
+  if (inicial !== undefined) dados.set(CHAVE_TROFEUS, inicial);
+  return {
+    dados,
+    getItem: (chave) => dados.get(chave) ?? null,
+    setItem: (chave, valor) => {
+      dados.set(chave, valor);
+    },
+  };
+}
+
+function snapshotGravado(armazenamento: { dados: Map<string, string> }): SnapshotTrofeus {
+  return JSON.parse(armazenamento.dados.get(CHAVE_TROFEUS) ?? '') as SnapshotTrofeus;
+}
+
+function armazenamentoQueLanca(metodo: 'getItem' | 'setItem'): Pick<Storage, 'getItem' | 'setItem'> {
+  const falhar = (): never => {
+    throw new DOMException('storage indisponível', 'SecurityError');
+  };
+  return { getItem: () => null, setItem: () => undefined, [metodo]: falhar };
+}
+
+function jogador(id: string, nome: string, perfilId?: string): Jogador {
+  return { id, nome, pontos: 0, perfilId };
+}
+
+const humanoVenceu: Jogador[] = [jogador('humano', 'Você'), jogador('bot1', 'Brás', 'bras')];
+const humanoPerdeu: Jogador[] = [jogador('bot1', 'Brás', 'bras'), jogador('humano', 'Você')];
+
+function snapshotInicial(sequenciaAtual: number): string {
+  return JSON.stringify({ versao: 1, sequenciaAtual, maiorTrofeu: null });
+}
+
+describe('registrarTrofeusNoArmazenamento quando o humano vence', () => {
+  it('grava a sequência incrementada na chave de troféus e retorna o resultado', () => {
+    const armazenamento = armazenamentoFake(snapshotInicial(2));
+
+    const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
+
+    expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 3, maiorTrofeu: null });
+    expect(resultado).toEqual({ sequenciaAtual: 3 });
+  });
+
+  it('parte do zero quando ainda não havia snapshot', () => {
+    const armazenamento = armazenamentoFake();
+
+    const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
+
+    expect(resultado).toEqual({ sequenciaAtual: 1 });
+  });
+
+  it('parte do zero quando o snapshot existente está corrompido', () => {
+    const armazenamento = armazenamentoFake('{ corrompido');
+
+    const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
+
+    expect(resultado).toEqual({ sequenciaAtual: 1 });
+  });
+});
+
+describe('registrarTrofeusNoArmazenamento quando o humano não vence', () => {
+  it('zera a sequência persistida e retorna o resultado zerado', () => {
+    const armazenamento = armazenamentoFake(snapshotInicial(5));
+
+    const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoPerdeu);
+
+    expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 0, maiorTrofeu: null });
+    expect(resultado).toEqual({ sequenciaAtual: 0 });
+  });
+});
+
+describe('registrarTrofeusNoArmazenamento — resiliência a falha de Storage', () => {
+  it('não propaga falha de escrita e retorna resultado neutro', () => {
+    const armazenamento = armazenamentoQueLanca('setItem');
+
+    let resultado: unknown;
+    expect(() => {
+      resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
+    }).not.toThrow();
+    expect(resultado).toBeNull();
+  });
+
+  it('absorve falha de leitura e retorna resultado neutro', () => {
+    const armazenamento = armazenamentoQueLanca('getItem');
+
+    expect(registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu)).toBeNull();
+  });
+
+  it('absorve falha do próprio getter de Storage', () => {
+    const obterArmazenamento = (): never => {
+      throw new DOMException('storage bloqueado', 'SecurityError');
+    };
+
+    expect(registrarTrofeusNoArmazenamento(obterArmazenamento, humanoVenceu)).toBeNull();
+  });
+});

--- a/tests/store/trofeus-gravar.test.ts
+++ b/tests/store/trofeus-gravar.test.ts
@@ -65,13 +65,13 @@ describe('registrarTrofeusNoArmazenamento quando o humano vence', () => {
 });
 
 describe('registrarTrofeusNoArmazenamento quando o humano não vence', () => {
-  it('zera a sequência persistida e retorna o resultado zerado', () => {
+  it('zera a sequência persistida e não retorna nada a exibir', () => {
     const armazenamento = armazenamentoFake(snapshotInicial(5));
 
     const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoPerdeu);
 
     expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 0, maiorTrofeu: null });
-    expect(resultado).toEqual({ sequenciaAtual: 0 });
+    expect(resultado).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fecha #260 (parte do PRD #259).

## O que entrega

Tracer bullet mais fino da **Sequência de Vitórias** do jogador humano:

- Ao encerrar uma Partida, a sequência **sobe 1** se o humano venceu e **zera** caso contrário.
- Persiste na chave nova **`fdp.trofeus.v1`**, separada do Ranking, e sobrevive ao recarregar o navegador.
- A tela de fim de jogo **mostra a sequência atual ao vencer** e **nada sobre sequência ao perder**.
- Exclusivo do humano; bots seguem apenas no Ranking. `maiorTrofeu` já existe na forma persistida mas é sempre `null` nesta slice (níveis de Troféu entram na próxima).

## Como funciona

Boundary independente disparado no mesmo `onJogoEncerrado` do Ranking: lê o snapshot, aplica a transição, persiste e **retorna o resultado** para a UI. Toda falha de `Storage` — incluindo o getter `window.localStorage` — é absorvida num `try/catch`, retornando resultado neutro sem interromper o encerramento. Leitura estrita: qualquer conteúdo fora da forma `versao: 1` íntegra vira estado zero. Abandonar a Partida não toca a sequência, pois a escrita só roda no encerramento regular (ADR 0003).

## Estrutura

- **Módulos puros** (`src/store/trofeus/`, TDD): `tipos`, `transicao-trofeus`, `carregar-trofeus`, `gravar-trofeus`.
- **Adapter** (sem Vitest — validação visual, AGENTS.md §3): `fim-jogo-renderer`/`fim-jogo-scene`, fiação em `jogo-controller`/`JogoScene`.
- Decisões de domínio cravadas em `CONTEXT.md` e na ADR `0003-abandono-nao-zera-sequencia-de-vitorias.md`.

## Verificação

- `pnpm test` ✅ (835 testes, +23 novos), `pnpm typecheck` ✅, `pnpm lint` ✅, `pnpm build` ✅
- Validação visual local: vitórias consecutivas fazem a sequência crescer; perder some com o indicador e a próxima vitória reinicia em 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Win Streak tracking for the player that persists across sessions
  * Win Streak displays at the end of each game, increments on victories, and resets on losses
  * Mid-game abandonment no longer affects your Win Streak; only completed matches count
  * Added Trophy system that unlocks at Win Streak milestones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->