### PR TITLE
fix(bots): descarte reserva as N cartas mais fortes ao precisar fazer

### DIFF
--- a/docs/arvores-de-decisao-dos-bots.md
+++ b/docs/arvores-de-decisao-dos-bots.md
@@ -74,11 +74,17 @@ escolherVencedoraPorNecessidade(vencedoras, necessidade):
 descartePorNecessidade(candidatas, necessidade):
   ordenadas = candidatas da mais fraca para a mais forte
   indice = se ordenadas.length > necessidade:
-    ordenadas.length - necessidade
+    ordenadas.length - necessidade - 1
   senao:
     0
   retornar ordenadas[indice]
 ```
+
+Diferente da escolha de vencedora, o descarte **nao** ganha vaza agora: a vaza
+ja esta perdida. Por isso ele reserva as `necessidade` cartas mais fortes
+inteiras (as melhores chances de fazer as vazas que ainda faltam) e descarta a
+mais forte do restante. Quando nao ha folga (`length <= necessidade`), descarta
+a mais fraca.
 
 ## Arvore: Abre a Mesa
 

--- a/src/adapters/bots/escolhas-por-necessidade.ts
+++ b/src/adapters/bots/escolhas-por-necessidade.ts
@@ -18,7 +18,7 @@ export function descartePorNecessidade(
   necessidade: number,
 ): CartaAvaliada {
   const ordenadas = ordenarPorForcaReal(avaliadas, manilha);
-  const indice = ordenadas.length > necessidade ? ordenadas.length - necessidade : 0;
+  const indice = ordenadas.length > necessidade ? ordenadas.length - necessidade - 1 : 0;
   return ordenadas[indice];
 }
 

--- a/tests/adapters/DecisorJogadaLinhaFria.test.ts
+++ b/tests/adapters/DecisorJogadaLinhaFria.test.ts
@@ -34,7 +34,7 @@ const cenariosDeUltimo: {
     mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' }),
     esperado: {
-      carta: criarCarta('9', '♦'),
+      carta: criarCarta('6', '♦'),
       motivo: 'precisa fazer sem carta que vence; regra P[N-X]',
       etapa: ETAPA_FECHA_PRECISA,
     },
@@ -121,7 +121,7 @@ async function deveEscolherPerdedoraPorNecessidade(): Promise<void> {
   const bot = new DecisorJogadaLinhaFria();
   await expect(
     bot.decidirJogada([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')], estado),
-  ).resolves.toEqual(criarCarta('9', '♦'));
+  ).resolves.toEqual(criarCarta('6', '♦'));
 }
 
 async function deveEscolherPerdedoraEscassa(): Promise<void> {

--- a/tests/adapters/decidir-linha-quente.test.ts
+++ b/tests/adapters/decidir-linha-quente.test.ts
@@ -233,6 +233,16 @@ const cenariosFecha: {
     estado: { mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' },
     esperado: {
       tipo: 'recomenda',
+      carta: criarCarta('6', '♦'),
+      motivo: 'precisa fazer, sem carta que vence; P[N-X]',
+    },
+  },
+  {
+    nome: 'deve preservar a mais alta no último quando precisa fazer 1 e o líder jogou alta',
+    mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
+    estado: { mesa: mesaComK(), declaracoes: { bot: 1 }, vazas: { bot: 0 }, manilha: '5' },
+    esperado: {
+      tipo: 'recomenda',
       carta: criarCarta('9', '♦'),
       motivo: 'precisa fazer, sem carta que vence; P[N-X]',
     },

--- a/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
+++ b/tests/adapters/decidirNaoUltimoLinhaFria.test.ts
@@ -103,7 +103,7 @@ const cenarios: {
     mao: [criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')],
     estado: criarEstadoLinhaFria({ mesa: mesaComK(), declaracoes: { bot: 2 }, vazas: { bot: 0 }, manilha: '5' }),
     esperado: {
-      carta: criarCarta('9', '♦'),
+      carta: criarCarta('6', '♦'),
       motivo: 'guarda de posição permitiu; jogadores por agir já cumpriram; precisa fazer; regra P[N-X]',
       etapa: ETAPA_GUARDA_PERMITIU,
     },

--- a/tests/adapters/escolhas-por-necessidade.test.ts
+++ b/tests/adapters/escolhas-por-necessidade.test.ts
@@ -12,6 +12,10 @@ describe('escolhas por necessidade', () => {
   it('deve escolher vencedora pelo índice canônico quando há cartas suficientes', deveEscolherVencedoraPorIndice);
   it('deve escolher a vencedora mais fraca quando vencedoras são escassas', deveEscolherVencedoraEscassa);
   it('deve descartar pelo índice canônico quando há folga sobre a necessidade', deveDescartarPorIndice);
+  it(
+    'deve preservar a mais forte e descartar a segunda mais forte com necessidade 1',
+    deveDescartarPreservandoAMaisForte,
+  );
   it('deve descartar a carta mais fraca quando candidatas não excedem a necessidade', deveDescartarEscassa);
   it('deve ordenar por força real considerando manilha e desempate por naipe', deveOrdenarPorForcaReal);
 });
@@ -31,7 +35,14 @@ function deveEscolherVencedoraEscassa(): void {
 function deveDescartarPorIndice(): void {
   const candidatas = avaliar([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')]);
 
-  expect(descartePorNecessidade(candidatas, '5', 2).carta).toEqual(criarCarta('9', '♦'));
+  expect(descartePorNecessidade(candidatas, '5', 2).carta).toEqual(criarCarta('6', '♦'));
+}
+
+function deveDescartarPreservandoAMaisForte(): void {
+  const candidatas = avaliar([criarCarta('4', '♦'), criarCarta('6', '♦'), criarCarta('9', '♦'), criarCarta('Q', '♦')]);
+
+  // Precisa fazer 1 e não vence agora: reserva a Q para a vaza futura e joga a 9.
+  expect(descartePorNecessidade(candidatas, '5', 1).carta).toEqual(criarCarta('9', '♦'));
 }
 
 function deveDescartarEscassa(): void {


### PR DESCRIPTION
## Problema

Quando o bot é o último a falar e ainda precisa fazer vazas, mas não consegue vencer a vaza atual (o líder jogou uma carta alta), ele **desperdiçava a carta mais alta da mão** em vez de jogar a `P[N-X]`.

## Causa raiz

Off-by-one em `descartePorNecessidade` (`src/adapters/bots/escolhas-por-necessidade.ts`). A fórmula usava `length - necessidade`, reservando apenas `necessidade - 1` cartas no topo.

Ao contrário da escolha de vencedora — que *gasta* uma vaza agora e por isso reserva `necessidade - 1` —, o descarte **não ganha vaza alguma**: a vaza já está perdida. Logo precisa reservar as `necessidade` cartas mais fortes inteiras (as melhores chances futuras) e descartar a mais forte do restante. Com `necessidade = 1`, o erro fazia o bot jogar literalmente a carta mais alta.

## Correção

- `escolhas-por-necessidade.ts`: fórmula passa para `length - necessidade - 1` (cai em `0` quando não há folga).
- `docs/arvores-de-decisao-dos-bots.md`: pseudocódigo + parágrafo explicando por que o descarte difere da escolha de vencedora. **A fórmula documentada estava errada** desde a definição original.
- Ajusta 4 testes que cristalizavam o comportamento bugado (`[4,6,9,Q]` com necessidade 2 passa de `9♦` → `6♦`, reservando `Q,9`).
- Adiciona 2 testes de regressão para `necessidade=1`: descarta a 2ª mais forte (`9♦`) e preserva a `Q♦`, no seam puro e no seam real (`fecha` + líder alto).

## Verificação

- 871 testes passando
- `typecheck` e `lint` limpos

🤖 Generated with [Claude Code](https://claude.com/claude-code)