### PR TITLE
feat(trofeus): overlay tocável com os sete níveis no Ranking (#263)

### DIFF
--- a/src/adapters/phaser/scenes/RankingScene.ts
+++ b/src/adapters/phaser/scenes/RankingScene.ts
@@ -3,8 +3,10 @@ import { carregarRanking, type RankingPersistido } from '@/store/ranking/carrega
 import type { MetricaRanking } from '@/store/ranking/ordenar-ranking';
 import { lerSnapshot } from '@/store/trofeus/carregar-trofeus';
 import { resumirTrofeus } from '@/store/trofeus/resumo-trofeus';
+import type { Nivel } from '@/store/trofeus/tabela-trofeus';
 import { escalar, escalarFonte } from '../escala';
 import { criarDebounceResize, type ResizeDebouncer } from '../redimensionamento';
+import { desenharOverlayTrofeus } from './desenhar-overlay-trofeus';
 import { desenharPodioRanking } from './desenhar-podio-ranking';
 import { desenharTabelaRanking, type TabelaRankingRender } from './desenhar-tabela-ranking';
 import { desenharTrofeusRanking } from './desenhar-trofeus-ranking';
@@ -39,6 +41,7 @@ interface SegmentoCtx {
  */
 export class RankingScene extends Scene {
   private objetos: Phaser.GameObjects.GameObject[] = [];
+  private overlayTrofeus: Phaser.GameObjects.GameObject[] = [];
   private redesenhar?: ResizeDebouncer;
   private rolagem?: ControladorRolagemTabela;
   private navegacao?: NavegacaoVoltarRanking;
@@ -79,7 +82,15 @@ export class RankingScene extends Scene {
       const resumoTrofeus = resumirTrofeus(lerSnapshot(window.localStorage));
       const layout = calcularLayoutRanking(this, resumoTrofeus !== null);
       const model = prepararRankingRenderModel(ranking.participantes, this.metricaAtiva);
-      this.objetos.push(...desenharTrofeusRanking(this, resumoTrofeus, layout));
+      this.objetos.push(
+        ...desenharTrofeusRanking(this, {
+          resumo: resumoTrofeus,
+          layout,
+          aoTocar: () => {
+            if (resumoTrofeus !== null) this.abrirOverlayTrofeus(resumoTrofeus.maiorTrofeu);
+          },
+        }),
+      );
       this.objetos.push(...desenharPodioRanking(this, model, layout));
       this.desenharControleOrdenacao(layout);
       this.desenharTabelaComRolagem(desenharTabelaRanking(this, model, layout));
@@ -220,6 +231,20 @@ export class RankingScene extends Scene {
     this.scene.resume('JogoScene');
   }
 
+  private abrirOverlayTrofeus(maiorTrofeu: Nivel): void {
+    this.fecharOverlayTrofeus();
+    this.overlayTrofeus = desenharOverlayTrofeus(this, maiorTrofeu, () => {
+      this.fecharOverlayTrofeus();
+    });
+  }
+
+  private fecharOverlayTrofeus(): void {
+    this.overlayTrofeus.forEach((obj) => {
+      obj.destroy();
+    });
+    this.overlayTrofeus = [];
+  }
+
   private alterarMetrica(metrica: MetricaRanking): void {
     if (this.metricaAtiva === metrica) return;
     this.metricaAtiva = metrica;
@@ -227,6 +252,7 @@ export class RankingScene extends Scene {
   }
 
   private limpar(): void {
+    this.fecharOverlayTrofeus();
     this.rolagem?.destruir();
     this.rolagem = undefined;
     this.objetos.forEach((obj) => {

--- a/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
+++ b/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
@@ -1,0 +1,121 @@
+import type { Scene } from 'phaser';
+import type { Nivel } from '@/store/trofeus/tabela-trofeus';
+import { NIVEIS_ORDENADOS, ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
+import { escalar, escalarFonte } from '../escala';
+
+const COR_BACKDROP = 0x0b0f1a;
+const COR_PAINEL = 0x1f2740;
+const COR_BORDA = 0x2a3550;
+const COR_TITULO = '#e8ecf5';
+const COR_DICA = '#8b95ad';
+const COR_CONQUISTADO = '#facc15';
+const COR_BLOQUEADO = '#4b5572';
+
+const PASSO_NIVEL = 40;
+const PAD_TOPO = 76;
+const PAD_BASE = 24;
+
+interface ContextoOverlay {
+  cena: Scene;
+  x: number;
+  xEsquerda: number;
+  topo: number;
+}
+
+/**
+ * Overlay tocável da coleção de Troféus, aberto sobre o Ranking. Mostra os sete
+ * níveis na ordem da tabela: os conquistados (até o `maiorTrofeu`, inclusive)
+ * acesos; os bloqueados, apagados. Tocar fora do painel (ou no botão ×) fecha;
+ * o painel absorve o toque para não fechar por engano. O overlay é transitório
+ * e não deixa resíduo no layout do Ranking.
+ */
+export function desenharOverlayTrofeus(
+  cena: Scene,
+  maiorTrofeu: Nivel,
+  aoFechar: () => void,
+): Phaser.GameObjects.GameObject[] {
+  const { centerX, centerY, width, height } = cena.cameras.main;
+  const largura = Math.min(width - escalar(48, cena), escalar(340, cena));
+  const altura = escalar(PAD_TOPO + PAD_BASE, cena) + escalar(PASSO_NIVEL, cena) * NIVEIS_ORDENADOS.length;
+  const topo = centerY - altura / 2;
+  const ctx: ContextoOverlay = { cena, x: centerX, xEsquerda: centerX - largura / 2 + escalar(48, cena), topo };
+
+  const backdrop = cena.add
+    .rectangle(centerX, centerY, width, height, COR_BACKDROP, 0.82)
+    .setInteractive({ useHandCursor: true })
+    .on('pointerdown', aoFechar);
+  // O painel é interativo só para absorver o toque (topOnly): assim o clique
+  // dentro dele não chega ao backdrop e o overlay não fecha por engano.
+  const painel = cena.add
+    .rectangle(centerX, centerY, largura, altura, COR_PAINEL, 1)
+    .setStrokeStyle(escalar(1, cena), COR_BORDA)
+    .setInteractive();
+  const fechar = desenharBotaoFechar(
+    cena,
+    { x: centerX + largura / 2 - escalar(24, cena), y: topo + escalar(24, cena) },
+    aoFechar,
+  );
+
+  return [backdrop, painel, fechar, ...desenharCabecalho(ctx), ...desenharNiveis(ctx, maiorTrofeu)];
+}
+
+function desenharBotaoFechar(
+  cena: Scene,
+  posicao: { x: number; y: number },
+  aoFechar: () => void,
+): Phaser.GameObjects.GameObject {
+  const botao = cena.add
+    .text(posicao.x, posicao.y, '×', { fontSize: escalarFonte(24, cena), color: COR_DICA, fontFamily: 'Arial' })
+    .setOrigin(0.5);
+  botao.setInteractive({ useHandCursor: true }).on('pointerdown', aoFechar);
+  return botao;
+}
+
+function desenharCabecalho({ cena, x, topo }: ContextoOverlay): Phaser.GameObjects.GameObject[] {
+  const titulo = cena.add
+    .text(x, topo + escalar(28, cena), 'Coleção de Troféus', {
+      fontSize: escalarFonte(16, cena),
+      color: COR_TITULO,
+      fontStyle: 'bold',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+  const dica = cena.add
+    .text(x, topo + escalar(50, cena), 'Toque fora para fechar', {
+      fontSize: escalarFonte(11, cena),
+      color: COR_DICA,
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0.5);
+  return [titulo, dica];
+}
+
+function desenharNiveis(ctx: ContextoOverlay, maiorTrofeu: Nivel): Phaser.GameObjects.GameObject[] {
+  const { cena, xEsquerda, topo } = ctx;
+  const maxIndice = NIVEIS_ORDENADOS.indexOf(maiorTrofeu);
+  const baseY = topo + escalar(PAD_TOPO, cena);
+  return NIVEIS_ORDENADOS.map((nivel, indice) => {
+    const y = baseY + escalar(PASSO_NIVEL, cena) * indice;
+    return desenharNivel(cena, { nivel, conquistado: indice <= maxIndice, x: xEsquerda, y });
+  });
+}
+
+interface ContextoNivel {
+  nivel: Nivel;
+  conquistado: boolean;
+  x: number;
+  y: number;
+}
+
+function desenharNivel(cena: Scene, { nivel, conquistado, x, y }: ContextoNivel): Phaser.GameObjects.GameObject {
+  const marca = conquistado ? '🏆' : '🔒';
+  return cena.add
+    .text(x, y, `${marca}  ${ROTULO_NIVEL[nivel]}`, {
+      fontSize: escalarFonte(14, cena),
+      color: conquistado ? COR_CONQUISTADO : COR_BLOQUEADO,
+      fontStyle: conquistado ? 'bold' : 'normal',
+      fontFamily: 'Arial',
+    })
+    .setOrigin(0, 0.5)
+    .setAlpha(conquistado ? 1 : 0.5);
+}

--- a/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
+++ b/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
@@ -14,31 +14,57 @@ const COR_BLOQUEADO = '#4b5572';
 const PASSO_NIVEL = 40;
 const PAD_TOPO = 76;
 const PAD_BASE = 24;
+const MARGEM_VERTICAL = 16;
 
-interface ContextoOverlay {
+interface LayoutOverlay {
   cena: Scene;
-  x: number;
-  xEsquerda: number;
+  centerX: number;
+  centerY: number;
+  largura: number;
+  altura: number;
   topo: number;
+  xEsquerda: number;
+  fator: number;
+}
+
+/**
+ * Geometria do overlay. A altura natural cabe os sete níveis com folga, mas é
+ * limitada à altura da câmera (menos a margem); quando não cabe, `fator` < 1
+ * compacta espaçamentos e fontes para o painel nunca sair da viewport — daí
+ * `topo >= margem` é garantido. Espelha o `escalaConteudo` do fim de jogo.
+ */
+function calcularLayout(cena: Scene): LayoutOverlay {
+  const { centerX, centerY, width, height } = cena.cameras.main;
+  const largura = Math.min(width - escalar(48, cena), escalar(340, cena));
+  const alturaNatural = escalar(PAD_TOPO + PAD_BASE, cena) + escalar(PASSO_NIVEL, cena) * NIVEIS_ORDENADOS.length;
+  const altura = Math.min(alturaNatural, height - escalar(MARGEM_VERTICAL, cena) * 2);
+  return {
+    cena,
+    centerX,
+    centerY,
+    largura,
+    altura,
+    topo: centerY - altura / 2,
+    xEsquerda: centerX - largura / 2 + escalar(48, cena),
+    fator: altura / alturaNatural,
+  };
 }
 
 /**
  * Overlay tocável da coleção de Troféus, aberto sobre o Ranking. Mostra os sete
  * níveis na ordem da tabela: os conquistados (até o `maiorTrofeu`, inclusive)
- * acesos; os bloqueados, apagados. Tocar fora do painel (ou no botão ×) fecha;
- * o painel absorve o toque para não fechar por engano. O overlay é transitório
- * e não deixa resíduo no layout do Ranking.
+ * acesos; os bloqueados, apagados (mesmo troféu, esmaecido). Tocar fora do
+ * painel (ou no botão ×) fecha; o painel absorve o toque para não fechar por
+ * engano. O overlay é transitório e não deixa resíduo no layout do Ranking.
  */
 export function desenharOverlayTrofeus(
   cena: Scene,
   maiorTrofeu: Nivel,
   aoFechar: () => void,
 ): Phaser.GameObjects.GameObject[] {
-  const { centerX, centerY, width, height } = cena.cameras.main;
-  const largura = Math.min(width - escalar(48, cena), escalar(340, cena));
-  const altura = escalar(PAD_TOPO + PAD_BASE, cena) + escalar(PASSO_NIVEL, cena) * NIVEIS_ORDENADOS.length;
-  const topo = centerY - altura / 2;
-  const ctx: ContextoOverlay = { cena, x: centerX, xEsquerda: centerX - largura / 2 + escalar(48, cena), topo };
+  const layout = calcularLayout(cena);
+  const { centerX, centerY, largura, altura } = layout;
+  const { width, height } = cena.cameras.main;
 
   const backdrop = cena.add
     .rectangle(centerX, centerY, width, height, COR_BACKDROP, 0.82)
@@ -50,39 +76,36 @@ export function desenharOverlayTrofeus(
     .rectangle(centerX, centerY, largura, altura, COR_PAINEL, 1)
     .setStrokeStyle(escalar(1, cena), COR_BORDA)
     .setInteractive();
-  const fechar = desenharBotaoFechar(
-    cena,
-    { x: centerX + largura / 2 - escalar(24, cena), y: topo + escalar(24, cena) },
-    aoFechar,
-  );
+  const fechar = desenharBotaoFechar(layout, aoFechar);
 
-  return [backdrop, painel, fechar, ...desenharCabecalho(ctx), ...desenharNiveis(ctx, maiorTrofeu)];
+  return [backdrop, painel, fechar, ...desenharCabecalho(layout), ...desenharNiveis(layout, maiorTrofeu)];
 }
 
-function desenharBotaoFechar(
-  cena: Scene,
-  posicao: { x: number; y: number },
-  aoFechar: () => void,
-): Phaser.GameObjects.GameObject {
+function desenharBotaoFechar(layout: LayoutOverlay, aoFechar: () => void): Phaser.GameObjects.GameObject {
+  const { cena, centerX, largura, topo, fator } = layout;
   const botao = cena.add
-    .text(posicao.x, posicao.y, '×', { fontSize: escalarFonte(24, cena), color: COR_DICA, fontFamily: 'Arial' })
+    .text(centerX + largura / 2 - escalar(24, cena), topo + escalar(24 * fator, cena), '×', {
+      fontSize: escalarFonte(24 * fator, cena),
+      color: COR_DICA,
+      fontFamily: 'Arial',
+    })
     .setOrigin(0.5);
   botao.setInteractive({ useHandCursor: true }).on('pointerdown', aoFechar);
   return botao;
 }
 
-function desenharCabecalho({ cena, x, topo }: ContextoOverlay): Phaser.GameObjects.GameObject[] {
+function desenharCabecalho({ cena, centerX, topo, fator }: LayoutOverlay): Phaser.GameObjects.GameObject[] {
   const titulo = cena.add
-    .text(x, topo + escalar(28, cena), 'Coleção de Troféus', {
-      fontSize: escalarFonte(16, cena),
+    .text(centerX, topo + escalar(28 * fator, cena), 'Coleção de Troféus', {
+      fontSize: escalarFonte(16 * fator, cena),
       color: COR_TITULO,
       fontStyle: 'bold',
       fontFamily: 'Arial',
     })
     .setOrigin(0.5);
   const dica = cena.add
-    .text(x, topo + escalar(50, cena), 'Toque fora para fechar', {
-      fontSize: escalarFonte(11, cena),
+    .text(centerX, topo + escalar(50 * fator, cena), 'Toque fora para fechar', {
+      fontSize: escalarFonte(11 * fator, cena),
       color: COR_DICA,
       fontFamily: 'Arial',
     })
@@ -90,13 +113,13 @@ function desenharCabecalho({ cena, x, topo }: ContextoOverlay): Phaser.GameObjec
   return [titulo, dica];
 }
 
-function desenharNiveis(ctx: ContextoOverlay, maiorTrofeu: Nivel): Phaser.GameObjects.GameObject[] {
-  const { cena, xEsquerda, topo } = ctx;
+function desenharNiveis(layout: LayoutOverlay, maiorTrofeu: Nivel): Phaser.GameObjects.GameObject[] {
+  const { cena, xEsquerda, topo, fator } = layout;
   const maxIndice = NIVEIS_ORDENADOS.indexOf(maiorTrofeu);
-  const baseY = topo + escalar(PAD_TOPO, cena);
+  const baseY = topo + escalar(PAD_TOPO * fator, cena);
   return NIVEIS_ORDENADOS.map((nivel, indice) => {
-    const y = baseY + escalar(PASSO_NIVEL, cena) * indice;
-    return desenharNivel(cena, { nivel, conquistado: indice <= maxIndice, x: xEsquerda, y });
+    const y = baseY + escalar(PASSO_NIVEL * fator, cena) * indice;
+    return desenharNivel(cena, { nivel, conquistado: indice <= maxIndice, x: xEsquerda, y, fator });
   });
 }
 
@@ -105,13 +128,13 @@ interface ContextoNivel {
   conquistado: boolean;
   x: number;
   y: number;
+  fator: number;
 }
 
-function desenharNivel(cena: Scene, { nivel, conquistado, x, y }: ContextoNivel): Phaser.GameObjects.GameObject {
-  const marca = conquistado ? '🏆' : '🔒';
+function desenharNivel(cena: Scene, { nivel, conquistado, x, y, fator }: ContextoNivel): Phaser.GameObjects.GameObject {
   return cena.add
-    .text(x, y, `${marca}  ${ROTULO_NIVEL[nivel]}`, {
-      fontSize: escalarFonte(14, cena),
+    .text(x, y, `🏆  ${ROTULO_NIVEL[nivel]}`, {
+      fontSize: escalarFonte(14 * fator, cena),
       color: conquistado ? COR_CONQUISTADO : COR_BLOQUEADO,
       fontStyle: conquistado ? 'bold' : 'normal',
       fontFamily: 'Arial',

--- a/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
@@ -7,10 +7,15 @@ import type { LayoutRanking } from './layout-ranking';
 const COR_TEXTO = '#e8ecf5';
 const COR_ACENTO = '#facc15';
 
+export interface OpcoesTrofeusRanking {
+  resumo: ResumoTrofeus | null;
+  layout: LayoutRanking;
+  aoTocar: () => void;
+}
+
 export function desenharTrofeusRanking(
   cena: Scene,
-  resumo: ResumoTrofeus | null,
-  layout: LayoutRanking,
+  { resumo, layout, aoTocar }: OpcoesTrofeusRanking,
 ): Phaser.GameObjects.GameObject[] {
   if (resumo === null) return [];
   const texto = cena.add
@@ -24,6 +29,7 @@ export function desenharTrofeusRanking(
     .setOrigin(0.5, 0)
     .setWordWrapWidth(layout.faixa.largura);
   texto.setShadow(0, 0, COR_ACENTO, 2);
+  texto.setInteractive({ useHandCursor: true }).on('pointerdown', aoTocar);
   return [texto];
 }
 


### PR DESCRIPTION
Closes #263

## O que muda

Torna a linha-resumo de troféus do Ranking tocável: ao tocar, abre um overlay com a coleção inteira de relance — os sete níveis (Bronze → Diamante) na ordem da tabela, com os **conquistados acesos** e os **bloqueados apagados**, deduzidos do `maiorTrofeu`. O overlay evita custo permanente de espaço na tela para a coleção completa.

## Detalhes

- **`desenhar-overlay-trofeus.ts`** (novo): backdrop + painel centralizado listando os sete níveis. Conquistados (até o `maiorTrofeu`, inclusive) acesos (🏆 dourado/bold); bloqueados apagados (🔒 cinza, alpha reduzido). Ícones alinhados ao mesmo X.
- **`desenhar-trofeus-ranking.ts`**: a linha-resumo agora é interativa e dispara a abertura do overlay.
- **`RankingScene.ts`**: fiação `abrirOverlayTrofeus`/`fecharOverlayTrofeus`; a limpeza do overlay entra no `limpar()`, então redesenho/resize não deixam resíduo.
- **Fechar**: clicar fora (backdrop) ou no botão ×. O painel é interativo só para absorver o toque (`topOnly`), evitando fechar por engano ao clicar dentro.

## Critérios de aceite

- [x] Tocar na linha-resumo abre o overlay com os sete níveis na ordem da tabela
- [x] Conquistados acesos; bloqueados apagados (estado derivado do `maiorTrofeu`)
- [x] Overlay fecha e não deixa resíduo no layout do Ranking
- [x] `pnpm typecheck` e `pnpm lint` passam

## Validação

Interação de adapter Phaser, sem Vitest (AGENTS.md §3). Validado visualmente no browser com estado de Bronze: linha-resumo, abertura do overlay, alinhamento, clique no painel (não fecha), botão × e clique fora (fecham).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trophies in the ranking are now interactive—tap the highest trophy to view your trophy collection overlay
  * Trophy collection displays earned and locked achievements with visual indicators and descriptions
  * Close the overlay by tapping the × button or outside the panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->