### PR TITLE
feat(trofeus): arte visual dos troféus com metais e pedras (#264)

### DIFF
--- a/src/adapters/phaser/desenhar-trofeu-arte.ts
+++ b/src/adapters/phaser/desenhar-trofeu-arte.ts
@@ -10,41 +10,58 @@ import type { Nivel } from '@/store/trofeus/tabela-trofeus';
  *   engravada na cor da pedra — visualmente "depois" dos metais. A gema é
  *   facetada (topo claro / base escura) com um brilho, para ler como joia.
  *
+ * Cada nível é classificado uma única vez em {@link COR_METAL} ou {@link COR_GEMA}
+ * (a cobertura de todos os níveis é checada em tempo de compilação), e tudo o
+ * mais — `ehPedra`, a cor do corpo, a gema — deriva daí. `desenharTrofeuArte`
+ * desenha a taça inteira; `desenharCristalTrofeu` desenha só o cristal e só
+ * aceita níveis de pedra, então não há combinação inválida possível.
+ *
  * O ouro é um tom escurecido (compartilhado por Ouro e por todas as pedras), com
  * um filete claro na boca da taça para não chapar. `aceso: false` apaga o Troféu
  * (cinza esmaecido) para os níveis bloqueados do overlay, preservando a
- * silhueta. Retorna um Container centrado em (x, y); a geometria ocupa cerca de
- * `tamanho` na vertical.
+ * silhueta. Cada função retorna um Container centrado em (x, y); a geometria
+ * ocupa cerca de `tamanho` na vertical.
  */
 
 const COR_OURO = 0xd4951f;
 const COR_BLOQUEADO = 0x4b5572;
 const COR_CONTORNO = 0x1a2138;
 const ESCALA_GEMA = 1.55;
-/** A gema sozinha (`apenasGema`) cresce para preencher o lugar da taça. */
+/** A gema sozinha (`desenharCristalTrofeu`) cresce para preencher o lugar da taça. */
 const ESCALA_GEMA_SOLO = 4;
-
-const COR_METAL: Partial<Record<Nivel, number>> = {
-  bronze: 0xcd7f32,
-  prata: 0xc0c6d4,
-  ouro: COR_OURO,
-};
 
 interface CorGema {
   cor: number;
   topo: number;
 }
 
-const COR_GEMA: Partial<Record<Nivel, CorGema>> = {
-  esmeralda: { cor: 0x12a150, topo: 0x86efac },
-  safira: { cor: 0x2563eb, topo: 0x7cb0ff },
-  rubi: { cor: 0xdc2626, topo: 0xfb9a9a },
-  diamante: { cor: 0x9cc3ea, topo: 0xffffff },
-};
+type VisualNivel = { tipo: 'metal'; cor: number } | { tipo: 'pedra'; gema: CorGema };
+
+// Fonte única da classificação visual. `satisfies Record<Nivel, ...>` obriga a
+// cobrir os sete níveis: um Nível novo sem entrada aqui não compila — não há
+// fallback silencioso. `Pedra` e tudo o mais derivam deste mapa.
+const VISUAL = {
+  bronze: { tipo: 'metal', cor: 0xcd7f32 },
+  prata: { tipo: 'metal', cor: 0xc0c6d4 },
+  ouro: { tipo: 'metal', cor: COR_OURO },
+  esmeralda: { tipo: 'pedra', gema: { cor: 0x12a150, topo: 0x86efac } },
+  safira: { tipo: 'pedra', gema: { cor: 0x2563eb, topo: 0x7cb0ff } },
+  rubi: { tipo: 'pedra', gema: { cor: 0xdc2626, topo: 0xfb9a9a } },
+  diamante: { tipo: 'pedra', gema: { cor: 0x9cc3ea, topo: 0xffffff } },
+} as const satisfies Record<Nivel, VisualNivel>;
+
+/** Níveis de pedra, derivados do mapa: garante que o cristal só receba pedras. */
+export type Pedra = { [K in Nivel]: (typeof VISUAL)[K]['tipo'] extends 'pedra' ? K : never }[Nivel];
 
 /** Pedras (têm gema engravada) vs. metais (taça lisa). */
-export function ehPedra(nivel: Nivel): boolean {
-  return COR_GEMA[nivel] !== undefined;
+export function ehPedra(nivel: Nivel): nivel is Pedra {
+  return VISUAL[nivel].tipo === 'pedra';
+}
+
+/** Cor do corpo da taça: a do metal, ou ouro para qualquer pedra. */
+function corCorpo(nivel: Nivel): number {
+  const v = VISUAL[nivel];
+  return v.tipo === 'metal' ? v.cor : COR_OURO;
 }
 
 export interface OpcoesTrofeuArte {
@@ -55,8 +72,14 @@ export interface OpcoesTrofeuArte {
   nivel: Nivel;
   /** `false` apaga o Troféu (nível bloqueado); padrão `true`. */
   aceso?: boolean;
-  /** Desenha só a gema (sem a taça). Para metais não há gema: nada é desenhado. */
-  apenasGema?: boolean;
+}
+
+export interface OpcoesCristalTrofeu {
+  x: number;
+  y: number;
+  tamanho: number;
+  /** Só pedras têm cristal; o tipo impede passar um metal. */
+  nivel: Pedra;
 }
 
 interface PinturaTaca {
@@ -69,31 +92,24 @@ interface PinturaTaca {
 export function desenharTrofeuArte(cena: Scene, opcoes: OpcoesTrofeuArte): Phaser.GameObjects.Container {
   const aceso = opcoes.aceso ?? true;
   const t = opcoes.tamanho;
-  const gema = aceso ? COR_GEMA[opcoes.nivel] : undefined;
+  const cor = aceso ? corCorpo(opcoes.nivel) : COR_BLOQUEADO;
+  const v = VISUAL[opcoes.nivel];
+  const gema = aceso && v.tipo === 'pedra' ? v.gema : undefined;
   const g = cena.add.graphics();
-  if (opcoes.apenasGema) {
-    if (gema !== undefined) desenharGema(g, { t, gema, cy: 0, escala: ESCALA_GEMA_SOLO });
-  } else {
-    desenharTrofeuCompleto(g, { t, nivel: opcoes.nivel, aceso, gema });
-  }
+  desenharAlcas(g, t, cor);
+  desenharTaca(g, { t, cor, rim: aceso ? clarear(cor, 0.5) : undefined });
+  desenharPe(g, t, cor);
+  if (gema !== undefined) desenharGema(g, { t, gema, cy: -0.25 * t, escala: ESCALA_GEMA });
+  // Centraliza verticalmente: a silhueta vai de -0.46t (boca) a 0.29t (pé).
+  g.setY(t * 0.085);
   return cena.add.container(opcoes.x, opcoes.y, [g]).setAlpha(aceso ? 1 : 0.5);
 }
 
-interface DesenhoCompleto {
-  t: number;
-  nivel: Nivel;
-  aceso: boolean;
-  gema?: CorGema;
-}
-
-function desenharTrofeuCompleto(g: Phaser.GameObjects.Graphics, c: DesenhoCompleto): void {
-  const cor = c.aceso ? (COR_METAL[c.nivel] ?? COR_OURO) : COR_BLOQUEADO;
-  desenharAlcas(g, c.t, cor);
-  desenharTaca(g, { t: c.t, cor, rim: c.aceso ? clarear(cor, 0.5) : undefined });
-  desenharPe(g, c.t, cor);
-  if (c.gema !== undefined) desenharGema(g, { t: c.t, gema: c.gema, cy: -0.25 * c.t, escala: ESCALA_GEMA });
-  // Centraliza verticalmente: a silhueta vai de -0.46t (boca) a 0.29t (pé).
-  g.setY(c.t * 0.085);
+/** Só o cristal do nível, sem a taça (usado no resumo do Ranking para pedras). */
+export function desenharCristalTrofeu(cena: Scene, opcoes: OpcoesCristalTrofeu): Phaser.GameObjects.Container {
+  const g = cena.add.graphics();
+  desenharGema(g, { t: opcoes.tamanho, gema: VISUAL[opcoes.nivel].gema, cy: 0, escala: ESCALA_GEMA_SOLO });
+  return cena.add.container(opcoes.x, opcoes.y, [g]);
 }
 
 function desenharTaca(g: Phaser.GameObjects.Graphics, { t, cor, rim }: PinturaTaca): void {

--- a/src/adapters/phaser/desenhar-trofeu-arte.ts
+++ b/src/adapters/phaser/desenhar-trofeu-arte.ts
@@ -1,0 +1,203 @@
+import type { Scene } from 'phaser';
+import type { Nivel } from '@/store/trofeus/tabela-trofeus';
+
+/**
+ * Arte vetorial do Troféu, desenhada em Phaser puro (adapter — validação visual,
+ * sem Vitest; AGENTS.md §3). Conta a progressão dos sete níveis pela cor:
+ *
+ * - **Metais** (Bronze, Prata, Ouro): a taça inteira na cor do metal.
+ * - **Pedras** (Esmeralda, Safira, Rubi, Diamante): taça de ouro com a gema
+ *   engravada na cor da pedra — visualmente "depois" dos metais. A gema é
+ *   facetada (topo claro / base escura) com um brilho, para ler como joia.
+ *
+ * O ouro é um tom escurecido (compartilhado por Ouro e por todas as pedras), com
+ * um filete claro na boca da taça para não chapar. `aceso: false` apaga o Troféu
+ * (cinza esmaecido) para os níveis bloqueados do overlay, preservando a
+ * silhueta. Retorna um Container centrado em (x, y); a geometria ocupa cerca de
+ * `tamanho` na vertical.
+ */
+
+const COR_OURO = 0xd4951f;
+const COR_BLOQUEADO = 0x4b5572;
+const COR_CONTORNO = 0x1a2138;
+const ESCALA_GEMA = 1.55;
+/** A gema sozinha (`apenasGema`) cresce para preencher o lugar da taça. */
+const ESCALA_GEMA_SOLO = 4;
+
+const COR_METAL: Partial<Record<Nivel, number>> = {
+  bronze: 0xcd7f32,
+  prata: 0xc0c6d4,
+  ouro: COR_OURO,
+};
+
+interface CorGema {
+  cor: number;
+  topo: number;
+}
+
+const COR_GEMA: Partial<Record<Nivel, CorGema>> = {
+  esmeralda: { cor: 0x12a150, topo: 0x86efac },
+  safira: { cor: 0x2563eb, topo: 0x7cb0ff },
+  rubi: { cor: 0xdc2626, topo: 0xfb9a9a },
+  diamante: { cor: 0x9cc3ea, topo: 0xffffff },
+};
+
+/** Pedras (têm gema engravada) vs. metais (taça lisa). */
+export function ehPedra(nivel: Nivel): boolean {
+  return COR_GEMA[nivel] !== undefined;
+}
+
+export interface OpcoesTrofeuArte {
+  x: number;
+  y: number;
+  /** Altura aproximada da arte em pixels físicos (o chamador já escala). */
+  tamanho: number;
+  nivel: Nivel;
+  /** `false` apaga o Troféu (nível bloqueado); padrão `true`. */
+  aceso?: boolean;
+  /** Desenha só a gema (sem a taça). Para metais não há gema: nada é desenhado. */
+  apenasGema?: boolean;
+}
+
+interface PinturaTaca {
+  t: number;
+  cor: number;
+  /** Filete claro na boca da taça; ausente quando o Troféu está apagado. */
+  rim?: number;
+}
+
+export function desenharTrofeuArte(cena: Scene, opcoes: OpcoesTrofeuArte): Phaser.GameObjects.Container {
+  const aceso = opcoes.aceso ?? true;
+  const t = opcoes.tamanho;
+  const gema = aceso ? COR_GEMA[opcoes.nivel] : undefined;
+  const g = cena.add.graphics();
+  if (opcoes.apenasGema) {
+    if (gema !== undefined) desenharGema(g, { t, gema, cy: 0, escala: ESCALA_GEMA_SOLO });
+  } else {
+    desenharTrofeuCompleto(g, { t, nivel: opcoes.nivel, aceso, gema });
+  }
+  return cena.add.container(opcoes.x, opcoes.y, [g]).setAlpha(aceso ? 1 : 0.5);
+}
+
+interface DesenhoCompleto {
+  t: number;
+  nivel: Nivel;
+  aceso: boolean;
+  gema?: CorGema;
+}
+
+function desenharTrofeuCompleto(g: Phaser.GameObjects.Graphics, c: DesenhoCompleto): void {
+  const cor = c.aceso ? (COR_METAL[c.nivel] ?? COR_OURO) : COR_BLOQUEADO;
+  desenharAlcas(g, c.t, cor);
+  desenharTaca(g, { t: c.t, cor, rim: c.aceso ? clarear(cor, 0.5) : undefined });
+  desenharPe(g, c.t, cor);
+  if (c.gema !== undefined) desenharGema(g, { t: c.t, gema: c.gema, cy: -0.25 * c.t, escala: ESCALA_GEMA });
+  // Centraliza verticalmente: a silhueta vai de -0.46t (boca) a 0.29t (pé).
+  g.setY(c.t * 0.085);
+}
+
+function desenharTaca(g: Phaser.GameObjects.Graphics, { t, cor, rim }: PinturaTaca): void {
+  const pts = [
+    { x: -0.3 * t, y: -0.46 * t },
+    { x: 0.3 * t, y: -0.46 * t },
+    { x: 0.24 * t, y: -0.3 * t },
+    { x: 0.16 * t, y: -0.14 * t },
+    { x: 0.12 * t, y: -0.05 * t },
+    { x: -0.12 * t, y: -0.05 * t },
+    { x: -0.16 * t, y: -0.14 * t },
+    { x: -0.24 * t, y: -0.3 * t },
+  ];
+  g.fillStyle(cor, 1);
+  g.lineStyle(Math.max(1, t * 0.03), COR_CONTORNO, 0.5);
+  g.fillPoints(pts, true);
+  g.strokePoints(pts, true);
+  if (rim !== undefined) {
+    g.lineStyle(Math.max(1, t * 0.02), rim, 0.9);
+    g.lineBetween(-0.3 * t, -0.46 * t, 0.3 * t, -0.46 * t);
+  }
+  g.fillStyle(cor, 1);
+  g.fillRect(-0.05 * t, -0.06 * t, 0.1 * t, 0.16 * t);
+}
+
+function desenharAlcas(g: Phaser.GameObjects.Graphics, t: number, cor: number): void {
+  g.lineStyle(Math.max(2, t * 0.06), cor, 1);
+  g.beginPath();
+  g.arc(-0.28 * t, -0.34 * t, 0.13 * t, Math.PI * 0.5, Math.PI * 1.5, false);
+  g.strokePath();
+  g.beginPath();
+  g.arc(0.28 * t, -0.34 * t, 0.13 * t, -Math.PI * 0.5, Math.PI * 0.5, false);
+  g.strokePath();
+}
+
+function desenharPe(g: Phaser.GameObjects.Graphics, t: number, cor: number): void {
+  g.fillStyle(cor, 1);
+  g.fillRect(-0.13 * t, 0.1 * t, 0.26 * t, 0.05 * t);
+  g.fillPoints(
+    [
+      { x: -0.16 * t, y: 0.15 * t },
+      { x: 0.16 * t, y: 0.15 * t },
+      { x: 0.22 * t, y: 0.29 * t },
+      { x: -0.22 * t, y: 0.29 * t },
+    ],
+    true,
+  );
+}
+
+interface DesenhoGema {
+  t: number;
+  gema: CorGema;
+  /** Centro vertical da gema (a taça usa -0.25t; sozinha, 0). */
+  cy: number;
+  escala: number;
+}
+
+function desenharGema(g: Phaser.GameObjects.Graphics, d: DesenhoGema): void {
+  const { t, gema, cy, escala } = d;
+  const gw = 0.08 * t * escala;
+  const gh = 0.09 * t * escala;
+  const pts = [
+    { x: 0, y: cy - gh },
+    { x: gw, y: cy },
+    { x: 0, y: cy + gh },
+    { x: -gw, y: cy },
+  ];
+  g.fillStyle(gema.cor, 1);
+  g.fillPoints(pts, true);
+  g.fillStyle(gema.topo, 1);
+  g.fillPoints([pts[3], pts[0], pts[1]], true);
+  g.lineStyle(Math.max(1, t * 0.02), 0xffffff, 0.7);
+  g.strokePoints(pts, true);
+  desenharBrilho(g, { x: -gw * 0.35, y: cy - gh * 0.35, r: gw * 0.25 });
+}
+
+function desenharBrilho(g: Phaser.GameObjects.Graphics, brilho: { x: number; y: number; r: number }): void {
+  const { x, y, r } = brilho;
+  g.fillStyle(0xffffff, 0.95);
+  g.fillPoints(
+    [
+      { x, y: y - r },
+      { x: x + r * 0.3, y },
+      { x, y: y + r },
+      { x: x - r * 0.3, y },
+    ],
+    true,
+  );
+  g.fillPoints(
+    [
+      { x: x - r, y },
+      { x, y: y - r * 0.3 },
+      { x: x + r, y },
+      { x, y: y + r * 0.3 },
+    ],
+    true,
+  );
+}
+
+/** Mistura a cor em direção ao branco por `fator` (0 = cor, 1 = branco). */
+function clarear(cor: number, fator: number): number {
+  const r = (cor >> 16) & 0xff;
+  const g = (cor >> 8) & 0xff;
+  const b = cor & 0xff;
+  const mix = (c: number): number => Math.round(c + (255 - c) * fator);
+  return (mix(r) << 16) | (mix(g) << 8) | mix(b);
+}

--- a/src/adapters/phaser/renderers/fim-jogo-renderer.ts
+++ b/src/adapters/phaser/renderers/fim-jogo-renderer.ts
@@ -1,7 +1,7 @@
 import type { Scene } from 'phaser';
-import { ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
 import type { ResultadoTrofeus } from '@/store/trofeus/tipos';
 import type { Jogador } from '@/types/entidades';
+import { desenharTrofeuArte } from '../desenhar-trofeu-arte';
 import { escalar } from '../escala';
 import { limparObjetos } from './limpar-objetos';
 
@@ -170,24 +170,34 @@ function desenharSequencia(config: ConfigFimJogo, layout: LayoutFimJogo): void {
 }
 
 /**
- * Destaque de celebração quando a vitória desbloqueia um Troféu novo. Nesta
- * slice o Troféu é só o rótulo textual do nível — a arte visual fica para a
- * slice de visual.
+ * Destaque de celebração quando a vitória desbloqueia um Troféu novo: o texto
+ * seguido da arte do Troféu conquistado, centrados como um grupo na linha.
  */
 function desenharTrofeuDesbloqueado(config: ConfigFimJogo, layout: LayoutFimJogo): void {
   const nivel = config.resultadoTrofeus?.trofeuDesbloqueado;
   if (!nivel || layout.trofeuY === null) return;
   const { cena, objetos } = config;
-  const destaque = cena.add
-    .text(cena.cameras.main.centerX, layout.trofeuY, `Troféu desbloqueado: ${ROTULO_NIVEL[nivel]}`, {
+  const tamanho = Math.round(escalar(26, cena) * layout.escalaConteudo);
+  const gap = escalar(8, cena);
+  const texto = cena.add
+    .text(0, layout.trofeuY, 'Troféu desbloqueado:', {
       fontSize: fonteFimJogo(20, cena, layout),
       fontStyle: 'bold',
       color: '#fde68a',
       fontFamily: 'Arial',
     })
-    .setOrigin(0.5)
+    .setOrigin(0, 0.5)
     .setDepth(102);
-  objetos.push(destaque);
+  const larguraTotal = texto.width + gap + tamanho;
+  const inicioX = cena.cameras.main.centerX - larguraTotal / 2;
+  texto.setX(inicioX);
+  const trofeu = desenharTrofeuArte(cena, {
+    x: inicioX + texto.width + gap + tamanho / 2,
+    y: layout.trofeuY,
+    tamanho,
+    nivel,
+  }).setDepth(102);
+  objetos.push(texto, trofeu);
 }
 
 function desenharFundo(config: ConfigFimJogo): void {

--- a/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
+++ b/src/adapters/phaser/scenes/desenhar-overlay-trofeus.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { Nivel } from '@/store/trofeus/tabela-trofeus';
 import { NIVEIS_ORDENADOS, ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
+import { desenharTrofeuArte } from '../desenhar-trofeu-arte';
 import { escalar, escalarFonte } from '../escala';
 
 const COR_BACKDROP = 0x0b0f1a;
@@ -117,7 +118,7 @@ function desenharNiveis(layout: LayoutOverlay, maiorTrofeu: Nivel): Phaser.GameO
   const { cena, xEsquerda, topo, fator } = layout;
   const maxIndice = NIVEIS_ORDENADOS.indexOf(maiorTrofeu);
   const baseY = topo + escalar(PAD_TOPO * fator, cena);
-  return NIVEIS_ORDENADOS.map((nivel, indice) => {
+  return NIVEIS_ORDENADOS.flatMap((nivel, indice) => {
     const y = baseY + escalar(PASSO_NIVEL * fator, cena) * indice;
     return desenharNivel(cena, { nivel, conquistado: indice <= maxIndice, x: xEsquerda, y, fator });
   });
@@ -131,9 +132,14 @@ interface ContextoNivel {
   fator: number;
 }
 
-function desenharNivel(cena: Scene, { nivel, conquistado, x, y, fator }: ContextoNivel): Phaser.GameObjects.GameObject {
-  return cena.add
-    .text(x, y, `🏆  ${ROTULO_NIVEL[nivel]}`, {
+function desenharNivel(
+  cena: Scene,
+  { nivel, conquistado, x, y, fator }: ContextoNivel,
+): Phaser.GameObjects.GameObject[] {
+  const tamanho = escalar(28 * fator, cena);
+  const trofeu = desenharTrofeuArte(cena, { x: x + tamanho / 2, y, tamanho, nivel, aceso: conquistado });
+  const rotulo = cena.add
+    .text(x + tamanho + escalar(12, cena), y, ROTULO_NIVEL[nivel], {
       fontSize: escalarFonte(14 * fator, cena),
       color: conquistado ? COR_CONQUISTADO : COR_BLOQUEADO,
       fontStyle: conquistado ? 'bold' : 'normal',
@@ -141,4 +147,5 @@ function desenharNivel(cena: Scene, { nivel, conquistado, x, y, fator }: Context
     })
     .setOrigin(0, 0.5)
     .setAlpha(conquistado ? 1 : 0.5);
+  return [trofeu, rotulo];
 }

--- a/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
@@ -1,6 +1,7 @@
 import type { Scene } from 'phaser';
 import type { ResumoTrofeus } from '@/store/trofeus/resumo-trofeus';
-import { desenharTrofeuArte, ehPedra } from '../desenhar-trofeu-arte';
+import type { Nivel } from '@/store/trofeus/tabela-trofeus';
+import { desenharCristalTrofeu, desenharTrofeuArte, ehPedra } from '../desenhar-trofeu-arte';
 import { escalar, escalarFonte } from '../escala';
 import type { LayoutRanking } from './layout-ranking';
 
@@ -30,18 +31,31 @@ export function desenharTrofeusRanking(
   const gap = escalar(6, cena);
   const centerY = layout.resumoTrofeus.y + tamanho / 2;
   const texto = criarTexto(cena, resumo, centerY);
+  // A medição do grupo respeita a faixa do Ranking: o texto quebra dentro do
+  // espaço restante em vez de o grupo estourar para fora da faixa (i18n/telas
+  // estreitas). O `max` evita largura negativa em faixas muito apertadas.
+  texto.setWordWrapWidth(Math.max(escalar(40, cena), layout.faixa.largura - tamanho - gap));
   const larguraTotal = tamanho + gap + texto.width;
   const inicioX = cena.cameras.main.centerX - larguraTotal / 2;
   texto.setX(inicioX + tamanho + gap);
-  const trofeu = desenharTrofeuArte(cena, {
-    x: inicioX + tamanho / 2,
-    y: centerY,
-    tamanho,
-    nivel: resumo.maiorTrofeu,
-    apenasGema: ehPedra(resumo.maiorTrofeu),
-  });
-  const zona = criarZona(cena, { inicioX, centerY, larguraTotal, tamanho }, aoTocar);
-  return [trofeu, texto, zona];
+  const icone = desenharIcone(cena, { x: inicioX + tamanho / 2, y: centerY, tamanho, nivel: resumo.maiorTrofeu });
+  const altura = Math.max(tamanho, texto.height);
+  const zona = criarZona(cena, { inicioX, centerY, larguraTotal, altura }, aoTocar);
+  return [icone, texto, zona];
+}
+
+interface GeoIcone {
+  x: number;
+  y: number;
+  tamanho: number;
+  nivel: Nivel;
+}
+
+/** Pedra vira só o cristal; metal mantém o troféu inteiro. */
+function desenharIcone(cena: Scene, { x, y, tamanho, nivel }: GeoIcone): Phaser.GameObjects.Container {
+  return ehPedra(nivel)
+    ? desenharCristalTrofeu(cena, { x, y, tamanho, nivel })
+    : desenharTrofeuArte(cena, { x, y, tamanho, nivel });
 }
 
 function criarTexto(cena: Scene, resumo: ResumoTrofeus, centerY: number): Phaser.GameObjects.Text {
@@ -61,12 +75,12 @@ interface GeoZona {
   inicioX: number;
   centerY: number;
   larguraTotal: number;
-  tamanho: number;
+  altura: number;
 }
 
 function criarZona(cena: Scene, geo: GeoZona, aoTocar: () => void): Phaser.GameObjects.Zone {
   const zona = cena.add
-    .zone(geo.inicioX, geo.centerY, geo.larguraTotal, geo.tamanho)
+    .zone(geo.inicioX, geo.centerY, geo.larguraTotal, geo.altura)
     .setOrigin(0, 0.5)
     .setInteractive({ useHandCursor: true });
   zona.on('pointerdown', aoTocar);

--- a/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
+++ b/src/adapters/phaser/scenes/desenhar-trofeus-ranking.ts
@@ -1,7 +1,7 @@
 import type { Scene } from 'phaser';
 import type { ResumoTrofeus } from '@/store/trofeus/resumo-trofeus';
-import { ROTULO_NIVEL } from '@/store/trofeus/tabela-trofeus';
-import { escalarFonte } from '../escala';
+import { desenharTrofeuArte, ehPedra } from '../desenhar-trofeu-arte';
+import { escalar, escalarFonte } from '../escala';
 import type { LayoutRanking } from './layout-ranking';
 
 const COR_TEXTO = '#e8ecf5';
@@ -13,26 +13,62 @@ export interface OpcoesTrofeusRanking {
   aoTocar: () => void;
 }
 
+/**
+ * Linha-resumo dos Troféus no topo do Ranking: a arte do `maiorTrofeu` seguida
+ * da Sequência de Vitórias atual, centradas como um grupo. Uma zona interativa
+ * cobre o grupo inteiro para abrir o overlay dos sete níveis.
+ *
+ * Aqui a pedra aparece como só o cristal (sem a taça); o troféu inteiro só é
+ * desenhado para os metais (Bronze, Prata, Ouro).
+ */
 export function desenharTrofeusRanking(
   cena: Scene,
   { resumo, layout, aoTocar }: OpcoesTrofeusRanking,
 ): Phaser.GameObjects.GameObject[] {
   if (resumo === null) return [];
+  const tamanho = escalar(20, cena);
+  const gap = escalar(6, cena);
+  const centerY = layout.resumoTrofeus.y + tamanho / 2;
+  const texto = criarTexto(cena, resumo, centerY);
+  const larguraTotal = tamanho + gap + texto.width;
+  const inicioX = cena.cameras.main.centerX - larguraTotal / 2;
+  texto.setX(inicioX + tamanho + gap);
+  const trofeu = desenharTrofeuArte(cena, {
+    x: inicioX + tamanho / 2,
+    y: centerY,
+    tamanho,
+    nivel: resumo.maiorTrofeu,
+    apenasGema: ehPedra(resumo.maiorTrofeu),
+  });
+  const zona = criarZona(cena, { inicioX, centerY, larguraTotal, tamanho }, aoTocar);
+  return [trofeu, texto, zona];
+}
+
+function criarTexto(cena: Scene, resumo: ResumoTrofeus, centerY: number): Phaser.GameObjects.Text {
   const texto = cena.add
-    .text(cena.cameras.main.centerX, layout.resumoTrofeus.y, formatarResumo(resumo), {
+    .text(0, centerY, `🔥 ${String(resumo.sequenciaAtual)} seguidas`, {
       fontSize: escalarFonte(12, cena),
       color: COR_TEXTO,
       fontStyle: 'bold',
       fontFamily: 'Arial',
-      align: 'center',
     })
-    .setOrigin(0.5, 0)
-    .setWordWrapWidth(layout.faixa.largura);
+    .setOrigin(0, 0.5);
   texto.setShadow(0, 0, COR_ACENTO, 2);
-  texto.setInteractive({ useHandCursor: true }).on('pointerdown', aoTocar);
-  return [texto];
+  return texto;
 }
 
-function formatarResumo(resumo: ResumoTrofeus): string {
-  return `${ROTULO_NIVEL[resumo.maiorTrofeu]} · 🔥 ${String(resumo.sequenciaAtual)} seguidas`;
+interface GeoZona {
+  inicioX: number;
+  centerY: number;
+  larguraTotal: number;
+  tamanho: number;
+}
+
+function criarZona(cena: Scene, geo: GeoZona, aoTocar: () => void): Phaser.GameObjects.Zone {
+  const zona = cena.add
+    .zone(geo.inicioX, geo.centerY, geo.larguraTotal, geo.tamanho)
+    .setOrigin(0, 0.5)
+    .setInteractive({ useHandCursor: true });
+  zona.on('pointerdown', aoTocar);
+  return zona;
 }

--- a/src/store/trofeus/tabela-trofeus.ts
+++ b/src/store/trofeus/tabela-trofeus.ts
@@ -28,7 +28,7 @@ const NIVEIS: readonly DefinicaoNivel[] = [
 
 export const NIVEIS_ORDENADOS: readonly Nivel[] = NIVEIS.map((d) => d.nivel);
 
-/** Rótulos textuais exibidos na UI enquanto a arte visual não entra (slice futura). */
+/** Nomes dos níveis, exibidos junto à arte do Troféu (ex.: rótulo no overlay). */
 export const ROTULO_NIVEL: Record<Nivel, string> = {
   bronze: 'Bronze',
   prata: 'Prata',


### PR DESCRIPTION
Fecha #264.

Substitui os rótulos textuais de troféu pela arte vetorial (Phaser puro — validação visual, sem Vitest; AGENTS.md §3) nas três superfícies onde o troféu aparece.

## O que muda
- **Novo** `desenhar-trofeu-arte.ts` — desenha o troféu via Phaser Graphics, centrado em `(x, y)`, com `tamanho`, `aceso` e `apenasGema`.
  - **Metais** (Bronze, Prata, Ouro): taça inteira na cor do metal.
  - **Pedras** (Esmeralda, Safira, Rubi, Diamante): taça de **ouro** com a gema engravada na cor da pedra (esmeralda verde, safira azul, rubi vermelho, diamante cristal).
- **Fim de jogo**: "Troféu desbloqueado:" + a arte do nível conquistado.
- **Resumo do Ranking**: arte do `maiorTrofeu` + 🔥 sequência. Pedra aparece só como o **cristal**; metal mostra o troféu inteiro (`ehPedra`).
- **Overlay dos sete níveis**: arte + nome; conquistados acesos, bloqueados cinza esmaecido.

## Refinamentos validados visualmente (acordados na revisão)
- Ouro escurecido (`#d4951f`), compartilhado por Ouro e por todas as pedras.
- Gema +55% facetada (topo claro / base escura) com brilho.
- Filete claro na boca da taça pra não chapar o ouro escuro.
- No resumo do Ranking, pedra = só o cristal.

## Validação
- `pnpm typecheck`, `pnpm lint` e `pnpm test` (859) passam.
- Conferido no browser nas três superfícies: fim de jogo (Ouro), resumo do Ranking (pedra só cristal vs. metal com taça) e overlay (acesos vs. apagados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector-based trophy graphics rendering with 7 color-coded levels
  * Trophies now display in end-game unlock messages, trophy overlay, and ranking sections
  * Trophies support visual state indication (active/blocked appearance)
  * Different visual styles for metal and gem-based trophies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->