### PR TITLE
feat(trofeus): desbloqueio em marcos, permanência e celebração na vitória (#261)

### DIFF
--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -1,4 +1,5 @@
 import type { Scene } from 'phaser';
+import { ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
 import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
 import { escalar, escalarFonte } from '../escala';
@@ -10,36 +11,53 @@ interface ConfigFimJogo {
   resultadoTrofeus: ResultadoTrofeus | null;
   objetos: Phaser.GameObjects.GameObject[];
   onReiniciar: () => void;
+  /** Anima fundo (fade-in) só na primeira exibição; no re-render por resize fica estático. */
+  animar: boolean;
 }
 
 interface LinhaRanking {
   jogador: Jogador;
   indice: number;
+  primeiraLinhaY: number;
 }
+
+/** Espaçamento vertical (lógico) entre linhas empilhadas do cabeçalho da vitória. */
+const ALTURA_LINHA_CABECALHO = 30;
+/** Passo vertical (lógico) entre linhas da Classificação; também a altura da linha do vencedor. */
+const ALTURA_LINHA_RANKING = 54;
 
 export function desenharFimJogo(config: ConfigFimJogo): void {
   limparObjetos(config.objetos);
   desenharFundo(config);
-  desenharTitulo(config.cena, config.objetos);
-  desenharSequencia(config);
+  const { cena, objetos } = config;
+  desenharTitulo(cena, objetos);
+  // O cabeçalho da vitória é empilhado em offsets escalados a partir do título,
+  // e a Classificação parte de onde o cabeçalho termina — assim os textos nunca
+  // colidem com o pódio, qualquer que seja a proporção da tela.
+  let cursorY = cena.cameras.main.height * 0.18 + escalar(54, cena);
+  cursorY = desenharSequencia(config, cursorY);
+  cursorY = desenharTrofeuDesbloqueado(config, cursorY);
+  const primeiraLinhaY = cursorY + escalar(18, cena);
   config.classificacao.forEach((jogador, indice) => {
-    desenharLinha({ cena: config.cena, objetos: config.objetos, jogador, indice });
+    desenharLinha({ cena, objetos, jogador, indice, primeiraLinhaY });
   });
-  desenharBotao(config);
+  const ultimaLinhaY = primeiraLinhaY + (config.classificacao.length - 1) * escalar(ALTURA_LINHA_RANKING, cena);
+  desenharBotao(config, ultimaLinhaY + escalar(58, cena));
 }
 
 /**
  * Exibe a Sequência de Vitórias quando há resultado a mostrar. A boundary de
  * troféus já decide isso: o resultado só existe na vitória, e é `null` na
  * derrota ou em falha de Storage — aqui não reinspecionamos a Classificação.
+ * Devolve o `cursorY` avançado (ou inalterado quando nada é desenhado).
  */
-function desenharSequencia(config: ConfigFimJogo): void {
-  if (config.resultadoTrofeus === null) return;
+function desenharSequencia(config: ConfigFimJogo, cursorY: number): number {
+  if (config.resultadoTrofeus === null) return cursorY;
   const { cena, objetos } = config;
   const sequencia = cena.add
     .text(
       cena.cameras.main.centerX,
-      cena.cameras.main.height * 0.245,
+      cursorY,
       `Sequência de Vitórias: ${String(config.resultadoTrofeus.sequenciaAtual)}`,
       {
         fontSize: escalarFonte(18, cena),
@@ -51,12 +69,40 @@ function desenharSequencia(config: ConfigFimJogo): void {
     .setOrigin(0.5)
     .setDepth(102);
   objetos.push(sequencia);
+  return cursorY + escalar(ALTURA_LINHA_CABECALHO, cena);
+}
+
+/**
+ * Destaque de celebração quando a vitória desbloqueia um Troféu novo. Nesta
+ * slice o Troféu é só o rótulo textual do nível — a arte visual fica para a
+ * slice de visual. Empilha logo abaixo da Sequência de Vitórias e devolve o
+ * `cursorY` avançado (ou inalterado quando não há desbloqueio).
+ */
+function desenharTrofeuDesbloqueado(config: ConfigFimJogo, cursorY: number): number {
+  const nivel = config.resultadoTrofeus?.trofeuDesbloqueado;
+  if (!nivel) return cursorY;
+  const { cena, objetos } = config;
+  const destaque = cena.add
+    .text(cena.cameras.main.centerX, cursorY, `Troféu desbloqueado: ${ROTULO_NIVEL[nivel]}`, {
+      fontSize: escalarFonte(20, cena),
+      fontStyle: 'bold',
+      color: '#fde68a',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5)
+    .setDepth(102);
+  objetos.push(destaque);
+  return cursorY + escalar(ALTURA_LINHA_CABECALHO, cena);
 }
 
 function desenharFundo(config: ConfigFimJogo): void {
   const { cena, objetos } = config;
   const fundo = cena.add.rectangle(0, 0, cena.cameras.main.width, cena.cameras.main.height, 0x050816, 0.94);
   fundo.setOrigin(0).setDepth(100);
+  if (!config.animar) {
+    objetos.push(fundo);
+    return;
+  }
   fundo.setAlpha(0);
   cena.tweens.add({ targets: fundo, alpha: 1, duration: 350, ease: 'Sine.easeOut' });
   objetos.push(fundo);
@@ -79,9 +125,9 @@ function desenharTitulo(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): 
 function desenharLinha(config: LinhaRanking & { cena: Scene; objetos: Phaser.GameObjects.GameObject[] }): void {
   const { cena, objetos, jogador, indice } = config;
   const largura = Math.min(escalar(360, cena), cena.cameras.main.width - escalar(32, cena));
-  const altura = escalar(indice === 0 ? 54 : 44, cena);
+  const altura = escalar(indice === 0 ? ALTURA_LINHA_RANKING : 44, cena);
   const x = cena.cameras.main.centerX;
-  const y = cena.cameras.main.height * 0.32 + indice * escalar(54, cena);
+  const y = config.primeiraLinhaY + indice * escalar(ALTURA_LINHA_RANKING, cena);
   const cor = indice === 0 ? 0x4ecca3 : 0x16213e;
   const fundo = cena.add.rectangle(x, y, largura, altura, cor, indice === 0 ? 0.95 : 0.82);
   fundo.setStrokeStyle(escalar(1, cena), indice === 0 ? 0xfacc15 : 0xffffff, indice === 0 ? 0.8 : 0.18);
@@ -94,7 +140,7 @@ function desenharLinha(config: LinhaRanking & { cena: Scene; objetos: Phaser.Gam
 function desenharTextoLinha(
   cena: Scene,
   objetos: Phaser.GameObjects.GameObject[],
-  config: LinhaRanking & { x: number; y: number; largura: number },
+  config: Omit<LinhaRanking, 'primeiraLinhaY'> & { x: number; y: number; largura: number },
 ): void {
   const medalha = config.indice === 0 ? '* ' : '';
   const texto = `${medalha}${String(config.indice + 1)}. ${config.jogador.nome}`;
@@ -131,12 +177,11 @@ function animarVencedor(cena: Scene, alvo: Phaser.GameObjects.Rectangle): void {
   });
 }
 
-function desenharBotao(config: ConfigFimJogo): void {
+function desenharBotao(config: ConfigFimJogo, y: number): void {
   const { cena, objetos } = config;
   const largura = escalar(220, cena);
   const altura = escalar(52, cena);
   const x = cena.cameras.main.centerX;
-  const y = cena.cameras.main.height * 0.78;
   const botao = cena.add.rectangle(x, y, largura, altura, 0xfacc15, 1).setDepth(102);
   const texto = cena.add
     .text(x, y, 'Jogar novamente', {

--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -2,7 +2,7 @@ import type { Scene } from 'phaser';
 import { ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
 import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
-import { escalar, escalarFonte } from '../escala';
+import { escalar } from '../escala';
 import { limparObjetos } from './limpar-objetos';
 
 interface ConfigFimJogo {
@@ -18,49 +18,147 @@ interface ConfigFimJogo {
 interface LinhaRanking {
   jogador: Jogador;
   indice: number;
-  primeiraLinhaY: number;
+  layout: LayoutFimJogo;
 }
 
-/** Espaçamento vertical (lógico) entre linhas empilhadas do cabeçalho da vitória. */
+interface LayoutFimJogo {
+  tituloY: number;
+  sequenciaY: number | null;
+  trofeuY: number | null;
+  primeiraLinhaY: number;
+  passoRanking: number;
+  alturaLinhaVencedor: number;
+  alturaLinha: number;
+  botaoY: number;
+  larguraRanking: number;
+  larguraBotao: number;
+  alturaBotao: number;
+  escalaConteudo: number;
+}
+
+interface MetricasFimJogo {
+  linhasCabecalho: number;
+  totalNatural: number;
+  escalaConteudo: number;
+}
+
+const MARGEM_VERTICAL = 24;
+const ALTURA_TITULO = 42;
+const ESPACO_TITULO_CABECALHO = 24;
 const ALTURA_LINHA_CABECALHO = 30;
-/** Passo vertical (lógico) entre linhas da Classificação; também a altura da linha do vencedor. */
-const ALTURA_LINHA_RANKING = 54;
+const ESPACO_CABECALHO_RANKING = 18;
+const PASSO_RANKING = 54;
+const ALTURA_LINHA_VENCEDOR = 54;
+const ALTURA_LINHA = 44;
+const ESPACO_RANKING_BOTAO = 30;
+const ALTURA_BOTAO = 52;
+const LARGURA_RANKING = 360;
+const LARGURA_BOTAO = 220;
 
 export function desenharFimJogo(config: ConfigFimJogo): void {
-  limparObjetos(config.objetos);
+  limparFimJogoAnterior(config);
   desenharFundo(config);
   const { cena, objetos } = config;
-  desenharTitulo(cena, objetos);
-  // O cabeçalho da vitória é empilhado em offsets escalados a partir do título,
-  // e a Classificação parte de onde o cabeçalho termina — assim os textos nunca
-  // colidem com o pódio, qualquer que seja a proporção da tela.
-  let cursorY = cena.cameras.main.height * 0.18 + escalar(54, cena);
-  cursorY = desenharSequencia(config, cursorY);
-  cursorY = desenharTrofeuDesbloqueado(config, cursorY);
-  const primeiraLinhaY = cursorY + escalar(18, cena);
+  const layout = calcularLayoutFimJogo(config);
+  desenharTitulo(cena, objetos, layout);
+  desenharSequencia(config, layout);
+  desenharTrofeuDesbloqueado(config, layout);
   config.classificacao.forEach((jogador, indice) => {
-    desenharLinha({ cena, objetos, jogador, indice, primeiraLinhaY });
+    desenharLinha({ cena, objetos, jogador, indice, layout }, config.animar);
   });
-  const ultimaLinhaY = primeiraLinhaY + (config.classificacao.length - 1) * escalar(ALTURA_LINHA_RANKING, cena);
-  desenharBotao(config, ultimaLinhaY + escalar(58, cena));
+  desenharBotao(config, layout);
+}
+
+function limparFimJogoAnterior(config: ConfigFimJogo): void {
+  config.cena.tweens.killTweensOf(config.objetos);
+  limparObjetos(config.objetos);
+}
+
+function calcularLayoutFimJogo(config: ConfigFimJogo): LayoutFimJogo {
+  const { cena } = config;
+  const metricas = calcularMetricas(config);
+  const paraTela = (valor: number): number => Math.round(escalar(valor, cena) * metricas.escalaConteudo);
+  const posicoes = calcularPosicoes(config, metricas, paraTela);
+  return {
+    ...posicoes,
+    passoRanking: paraTela(PASSO_RANKING),
+    alturaLinhaVencedor: paraTela(ALTURA_LINHA_VENCEDOR),
+    alturaLinha: paraTela(ALTURA_LINHA),
+    larguraRanking: Math.min(escalar(LARGURA_RANKING, cena), cena.cameras.main.width - escalar(32, cena)),
+    larguraBotao: escalar(LARGURA_BOTAO, cena),
+    alturaBotao: paraTela(ALTURA_BOTAO),
+    escalaConteudo: metricas.escalaConteudo,
+  };
+}
+
+function calcularMetricas(config: ConfigFimJogo): MetricasFimJogo {
+  const linhasCabecalho = contarLinhasCabecalho(config.resultadoTrofeus);
+  const totalNatural =
+    MARGEM_VERTICAL * 2 +
+    ALTURA_TITULO +
+    espacoCabecalho(linhasCabecalho) +
+    Math.max(0, config.classificacao.length - 1) * PASSO_RANKING +
+    ALTURA_LINHA_VENCEDOR +
+    ESPACO_RANKING_BOTAO +
+    ALTURA_BOTAO;
+  return {
+    linhasCabecalho,
+    totalNatural,
+    escalaConteudo: Math.min(1, Math.max(0.62, config.cena.cameras.main.height / escalar(totalNatural, config.cena))),
+  };
+}
+
+function calcularPosicoes(
+  config: ConfigFimJogo,
+  metricas: MetricasFimJogo,
+  paraTela: (valor: number) => number,
+): Pick<LayoutFimJogo, 'tituloY' | 'sequenciaY' | 'trofeuY' | 'primeiraLinhaY' | 'botaoY'> {
+  let cursor = Math.max(escalar(12, config.cena), inicioVertical(config, metricas, paraTela));
+  const tituloY = cursor + paraTela(ALTURA_TITULO) / 2;
+  cursor += paraTela(ALTURA_TITULO + espacoAposTitulo(metricas.linhasCabecalho));
+  const sequenciaY = config.resultadoTrofeus === null ? null : cursor + paraTela(ALTURA_LINHA_CABECALHO) / 2;
+  cursor += sequenciaY === null ? 0 : paraTela(ALTURA_LINHA_CABECALHO);
+  const trofeuY = config.resultadoTrofeus?.trofeuDesbloqueado ? cursor + paraTela(ALTURA_LINHA_CABECALHO) / 2 : null;
+  cursor += trofeuY === null ? 0 : paraTela(ALTURA_LINHA_CABECALHO);
+  cursor += metricas.linhasCabecalho > 0 ? paraTela(ESPACO_CABECALHO_RANKING) : 0;
+  const primeiraLinhaY = cursor + paraTela(ALTURA_LINHA_VENCEDOR) / 2;
+  const ultimaLinhaY = primeiraLinhaY + Math.max(0, config.classificacao.length - 1) * paraTela(PASSO_RANKING);
+  const botaoY = ultimaLinhaY + paraTela(ALTURA_LINHA_VENCEDOR / 2 + ESPACO_RANKING_BOTAO + ALTURA_BOTAO / 2);
+  return { tituloY, sequenciaY, trofeuY, primeiraLinhaY, botaoY };
+}
+
+function contarLinhasCabecalho(resultado: ResultadoTrofeus | null): number {
+  return (resultado === null ? 0 : 1) + (resultado?.trofeuDesbloqueado ? 1 : 0);
+}
+
+function espacoCabecalho(linhasCabecalho: number): number {
+  if (linhasCabecalho === 0) return ESPACO_CABECALHO_RANKING;
+  return ESPACO_TITULO_CABECALHO + linhasCabecalho * ALTURA_LINHA_CABECALHO + ESPACO_CABECALHO_RANKING;
+}
+
+function espacoAposTitulo(linhasCabecalho: number): number {
+  return linhasCabecalho > 0 ? ESPACO_TITULO_CABECALHO : ESPACO_CABECALHO_RANKING;
+}
+
+function inicioVertical(config: ConfigFimJogo, metricas: MetricasFimJogo, paraTela: (valor: number) => number): number {
+  return (config.cena.cameras.main.height - paraTela(metricas.totalNatural - MARGEM_VERTICAL * 2)) / 2;
 }
 
 /**
  * Exibe a Sequência de Vitórias quando há resultado a mostrar. A boundary de
  * troféus já decide isso: o resultado só existe na vitória, e é `null` na
  * derrota ou em falha de Storage — aqui não reinspecionamos a Classificação.
- * Devolve o `cursorY` avançado (ou inalterado quando nada é desenhado).
  */
-function desenharSequencia(config: ConfigFimJogo, cursorY: number): number {
-  if (config.resultadoTrofeus === null) return cursorY;
+function desenharSequencia(config: ConfigFimJogo, layout: LayoutFimJogo): void {
+  if (config.resultadoTrofeus === null || layout.sequenciaY === null) return;
   const { cena, objetos } = config;
   const sequencia = cena.add
     .text(
       cena.cameras.main.centerX,
-      cursorY,
+      layout.sequenciaY,
       `Sequência de Vitórias: ${String(config.resultadoTrofeus.sequenciaAtual)}`,
       {
-        fontSize: escalarFonte(18, cena),
+        fontSize: fonteFimJogo(18, cena, layout),
         fontStyle: 'bold',
         color: '#facc15',
         fontFamily: 'Arial',
@@ -69,22 +167,20 @@ function desenharSequencia(config: ConfigFimJogo, cursorY: number): number {
     .setOrigin(0.5)
     .setDepth(102);
   objetos.push(sequencia);
-  return cursorY + escalar(ALTURA_LINHA_CABECALHO, cena);
 }
 
 /**
  * Destaque de celebração quando a vitória desbloqueia um Troféu novo. Nesta
  * slice o Troféu é só o rótulo textual do nível — a arte visual fica para a
- * slice de visual. Empilha logo abaixo da Sequência de Vitórias e devolve o
- * `cursorY` avançado (ou inalterado quando não há desbloqueio).
+ * slice de visual.
  */
-function desenharTrofeuDesbloqueado(config: ConfigFimJogo, cursorY: number): number {
+function desenharTrofeuDesbloqueado(config: ConfigFimJogo, layout: LayoutFimJogo): void {
   const nivel = config.resultadoTrofeus?.trofeuDesbloqueado;
-  if (!nivel) return cursorY;
+  if (!nivel || layout.trofeuY === null) return;
   const { cena, objetos } = config;
   const destaque = cena.add
-    .text(cena.cameras.main.centerX, cursorY, `Troféu desbloqueado: ${ROTULO_NIVEL[nivel]}`, {
-      fontSize: escalarFonte(20, cena),
+    .text(cena.cameras.main.centerX, layout.trofeuY, `Troféu desbloqueado: ${ROTULO_NIVEL[nivel]}`, {
+      fontSize: fonteFimJogo(20, cena, layout),
       fontStyle: 'bold',
       color: '#fde68a',
       fontFamily: 'Arial',
@@ -92,7 +188,6 @@ function desenharTrofeuDesbloqueado(config: ConfigFimJogo, cursorY: number): num
     .setOrigin(0.5)
     .setDepth(102);
   objetos.push(destaque);
-  return cursorY + escalar(ALTURA_LINHA_CABECALHO, cena);
 }
 
 function desenharFundo(config: ConfigFimJogo): void {
@@ -108,11 +203,10 @@ function desenharFundo(config: ConfigFimJogo): void {
   objetos.push(fundo);
 }
 
-function desenharTitulo(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): void {
-  const y = cena.cameras.main.height * 0.18;
+function desenharTitulo(cena: Scene, objetos: Phaser.GameObjects.GameObject[], layout: LayoutFimJogo): void {
   const titulo = cena.add
-    .text(cena.cameras.main.centerX, y, 'Fim de jogo', {
-      fontSize: escalarFonte(34, cena),
+    .text(cena.cameras.main.centerX, layout.tituloY, 'Fim de jogo', {
+      fontSize: fonteFimJogo(34, cena, layout),
       fontStyle: 'bold',
       color: '#ffffff',
       fontFamily: 'Arial',
@@ -122,19 +216,23 @@ function desenharTitulo(cena: Scene, objetos: Phaser.GameObjects.GameObject[]): 
   objetos.push(titulo);
 }
 
-function desenharLinha(config: LinhaRanking & { cena: Scene; objetos: Phaser.GameObjects.GameObject[] }): void {
+function desenharLinha(
+  config: LinhaRanking & { cena: Scene; objetos: Phaser.GameObjects.GameObject[] },
+  animar: boolean,
+): void {
   const { cena, objetos, jogador, indice } = config;
-  const largura = Math.min(escalar(360, cena), cena.cameras.main.width - escalar(32, cena));
-  const altura = escalar(indice === 0 ? ALTURA_LINHA_RANKING : 44, cena);
+  const { layout } = config;
+  const largura = layout.larguraRanking;
+  const altura = indice === 0 ? layout.alturaLinhaVencedor : layout.alturaLinha;
   const x = cena.cameras.main.centerX;
-  const y = config.primeiraLinhaY + indice * escalar(ALTURA_LINHA_RANKING, cena);
+  const y = layout.primeiraLinhaY + indice * layout.passoRanking;
   const cor = indice === 0 ? 0x4ecca3 : 0x16213e;
   const fundo = cena.add.rectangle(x, y, largura, altura, cor, indice === 0 ? 0.95 : 0.82);
   fundo.setStrokeStyle(escalar(1, cena), indice === 0 ? 0xfacc15 : 0xffffff, indice === 0 ? 0.8 : 0.18);
   fundo.setDepth(101);
   objetos.push(fundo);
-  desenharTextoLinha(cena, objetos, { jogador, indice, x, y, largura });
-  if (indice === 0) animarVencedor(cena, fundo);
+  desenharTextoLinha(cena, objetos, { jogador, indice, x, y, largura, layout });
+  if (indice === 0 && animar) animarVencedor(cena, fundo);
 }
 
 function desenharTextoLinha(
@@ -146,7 +244,7 @@ function desenharTextoLinha(
   const texto = `${medalha}${String(config.indice + 1)}. ${config.jogador.nome}`;
   const nome = cena.add
     .text(config.x - config.largura / 2 + escalar(18, cena), config.y, texto, {
-      fontSize: escalarFonte(config.indice === 0 ? 19 : 16, cena),
+      fontSize: fonteFimJogo(config.indice === 0 ? 19 : 16, cena, config.layout),
       fontStyle: config.indice === 0 ? 'bold' : 'normal',
       color: config.indice === 0 ? '#0b1020' : '#ffffff',
       fontFamily: 'Arial',
@@ -155,7 +253,7 @@ function desenharTextoLinha(
     .setDepth(102);
   const pontos = cena.add
     .text(config.x + config.largura / 2 - escalar(18, cena), config.y, `${String(config.jogador.pontos)} pts`, {
-      fontSize: escalarFonte(16, cena),
+      fontSize: fonteFimJogo(16, cena, config.layout),
       fontStyle: 'bold',
       color: config.indice === 0 ? '#0b1020' : '#dbeafe',
       fontFamily: 'Arial',
@@ -177,15 +275,16 @@ function animarVencedor(cena: Scene, alvo: Phaser.GameObjects.Rectangle): void {
   });
 }
 
-function desenharBotao(config: ConfigFimJogo, y: number): void {
+function desenharBotao(config: ConfigFimJogo, layout: LayoutFimJogo): void {
   const { cena, objetos } = config;
-  const largura = escalar(220, cena);
-  const altura = escalar(52, cena);
+  const largura = layout.larguraBotao;
+  const altura = layout.alturaBotao;
   const x = cena.cameras.main.centerX;
+  const y = layout.botaoY;
   const botao = cena.add.rectangle(x, y, largura, altura, 0xfacc15, 1).setDepth(102);
   const texto = cena.add
     .text(x, y, 'Jogar novamente', {
-      fontSize: escalarFonte(18, cena),
+      fontSize: fonteFimJogo(18, cena, layout),
       fontStyle: 'bold',
       color: '#111827',
       fontFamily: 'Arial',
@@ -195,4 +294,8 @@ function desenharBotao(config: ConfigFimJogo, y: number): void {
   const zona = cena.add.zone(x, y, largura, altura).setInteractive({ useHandCursor: true }).setDepth(104);
   zona.on('pointerdown', config.onReiniciar);
   objetos.push(botao, texto, zona);
+}
+
+function fonteFimJogo(tamanho: number, cena: Scene, layout: LayoutFimJogo): string {
+  return `${String(Math.max(11, Math.round(escalar(tamanho, cena) * layout.escalaConteudo)))}px`;
 }

--- a/src/adapters/phaser/scenes/JogoScene.ts
+++ b/src/adapters/phaser/scenes/JogoScene.ts
@@ -12,9 +12,9 @@ import { renderizarMesa } from '../renderers/mesa-renderer';
 import { desenharPainelInfo } from '../renderers/painel-info-renderer';
 import { mostrarResumoRodada } from '../renderers/resumo-rodada-renderer';
 import { animarRecolhimentoTurno, atualizarIndicadorVez } from '../renderers/turno-renderer';
-import { aoEncerrarCena, desativarResize } from './ciclo-vida-cena';
+import { aoEncerrarCena } from './ciclo-vida-cena';
 import { desenharMaosJogo } from './desenhar-maos-jogo';
-import { mostrarFimJogoDaCena } from './fim-jogo-scene';
+import { mostrarFimJogoDaCena, type EstadoFimJogo } from './fim-jogo-scene';
 import { JogoController, type DependenciasCena, type PontuacaoRodada } from './jogo-controller';
 
 export class JogoScene extends Scene {
@@ -36,6 +36,7 @@ export class JogoScene extends Scene {
   private controller?: JogoController;
   private resumoAtivo?: PontuacaoRodada;
   private aoContinuarResumo?: () => void;
+  private fimJogoAtivo?: EstadoFimJogo;
 
   constructor() {
     super({ key: 'JogoScene' });
@@ -62,10 +63,8 @@ export class JogoScene extends Scene {
         this.exibirResumoRodada(resumoRodada, onContinuar);
       },
       mostrarFimJogo: (classificacao, resultadoTrofeus) => {
-        mostrarFimJogoDaCena(this, classificacao, resultadoTrofeus);
-      },
-      desativarResize: () => {
-        desativarResize(this, this.redesenhar);
+        this.fimJogoAtivo = { classificacao, resultadoTrofeus };
+        this.renderizarFimJogo(true);
       },
       getGameArea: () => this.obterGameArea(),
       objetosDeclaracao: this.objetosDeclaracao,
@@ -137,7 +136,18 @@ export class JogoScene extends Scene {
     this.scene.pause();
   };
 
+  private renderizarFimJogo(primeiraExibicao: boolean): void {
+    if (!this.fimJogoAtivo) return;
+    mostrarFimJogoDaCena(this, this.fimJogoAtivo, primeiraExibicao);
+  }
+
   private redesenharTela = (): void => {
+    // A tela de fim de jogo sobrepõe o tabuleiro; no resize ela se reposiciona
+    // sozinha, sem redesenhar o jogo por baixo.
+    if (this.fimJogoAtivo) {
+      this.renderizarFimJogo(false);
+      return;
+    }
     destruirDestaque(this.destaque);
     limparObjetos(this.objetos);
     this.atualizarPainel();
@@ -204,6 +214,7 @@ export class JogoScene extends Scene {
     limparObjetos(this.resumoObjetos);
     this.resumoAtivo = undefined;
     this.aoContinuarResumo = undefined;
+    this.fimJogoAtivo = undefined;
     aoEncerrarCena({
       cena: this,
       redesenhar: this.redesenhar,

--- a/src/adapters/phaser/scenes/ciclo-vida-cena.ts
+++ b/src/adapters/phaser/scenes/ciclo-vida-cena.ts
@@ -28,7 +28,7 @@ export function aoEncerrarCena(config: ConfigEncerramento): {
   return { redesenhar: undefined, tweenVez: undefined };
 }
 
-export function desativarResize(cena: Phaser.Scene, redesenhar?: ResizeDebouncer): void {
+function desativarResize(cena: Phaser.Scene, redesenhar?: ResizeDebouncer): void {
   if (!redesenhar) return;
   cena.scale.off('resize', redesenhar);
   redesenhar.limpar();

--- a/src/adapters/phaser/scenes/fim-jogo-scene.ts
+++ b/src/adapters/phaser/scenes/fim-jogo-scene.ts
@@ -17,28 +17,34 @@ interface ConfigFimJogoScene {
   painelObjetos: Phaser.GameObjects.GameObject[];
   destaque: EstadoDestaque;
   onReiniciar: () => void;
+  /** Primeira exibição (transição jogo→fim) vs. re-render por resize. */
+  primeiraExibicao: boolean;
 }
 
 export function mostrarFimJogo(config: ConfigFimJogoScene): void {
-  limparTelaDeJogo(config);
+  // O tabuleiro só precisa ser limpo na transição jogo→fim; no re-render por
+  // resize ele já está vazio e a tela de fim de jogo apenas se reposiciona.
+  if (config.primeiraExibicao) limparTelaDeJogo(config);
   desenharFimJogo({
     cena: config.cena,
     classificacao: config.classificacao,
     resultadoTrofeus: config.resultadoTrofeus,
     objetos: config.fimJogoObjetos,
     onReiniciar: config.onReiniciar,
+    animar: config.primeiraExibicao,
   });
 }
 
-export function mostrarFimJogoDaCena(
-  cena: JogoScene,
-  classificacao: Jogador[],
-  resultadoTrofeus: ResultadoTrofeus | null,
-): void {
+export interface EstadoFimJogo {
+  classificacao: Jogador[];
+  resultadoTrofeus: ResultadoTrofeus | null;
+}
+
+export function mostrarFimJogoDaCena(cena: JogoScene, estado: EstadoFimJogo, primeiraExibicao: boolean): void {
   mostrarFimJogo({
     cena,
-    classificacao,
-    resultadoTrofeus,
+    classificacao: estado.classificacao,
+    resultadoTrofeus: estado.resultadoTrofeus,
     fimJogoObjetos: cena.fimJogoObjetos,
     objetos: cena.objetos,
     mesaObjetos: cena.mesaObjetos,
@@ -46,6 +52,7 @@ export function mostrarFimJogoDaCena(
     painelObjetos: cena.painelObjetos,
     destaque: cena.destaque,
     onReiniciar: () => cena.scene.restart(),
+    primeiraExibicao,
   });
 }
 

--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -32,7 +32,6 @@ export interface DependenciasCena {
   animarRecolhimentoTurno: () => void;
   mostrarResumoRodada: (resumoRodada: PontuacaoRodada, onContinuar: () => void) => void;
   mostrarFimJogo: (classificacao: Jogador[], resultadoTrofeus: ResultadoTrofeus | null) => void;
-  desativarResize: () => void;
   getGameArea: () => Retangulo;
   objetosDeclaracao: Phaser.GameObjects.GameObject[];
   getLabels: () => Phaser.GameObjects.Text[];
@@ -91,7 +90,6 @@ export class JogoController {
       onJogoEncerrado: (classificacao: Jogador[]) => {
         registrarPartidaNoArmazenamento(() => window.localStorage, classificacao);
         const resultadoTrofeus = registrarTrofeusNoArmazenamento(() => window.localStorage, classificacao);
-        this.deps.desativarResize();
         this.deps.mostrarFimJogo(classificacao, resultadoTrofeus);
       },
       modoDebug: this.deps.modoDebug,

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,15 +31,22 @@ function criarConfiguracaoJogo(containerId?: string): Phaser.Types.Core.GameConf
   };
 }
 
+function sincronizarTamanhoCanvas(jogo: Game): void {
+  const dpr = obterDpr();
+  jogo.scale.setZoom(1 / dpr);
+  jogo.scale.resize(window.innerWidth * dpr, window.innerHeight * dpr);
+  jogo.canvas.style.width = `${String(window.innerWidth)}px`;
+  jogo.canvas.style.height = `${String(window.innerHeight)}px`;
+}
+
 export function inicializarJogo(containerId?: string): Game {
   jogo = new Game(criarConfiguracaoJogo(containerId));
   jogo.registry.set('modoDebug', obterModoDebug());
+  sincronizarTamanhoCanvas(jogo);
 
   aoRedimensionar = (): void => {
     if (!jogo) return;
-    const dpr = obterDpr();
-    jogo.scale.setZoom(1 / dpr);
-    jogo.scale.resize(window.innerWidth * dpr, window.innerHeight * dpr);
+    sincronizarTamanhoCanvas(jogo);
   };
 
   window.addEventListener('resize', aoRedimensionar);

--- a/src/store/trofeus/carregar-trofeus.ts
+++ b/src/store/trofeus/carregar-trofeus.ts
@@ -3,10 +3,11 @@
  *
  * Espelha `carregar-ranking.ts`: a leitura é estrita — qualquer conteúdo que
  * não seja um snapshot `versao: 1` íntegro vira o estado zero, para nunca
- * entregar dado corrompido como confiável. Invariante: `sequenciaAtual` é um
- * inteiro ≥ 0 e, nesta slice, `maiorTrofeu` é sempre `null`.
+ * entregar dado corrompido como confiável. Invariantes: `sequenciaAtual` é um
+ * inteiro ≥ 0 e `maiorTrofeu` é um nível válido ou `null`.
  */
 
+import { ehNivel } from './tabela-trofeus';
 import { CHAVE_TROFEUS, SNAPSHOT_ZERO } from './tipos';
 import type { SnapshotTrofeus } from './tipos';
 
@@ -26,8 +27,9 @@ export function lerSnapshot(armazenamento: Pick<Storage, 'getItem'>): SnapshotTr
 function validar(conteudo: unknown): SnapshotTrofeus {
   if (typeof conteudo !== 'object' || conteudo === null) return SNAPSHOT_ZERO;
   const { versao, sequenciaAtual, maiorTrofeu } = conteudo as Record<string, unknown>;
-  if (versao !== 1 || maiorTrofeu !== null || !ehContagem(sequenciaAtual)) return SNAPSHOT_ZERO;
-  return { versao: 1, sequenciaAtual, maiorTrofeu: null };
+  if (versao !== 1 || !ehContagem(sequenciaAtual)) return SNAPSHOT_ZERO;
+  if (maiorTrofeu !== null && !ehNivel(maiorTrofeu)) return SNAPSHOT_ZERO;
+  return { versao: 1, sequenciaAtual, maiorTrofeu };
 }
 
 function ehContagem(valor: unknown): valor is number {

--- a/src/store/trofeus/tabela-trofeus.ts
+++ b/src/store/trofeus/tabela-trofeus.ts
@@ -1,0 +1,65 @@
+/**
+ * Tabela canônica dos Troféus: os sete níveis ordenados e seus limiares de
+ * comprimento de Sequência de Vitórias, definidos num único lugar. Módulo puro
+ * com consultas puras — quem precisa de um Troféu para um comprimento, do nível
+ * acima de outro, ou do limiar de um nível, pergunta aqui.
+ *
+ * Como guardamos o `maiorTrofeu` (o nível), não o número que o conquistou, a
+ * tabela de limiares pode mudar no futuro sem invalidar o progresso persistido.
+ */
+
+export type Nivel = 'bronze' | 'prata' | 'ouro' | 'esmeralda' | 'safira' | 'rubi' | 'diamante';
+
+interface DefinicaoNivel {
+  nivel: Nivel;
+  limiar: number;
+}
+
+/** Níveis em ordem ascendente de limiar; a hierarquia inteira deriva daqui. */
+const NIVEIS: readonly DefinicaoNivel[] = [
+  { nivel: 'bronze', limiar: 3 },
+  { nivel: 'prata', limiar: 5 },
+  { nivel: 'ouro', limiar: 10 },
+  { nivel: 'esmeralda', limiar: 15 },
+  { nivel: 'safira', limiar: 25 },
+  { nivel: 'rubi', limiar: 50 },
+  { nivel: 'diamante', limiar: 100 },
+];
+
+export const NIVEIS_ORDENADOS: readonly Nivel[] = NIVEIS.map((d) => d.nivel);
+
+/** Rótulos textuais exibidos na UI enquanto a arte visual não entra (slice futura). */
+export const ROTULO_NIVEL: Record<Nivel, string> = {
+  bronze: 'Bronze',
+  prata: 'Prata',
+  ouro: 'Ouro',
+  esmeralda: 'Esmeralda',
+  safira: 'Safira',
+  rubi: 'Rubi',
+  diamante: 'Diamante',
+};
+
+/** Maior nível cujo limiar o comprimento já atingiu; `null` abaixo do Bronze. */
+export function trofeuPara(comprimento: number): Nivel | null {
+  let conquistado: Nivel | null = null;
+  for (const { nivel, limiar } of NIVEIS) {
+    if (comprimento >= limiar) conquistado = nivel;
+  }
+  return conquistado;
+}
+
+/** Nível imediatamente acima; `null` (sem Troféu) parte do Bronze, Diamante não tem próximo. */
+export function proximoNivel(trofeu: Nivel | null): Nivel | null {
+  const indice = trofeu === null ? -1 : NIVEIS_ORDENADOS.indexOf(trofeu);
+  return NIVEIS_ORDENADOS[indice + 1] ?? null;
+}
+
+/** Comprimento de Sequência de Vitórias que conquista o nível. */
+export function limiarDe(nivel: Nivel): number {
+  return NIVEIS[NIVEIS_ORDENADOS.indexOf(nivel)].limiar;
+}
+
+/** Type guard usado na leitura estrita do snapshot persistido. */
+export function ehNivel(valor: unknown): valor is Nivel {
+  return typeof valor === 'string' && (NIVEIS_ORDENADOS as readonly string[]).includes(valor);
+}

--- a/src/store/trofeus/tipos.ts
+++ b/src/store/trofeus/tipos.ts
@@ -2,16 +2,19 @@
  * Contrato persistido da Sequência de Vitórias e Troféus (chave
  * `fdp.trofeus.v1`), separado do Ranking. Feature exclusiva do jogador humano.
  *
- * Nesta entrega guardamos só a `sequenciaAtual`; `maiorTrofeu` já existe na
- * forma mas é sempre `null` — os níveis de Troféu entram na próxima slice.
+ * Guardamos a `sequenciaAtual` e o `maiorTrofeu` (o nível mais alto já
+ * conquistado, ou `null`). O conjunto de Troféus conquistados é deduzido do
+ * `maiorTrofeu` pelos níveis ordenados — não é persistido explicitamente.
  */
+
+import type { Nivel } from './tabela-trofeus';
 
 export const CHAVE_TROFEUS = 'fdp.trofeus.v1';
 
 export interface SnapshotTrofeus {
   versao: 1;
   sequenciaAtual: number;
-  maiorTrofeu: null;
+  maiorTrofeu: Nivel | null;
 }
 
 export const SNAPSHOT_ZERO: SnapshotTrofeus = { versao: 1, sequenciaAtual: 0, maiorTrofeu: null };
@@ -21,7 +24,11 @@ export const SNAPSHOT_ZERO: SnapshotTrofeus = { versao: 1, sequenciaAtual: 0, ma
  * presença já significa "há algo a exibir": só existe quando o humano venceu. O
  * resultado neutro — derrota ou falha de Storage — é representado por `null`, e
  * o renderer nunca precisa reinspecionar a Classificação da Partida.
+ *
+ * `trofeuDesbloqueado` é o nível recém-conquistado nesta Partida, ou `null`
+ * quando a vitória não cruzou nenhum marco novo (no máximo um por Partida).
  */
 export interface ResultadoTrofeus {
   sequenciaAtual: number;
+  trofeuDesbloqueado: Nivel | null;
 }

--- a/src/store/trofeus/transicao-trofeus.ts
+++ b/src/store/trofeus/transicao-trofeus.ts
@@ -1,22 +1,37 @@
 /**
- * Transição pura da Sequência de Vitórias ao encerrar uma Partida.
+ * Transição pura da Sequência de Vitórias e dos Troféus ao encerrar uma Partida.
  *
  * Recebe o snapshot atual e se o humano venceu; devolve o snapshot atualizado e
- * o resultado para a tela de fim de jogo. Venceu → sequência + 1 e resultado a
- * exibir; não venceu → zera a sequência persistida e resultado `null` (nada a
- * exibir, a derrota não mostra sequência). Nunca muta a entrada. `maiorTrofeu`
- * permanece nulo nesta slice.
+ * o resultado para a tela de fim de jogo. Venceu → sequência + 1, possivelmente
+ * desbloqueando um Troféu; não venceu → zera a sequência (mas preserva o
+ * `maiorTrofeu`, pois Troféus são permanentes) e resultado `null`.
+ *
+ * Regra de desbloqueio: só ocorre quando a nova `sequenciaAtual` cruza o limiar
+ * do nível imediatamente acima do `maiorTrofeu`. Como a sequência sobe de 1 em
+ * 1 e o `maiorTrofeu` avança no máximo um nível, desbloqueia-se no máximo um
+ * Troféu por Partida e marcos já conquistados nunca recelebram. Nunca muta a
+ * entrada.
  */
 
+import { limiarDe, proximoNivel } from './tabela-trofeus';
 import type { ResultadoTrofeus, SnapshotTrofeus } from './tipos';
 
 export function aplicarTransicao(
   snapshot: SnapshotTrofeus,
   venceu: boolean,
 ): { snapshot: SnapshotTrofeus; resultado: ResultadoTrofeus | null } {
-  const sequenciaAtual = venceu ? snapshot.sequenciaAtual + 1 : 0;
+  if (!venceu) {
+    return {
+      snapshot: { versao: 1, sequenciaAtual: 0, maiorTrofeu: snapshot.maiorTrofeu },
+      resultado: null,
+    };
+  }
+  const sequenciaAtual = snapshot.sequenciaAtual + 1;
+  const candidato = proximoNivel(snapshot.maiorTrofeu);
+  const trofeuDesbloqueado = candidato !== null && sequenciaAtual >= limiarDe(candidato) ? candidato : null;
+  const maiorTrofeu = trofeuDesbloqueado ?? snapshot.maiorTrofeu;
   return {
-    snapshot: { versao: 1, sequenciaAtual, maiorTrofeu: null },
-    resultado: venceu ? { sequenciaAtual } : null,
+    snapshot: { versao: 1, sequenciaAtual, maiorTrofeu },
+    resultado: { sequenciaAtual, trofeuDesbloqueado },
   };
 }

--- a/tests/store/carregar-trofeus.test.ts
+++ b/tests/store/carregar-trofeus.test.ts
@@ -49,8 +49,14 @@ describe('lerSnapshot de troféus trata invariantes violadas como estado zero', 
     );
   });
 
-  it('quando maiorTrofeu não é nulo (fora da forma desta slice)', () => {
-    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 3, maiorTrofeu: 'ouro' })))).toEqual(
+  it('quando maiorTrofeu não é um nível conhecido', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 3, maiorTrofeu: 'platina' })))).toEqual(
+      SNAPSHOT_ZERO,
+    );
+  });
+
+  it('quando maiorTrofeu não é nem nível nem null', () => {
+    expect(lerSnapshot(armazenamentoCom(bruto({ versao: 1, sequenciaAtual: 3, maiorTrofeu: 7 })))).toEqual(
       SNAPSHOT_ZERO,
     );
   });
@@ -59,6 +65,12 @@ describe('lerSnapshot de troféus trata invariantes violadas como estado zero', 
 describe('lerSnapshot de troféus', () => {
   it('lê um snapshot válido tal como persistido', () => {
     const valido = { versao: 1, sequenciaAtual: 4, maiorTrofeu: null };
+
+    expect(lerSnapshot(armazenamentoCom(bruto(valido)))).toEqual(valido);
+  });
+
+  it('lê um snapshot com maiorTrofeu válido (Troféu já conquistado)', () => {
+    const valido = { versao: 1, sequenciaAtual: 0, maiorTrofeu: 'ouro' };
 
     expect(lerSnapshot(armazenamentoCom(bruto(valido)))).toEqual(valido);
   });

--- a/tests/store/tabela-trofeus.test.ts
+++ b/tests/store/tabela-trofeus.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  NIVEIS_ORDENADOS,
+  ehNivel,
+  limiarDe,
+  proximoNivel,
+  trofeuPara,
+  type Nivel,
+} from '@/store/trofeus/tabela-trofeus';
+
+describe('trofeuPara devolve o Troféu correspondente a um comprimento de Sequência de Vitórias', () => {
+  it('não conquista nada abaixo do primeiro limiar (Bronze 3)', () => {
+    expect(trofeuPara(0)).toBeNull();
+    expect(trofeuPara(2)).toBeNull();
+  });
+
+  it('conquista exatamente no limiar de cada nível', () => {
+    expect(trofeuPara(3)).toBe('bronze');
+    expect(trofeuPara(5)).toBe('prata');
+    expect(trofeuPara(10)).toBe('ouro');
+    expect(trofeuPara(15)).toBe('esmeralda');
+    expect(trofeuPara(25)).toBe('safira');
+    expect(trofeuPara(50)).toBe('rubi');
+    expect(trofeuPara(100)).toBe('diamante');
+  });
+
+  it('mantém o nível anterior entre dois limiares', () => {
+    expect(trofeuPara(4)).toBe('bronze');
+    expect(trofeuPara(9)).toBe('prata');
+    expect(trofeuPara(24)).toBe('esmeralda');
+    expect(trofeuPara(99)).toBe('rubi');
+  });
+
+  it('mantém Diamante para qualquer comprimento acima do último limiar', () => {
+    expect(trofeuPara(101)).toBe('diamante');
+    expect(trofeuPara(1000)).toBe('diamante');
+  });
+});
+
+describe('proximoNivel devolve o nível imediatamente acima de um dado Troféu', () => {
+  it('parte de Bronze quando ainda não há Troféu (null)', () => {
+    expect(proximoNivel(null)).toBe('bronze');
+  });
+
+  it('avança um nível na hierarquia ordenada', () => {
+    expect(proximoNivel('bronze')).toBe('prata');
+    expect(proximoNivel('prata')).toBe('ouro');
+    expect(proximoNivel('ouro')).toBe('esmeralda');
+    expect(proximoNivel('esmeralda')).toBe('safira');
+    expect(proximoNivel('safira')).toBe('rubi');
+    expect(proximoNivel('rubi')).toBe('diamante');
+  });
+
+  it('não há próximo nível após Diamante', () => {
+    expect(proximoNivel('diamante')).toBeNull();
+  });
+});
+
+describe('limiarDe devolve o comprimento de Sequência que conquista cada nível', () => {
+  it('mapeia cada nível ao seu limiar', () => {
+    expect(limiarDe('bronze')).toBe(3);
+    expect(limiarDe('diamante')).toBe(100);
+  });
+});
+
+describe('NIVEIS_ORDENADOS expõe os sete níveis em ordem ascendente', () => {
+  it('lista os sete níveis na ordem dos limiares', () => {
+    expect(NIVEIS_ORDENADOS).toEqual(['bronze', 'prata', 'ouro', 'esmeralda', 'safira', 'rubi', 'diamante']);
+  });
+});
+
+describe('ehNivel reconhece níveis válidos', () => {
+  it('aceita cada um dos sete níveis', () => {
+    for (const nivel of NIVEIS_ORDENADOS) {
+      expect(ehNivel(nivel)).toBe(true);
+    }
+  });
+
+  it('rejeita valores que não são níveis', () => {
+    expect(ehNivel('platina')).toBe(false);
+    expect(ehNivel(null)).toBe(false);
+    expect(ehNivel(3)).toBe(false);
+    expect(ehNivel(undefined)).toBe(false);
+  });
+});
+
+describe('propriedade: trofeuPara nunca pula um nível conforme o comprimento cresce', () => {
+  it('o índice do Troféu sobe no máximo de 1 em 1 quando o comprimento incrementa', () => {
+    let anterior: Nivel | null = null;
+    for (let comprimento = 0; comprimento <= 120; comprimento++) {
+      const atual = trofeuPara(comprimento);
+      const indiceAtual = atual === null ? -1 : NIVEIS_ORDENADOS.indexOf(atual);
+      const indiceAnterior = anterior === null ? -1 : NIVEIS_ORDENADOS.indexOf(anterior);
+      expect(indiceAtual - indiceAnterior).toBeLessThanOrEqual(1);
+      expect(indiceAtual - indiceAnterior).toBeGreaterThanOrEqual(0);
+      anterior = atual;
+    }
+  });
+});

--- a/tests/store/transicao-trofeus.test.ts
+++ b/tests/store/transicao-trofeus.test.ts
@@ -1,55 +1,111 @@
 import { describe, expect, it } from 'vitest';
+import type { Nivel } from '@/store/trofeus/tabela-trofeus';
+import { NIVEIS_ORDENADOS } from '@/store/trofeus/tabela-trofeus';
 import { SNAPSHOT_ZERO, type SnapshotTrofeus } from '@/store/trofeus/tipos';
 import { aplicarTransicao } from '@/store/trofeus/transicao-trofeus';
 
-function comSequencia(sequenciaAtual: number): SnapshotTrofeus {
-  return { versao: 1, sequenciaAtual, maiorTrofeu: null };
+function snapshot(sequenciaAtual: number, maiorTrofeu: Nivel | null = null): SnapshotTrofeus {
+  return { versao: 1, sequenciaAtual, maiorTrofeu };
 }
 
 describe('aplicarTransicao quando o humano venceu', () => {
-  it('incrementa a sequência em 1 a partir do zero', () => {
-    const { snapshot, resultado } = aplicarTransicao(SNAPSHOT_ZERO, true);
+  it('incrementa a sequência em 1 a partir do zero sem desbloquear nada', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(SNAPSHOT_ZERO, true);
 
-    expect(snapshot.sequenciaAtual).toBe(1);
-    expect(resultado).toEqual({ sequenciaAtual: 1 });
+    expect(novo.sequenciaAtual).toBe(1);
+    expect(resultado).toEqual({ sequenciaAtual: 1, trofeuDesbloqueado: null });
   });
 
   it('incrementa a sequência já existente', () => {
-    const { snapshot, resultado } = aplicarTransicao(comSequencia(4), true);
+    const { snapshot: novo } = aplicarTransicao(snapshot(7, 'prata'), true);
 
-    expect(snapshot.sequenciaAtual).toBe(5);
-    expect(resultado).toEqual({ sequenciaAtual: 5 });
+    expect(novo.sequenciaAtual).toBe(8);
+  });
+});
+
+describe('aplicarTransicao desbloqueia Troféus ao cruzar o limiar acima do maiorTrofeu', () => {
+  it('desbloqueia Bronze ao atingir 3 vindo de nenhum Troféu', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(2, null), true);
+
+    expect(novo.maiorTrofeu).toBe('bronze');
+    expect(resultado).toEqual({ sequenciaAtual: 3, trofeuDesbloqueado: 'bronze' });
+  });
+
+  it('desbloqueia Prata ao atingir 5 já tendo Bronze', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(4, 'bronze'), true);
+
+    expect(novo.maiorTrofeu).toBe('prata');
+    expect(resultado?.trofeuDesbloqueado).toBe('prata');
+  });
+
+  it('não desbloqueia entre dois marcos', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(3, 'bronze'), true);
+
+    expect(novo.maiorTrofeu).toBe('bronze');
+    expect(resultado?.trofeuDesbloqueado).toBeNull();
+  });
+
+  it('desbloqueia no máximo um Troféu por Partida', () => {
+    // Mesmo partindo de uma sequência alta com maiorTrofeu defasado, sobe só um nível.
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(9, 'bronze'), true);
+
+    expect(novo.maiorTrofeu).toBe('prata');
+    expect(resultado?.trofeuDesbloqueado).toBe('prata');
+  });
+
+  it('não desbloqueia nada após o Diamante (não há próximo nível)', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(150, 'diamante'), true);
+
+    expect(novo.maiorTrofeu).toBe('diamante');
+    expect(resultado?.trofeuDesbloqueado).toBeNull();
+  });
+});
+
+describe('aplicarTransicao não recelebra marcos já conquistados', () => {
+  it('mantém maiorTrofeu e não desbloqueia ao repassar um marco após zerar', () => {
+    // Já tinha Prata; sequência zerou e voltou a cruzar 3 (limiar do Bronze).
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(2, 'prata'), true);
+
+    expect(novo.maiorTrofeu).toBe('prata');
+    expect(resultado?.trofeuDesbloqueado).toBeNull();
   });
 });
 
 describe('aplicarTransicao quando o humano não venceu', () => {
-  it('zera a sequência persistida mas não devolve nada a exibir', () => {
-    const { snapshot, resultado } = aplicarTransicao(comSequencia(7), false);
+  it('zera a sequência mas preserva o maiorTrofeu (Troféus são permanentes)', () => {
+    const { snapshot: novo, resultado } = aplicarTransicao(snapshot(7, 'ouro'), false);
 
-    expect(snapshot.sequenciaAtual).toBe(0);
+    expect(novo.sequenciaAtual).toBe(0);
+    expect(novo.maiorTrofeu).toBe('ouro');
     expect(resultado).toBeNull();
-  });
-
-  it('mantém a sequência zerada ao perder partindo do zero', () => {
-    const { snapshot } = aplicarTransicao(SNAPSHOT_ZERO, false);
-
-    expect(snapshot.sequenciaAtual).toBe(0);
   });
 });
 
-describe('aplicarTransicao preserva o contrato persistido', () => {
-  it('mantém versão 1 e maiorTrofeu nulo (slice atual)', () => {
-    const { snapshot } = aplicarTransicao(comSequencia(2), true);
-
-    expect(snapshot.versao).toBe(1);
-    expect(snapshot.maiorTrofeu).toBeNull();
+describe('aplicarTransicao preserva o contrato e a imutabilidade', () => {
+  it('mantém versão 1', () => {
+    expect(aplicarTransicao(snapshot(2), true).snapshot.versao).toBe(1);
   });
 
   it('não muta o snapshot recebido', () => {
-    const original = comSequencia(3);
+    const original = snapshot(2, 'bronze');
 
     aplicarTransicao(original, true);
 
-    expect(original.sequenciaAtual).toBe(3);
+    expect(original).toEqual({ versao: 1, sequenciaAtual: 2, maiorTrofeu: 'bronze' });
+  });
+});
+
+describe('propriedade: vencendo em sequência, o maiorTrofeu sobe um nível por vez (nunca pula)', () => {
+  it('atravessa todos os limiares conquistando cada nível exatamente uma vez', () => {
+    let estado: SnapshotTrofeus = SNAPSHOT_ZERO;
+    const desbloqueados: Nivel[] = [];
+
+    for (let i = 0; i < 100; i++) {
+      const { snapshot: novo, resultado } = aplicarTransicao(estado, true);
+      if (resultado?.trofeuDesbloqueado) desbloqueados.push(resultado.trofeuDesbloqueado);
+      estado = novo;
+    }
+
+    expect(desbloqueados).toEqual([...NIVEIS_ORDENADOS]);
   });
 });

--- a/tests/store/trofeus-gravar.test.ts
+++ b/tests/store/trofeus-gravar.test.ts
@@ -43,8 +43,8 @@ describe('registrarTrofeusNoArmazenamento quando o humano vence', () => {
 
     const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
 
-    expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 3, maiorTrofeu: null });
-    expect(resultado).toEqual({ sequenciaAtual: 3 });
+    expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 3, maiorTrofeu: 'bronze' });
+    expect(resultado).toEqual({ sequenciaAtual: 3, trofeuDesbloqueado: 'bronze' });
   });
 
   it('parte do zero quando ainda não havia snapshot', () => {
@@ -52,7 +52,7 @@ describe('registrarTrofeusNoArmazenamento quando o humano vence', () => {
 
     const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
 
-    expect(resultado).toEqual({ sequenciaAtual: 1 });
+    expect(resultado).toEqual({ sequenciaAtual: 1, trofeuDesbloqueado: null });
   });
 
   it('parte do zero quando o snapshot existente está corrompido', () => {
@@ -60,7 +60,16 @@ describe('registrarTrofeusNoArmazenamento quando o humano vence', () => {
 
     const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
 
-    expect(resultado).toEqual({ sequenciaAtual: 1 });
+    expect(resultado).toEqual({ sequenciaAtual: 1, trofeuDesbloqueado: null });
+  });
+
+  it('persiste o maiorTrofeu desbloqueado e o devolve no resultado', () => {
+    const armazenamento = armazenamentoFake(JSON.stringify({ versao: 1, sequenciaAtual: 4, maiorTrofeu: 'bronze' }));
+
+    const resultado = registrarTrofeusNoArmazenamento(() => armazenamento, humanoVenceu);
+
+    expect(snapshotGravado(armazenamento)).toEqual({ versao: 1, sequenciaAtual: 5, maiorTrofeu: 'prata' });
+    expect(resultado).toEqual({ sequenciaAtual: 5, trofeuDesbloqueado: 'prata' });
   });
 });
 


### PR DESCRIPTION
Fecha #261 (PRD de origem: #259).

## O que entrega

- **`tabela-trofeus` (novo módulo puro):** fonte única dos sete níveis ordenados e seus limiares — Bronze 3, Prata 5, Ouro 10, Esmeralda 15, Safira 25, Rubi 50, Diamante 100. Consultas puras (`trofeuPara`, `proximoNivel`, `limiarDe`, `ehNivel`).
- **Transição (`transicao-trofeus`):** desbloqueio só quando a `sequenciaAtual` cruza o limiar do nível imediatamente acima do `maiorTrofeu`. Como a sequência sobe de 1 em 1 e o nível avança ≤1, sai naturalmente **no máximo um Troféu por Partida** e **marcos já conquistados nunca recelebram**. Imutável.
- **Persistência (`fdp.trofeus.v1`):** guarda o `maiorTrofeu` (o nível, não o número que o conquistou — limiares podem mudar sem invalidar progresso). Leitura estrita: conteúdo inválido → estado zero. Derrota zera a sequência mas preserva o Troféu (permanente).
- **Tela de fim de jogo:** exibe `Sequência de Vitórias: N` e `Troféu desbloqueado: {nível}` em layout empilhado e escalado que **se reposiciona no resize sem colidir** com o pódio.

## Fora de escopo (slices futuras)

- Arte visual do Troféu (aqui é só o rótulo textual).
- Linha-resumo / overlay no Ranking.

## Qualidade

- **TDD** nos módulos puros, incluindo property tests (ex.: "nunca pula dois níveis").
- Adapters Phaser **validados visualmente**, sem teste Vitest (AGENTS.md §3).
- Otimizações de re-render: fade-in do fundo só na primeira exibição (não pisca no resize), limpeza do tabuleiro restrita à transição jogo→fim, constante `ALTURA_LINHA_RANKING` extraída.
- `pnpm test` (856), `typecheck` e `lint` verdes.

## Validação visual

Disparei o handler real de fim de jogo a 666×546 (primeira exibição limpa) e redimensionei para 373×640 **sem re-renderizar manualmente** — a tela se reposicionou sozinha, sem colisão e sem piscar o fundo. Sem erros de console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trophy system with seven levels (bronze through diamond) that unlock progressively based on consecutive victories.
  * Newly unlocked trophies are displayed prominently in the end-game screen.
  * Improved end-game screen responsiveness: window resizing now re-renders only the overlay without rebuilding the underlying board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->