### PR TITLE
fix(jogo): mostra a última carta e o recolhimento antes do resumo da rodada

### DIFF
--- a/src/adapters/phaser/scenes/jogo-controller.ts
+++ b/src/adapters/phaser/scenes/jogo-controller.ts
@@ -47,7 +47,7 @@ export class JogoController {
   private turnoAnterior = 1;
   private valorDeclaracaoAtual = 0;
   private ultimaPontuacao: PlacarRodada = { placar: {}, penalidades: {} };
-  private processamentoTurno?: Promise<void>;
+  private resumoPendente?: PontuacaoRodada;
   private readonly decisorDeclaracaoHumano = new DecisorDeclaracaoHumano();
 
   private readonly deps: DependenciasCena;
@@ -97,9 +97,17 @@ export class JogoController {
   }
 
   private aoRodadaEncerrada(): void {
-    const aguardarLimpeza = this.processamentoTurno ?? Promise.resolve();
-    this.deps.mostrarResumoRodada(this.montarResumoRodada(), () => {
-      void this.continuarAposResumo(aguardarLimpeza);
+    // O resumo só aparece depois que o loop de turnos termina o recolhimento da
+    // última vaza; aqui apenas guardamos os dados, capturados no momento do evento.
+    this.resumoPendente = this.montarResumoRodada();
+  }
+
+  private exibirResumoPendente(): void {
+    const resumo = this.resumoPendente;
+    if (!resumo) return;
+    this.resumoPendente = undefined;
+    this.deps.mostrarResumoRodada(resumo, () => {
+      this.iniciarNovaRodada();
     });
   }
 
@@ -107,11 +115,6 @@ export class JogoController {
     const rodada = this.partida?.rodadaAtual;
     const jogadores = rodada ? estadoEmJogo(rodada.estado).maos.map((m) => m.jogador) : [];
     return { ...this.ultimaPontuacao, numeroRodada: this.partida?.estado.numeroRodada ?? 0, jogadores };
-  }
-
-  private async continuarAposResumo(aguardarLimpeza: Promise<void>): Promise<void> {
-    await aguardarLimpeza.catch(() => undefined);
-    this.iniciarNovaRodada();
   }
 
   iniciarNovaRodada(): void {
@@ -184,11 +187,9 @@ export class JogoController {
       atualizarIndicadorVez: this.deps.atualizarIndicadorVez,
       atualizarPainel: this.deps.atualizarPainel,
     });
-    this.processamentoTurno = processamento;
-    try {
-      await processamento;
-    } finally {
-      this.processamentoTurno = undefined;
-    }
+    await processamento;
+    // Loop concluído: o recolhimento da última vaza já rodou. Só agora o resumo
+    // aparece, sem cobrir a carta nem o sweep do fim de rodada.
+    this.exibirResumoPendente();
   }
 }


### PR DESCRIPTION
## Problema

No fim da rodada, quando a última carta da última vaza é jogada, o resumo aparecia **instantaneamente por cima** da carta recém-jogada. A carta e a animação de recolhimento da vaza ficavam escondidas atrás do overlay escuro.

Mais visível quando o **jogador humano é o último a jogar** (não há espera de bot antes, então é instantâneo) e quando há **só 1 carta na mão**.

## Causa raiz

Era **ordem, não timing**. `onRodadaEncerrada` dispara sincronamente dentro de `jogarTurno()` no core, na mesma batida em que a carta é desenhada. O `atualizarFimDeTurno` (recolhimento ~400ms + espera 800ms) já roda na última vaza, mas **atrás** do resumo que já foi exibido.

## Correção (adapter-only, core intocado)

- `aoRodadaEncerrada` deixa de mostrar o resumo na hora — apenas guarda os dados em `resumoPendente`.
- O resumo é exibido em `exibirResumoPendente`, chamado **após** o loop de turnos terminar — quando o recolhimento da última vaza já aconteceu.
- Removido o arranjo `processamentoTurno`/`continuarAposResumo`/`aguardarLimpeza`, que virou código morto.

A última vaza passa a se comportar **idêntica** a qualquer outra (mesma animação, mesmo ritmo — nenhum timing novo). Vale para qualquer N de rodada, incluindo 1 carta.

## Validação

Visual (adapter Phaser, sem teste unitário conforme AGENTS.md §3). Conferir no preview da Vercel, com atenção ao caso do humano jogando a última carta da última vaza e a rodadas de 1 carta. `typecheck`, `lint` e os 859 testes do core passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)